### PR TITLE
Added codegen to handle supertypes

### DIFF
--- a/compiler/src/it/abstract-parent-with-injected-members/pom.xml
+++ b/compiler/src/it/abstract-parent-with-injected-members/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2013 Google, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>abstract-parent-with-injected-members</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <name>Dagger Integration Test Basic</name>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/abstract-parent-with-injected-members/src/main/java/test/TestApp.java
+++ b/compiler/src/it/abstract-parent-with-injected-members/src/main/java/test/TestApp.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.Module;
+import dagger.Provides;
+import javax.inject.Inject;
+import test.parentpackage.AbstractParentWithInjectedMember;
+
+class TestApp {
+   
+  static class InjectableSubclass extends AbstractParentWithInjectedMember {
+     @Inject String string;
+  }
+
+  @Module(injects = InjectableSubclass.class)
+  static class TestModule {
+    @Provides String provideString() {
+      return "string";
+    }
+    
+    @Provides Integer provideInteger() {
+      return 5;
+    }
+  }
+}

--- a/compiler/src/it/abstract-parent-with-injected-members/src/main/java/test/parentpackage/AbstractParentWithInjectedMember.java
+++ b/compiler/src/it/abstract-parent-with-injected-members/src/main/java/test/parentpackage/AbstractParentWithInjectedMember.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.parentpackage;
+
+import javax.inject.Inject;
+
+public abstract class AbstractParentWithInjectedMember {
+  @Inject Integer integer;
+}

--- a/compiler/src/it/abstract-parent-with-injected-members/verify.bsh
+++ b/compiler/src/it/abstract-parent-with-injected-members/verify.bsh
@@ -1,0 +1,23 @@
+import java.io.File;
+
+File classes = new File(basedir, "target/classes/test/");
+
+File moduleAdapter = new File(classes, "TestApp$TestModule$$ModuleAdapter.class");
+if (!moduleAdapter.exists()) throw new Exception("No binding generated for module");
+
+File integerBinding = 
+    new File(classes, "TestApp$TestModule$$ModuleAdapter$ProvideIntegerProvidesAdapter.class");
+if (!integerBinding.exists()) throw new Exception("No binding generated for integer()");
+
+File stringBinding =
+    new File(classes, "TestApp$TestModule$$ModuleAdapter$ProvideStringProvidesAdapter.class");
+if (!stringBinding.exists()) throw new Exception("No binding generated for string()");
+
+File injectAdapter = new File(classes, "TestApp$InjectableSubclass$$InjectAdapter.class");
+if (!injectAdapter.exists()) 
+  throw new Exception("No inject adapter generated for InjectableSubclass");
+
+File parentAdapter = 
+    new File(classes, "parentpackage/AbstractParentWithInjectedMember$$ParentAdapter$$test_TestApp$InjectableSubclass.class");
+if (!parentAdapter.exists()) 
+  throw new Exception("No parent adapter generated for AbstractParentWithInjectedMember");

--- a/compiler/src/it/grandparent-with-injected-members/pom.xml
+++ b/compiler/src/it/grandparent-with-injected-members/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2013 Google, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>grandparent-with-injected-members</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <name>Dagger Integration Test Basic</name>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/grandparent-with-injected-members/src/main/java/test/TestApp.java
+++ b/compiler/src/it/grandparent-with-injected-members/src/main/java/test/TestApp.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.Module;
+import dagger.Provides;
+import javax.inject.Inject;
+import test.parentpackage.ParentWithNoInjectedMembers;
+
+class TestApp {
+   
+  static class InjectableSubclass extends ParentWithNoInjectedMembers {
+     @Inject String string;
+  }
+
+  @Module(injects = InjectableSubclass.class)
+  static class TestModule {
+    @Provides String provideString() {
+      return "string";
+    }
+    
+    @Provides Integer provideInteger() {
+      return 5;
+    }
+  }
+}

--- a/compiler/src/it/grandparent-with-injected-members/src/main/java/test/grandparentpackage/GrandparentWithInjectedMember.java
+++ b/compiler/src/it/grandparent-with-injected-members/src/main/java/test/grandparentpackage/GrandparentWithInjectedMember.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.grandparentpackage;
+
+import javax.inject.Inject;
+
+public class GrandparentWithInjectedMember {
+  @Inject Integer integer;
+}

--- a/compiler/src/it/grandparent-with-injected-members/src/main/java/test/parentpackage/ParentWithNoInjectedMembers.java
+++ b/compiler/src/it/grandparent-with-injected-members/src/main/java/test/parentpackage/ParentWithNoInjectedMembers.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.parentpackage;
+
+import test.grandparentpackage.GrandparentWithInjectedMember;
+
+public class ParentWithNoInjectedMembers extends GrandparentWithInjectedMember {
+}

--- a/compiler/src/it/grandparent-with-injected-members/verify.bsh
+++ b/compiler/src/it/grandparent-with-injected-members/verify.bsh
@@ -1,0 +1,28 @@
+import java.io.File;
+
+File classes = new File(basedir, "target/classes/test/");
+
+File moduleAdapter = new File(classes, "TestApp$TestModule$$ModuleAdapter.class");
+if (!moduleAdapter.exists()) throw new Exception("No binding generated for module");
+
+File integerBinding = 
+    new File(classes, "TestApp$TestModule$$ModuleAdapter$ProvideIntegerProvidesAdapter.class");
+if (!integerBinding.exists()) throw new Exception("No binding generated for integer()");
+
+File stringBinding =
+    new File(classes, "TestApp$TestModule$$ModuleAdapter$ProvideStringProvidesAdapter.class");
+if (!stringBinding.exists()) throw new Exception("No binding generated for string()");
+
+File injectAdapter = new File(classes, "TestApp$InjectableSubclass$$InjectAdapter.class");
+if (!injectAdapter.exists()) 
+  throw new Exception("No inject adapter generated for InjectableSubclass");
+
+File parentAdapter = 
+    new File(classes, "parentpackage/ParentWithNoInjectedMembers$$ParentAdapter$$test_TestApp$InjectableSubclass.class");
+if (parentAdapter.exists()) 
+  throw new Exception("An unnecessary parent adapter was generated for ParentwithNoInjectedMembers.");
+    
+File grandparentAdapter = 
+    new File(classes, "grandparentpackage/GrandparentWithInjectedMember$$ParentAdapter$$test_TestApp$InjectableSubclass.class");
+if (!grandparentAdapter.exists()) 
+  throw new Exception("No parent adapter was generated for GrandparentwithInjectedMember.");

--- a/compiler/src/it/parent-with-injected-members/pom.xml
+++ b/compiler/src/it/parent-with-injected-members/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (C) 2013 Google, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.dagger.tests</groupId>
+  <artifactId>parent-with-injected-members</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <name>Dagger Integration Test Basic</name>
+  <dependencies>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger</artifactId>
+      <version>@dagger.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>@dagger.groupId@</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>@dagger.version@</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/compiler/src/it/parent-with-injected-members/src/main/java/test/TestApp.java
+++ b/compiler/src/it/parent-with-injected-members/src/main/java/test/TestApp.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import dagger.Module;
+import dagger.Provides;
+import javax.inject.Inject;
+import test.parentpackage.ParentWithInjectedMember;
+
+class TestApp {
+   
+  static class InjectableSubclass extends ParentWithInjectedMember {
+     @Inject String string;
+  }
+
+  @Module(injects = InjectableSubclass.class)
+  static class TestModule {
+    @Provides String provideString() {
+      return "string";
+    }
+    
+    @Provides Integer provideInteger() {
+      return 5;
+    }
+  }
+}

--- a/compiler/src/it/parent-with-injected-members/src/main/java/test/grandparentpackage/GrandparentWithNoInjectedMembers.java
+++ b/compiler/src/it/parent-with-injected-members/src/main/java/test/grandparentpackage/GrandparentWithNoInjectedMembers.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.grandparentpackage;
+
+public class GrandparentWithNoInjectedMembers {
+}

--- a/compiler/src/it/parent-with-injected-members/src/main/java/test/parentpackage/ParentWithInjectedMember.java
+++ b/compiler/src/it/parent-with-injected-members/src/main/java/test/parentpackage/ParentWithInjectedMember.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.parentpackage;
+
+import javax.inject.Inject;
+import test.grandparentpackage.GrandparentWithNoInjectedMembers;
+
+public class ParentWithInjectedMember extends GrandparentWithNoInjectedMembers {
+  @Inject Integer integer;
+}

--- a/compiler/src/it/parent-with-injected-members/verify.bsh
+++ b/compiler/src/it/parent-with-injected-members/verify.bsh
@@ -1,0 +1,28 @@
+import java.io.File;
+
+File classes = new File(basedir, "target/classes/test/");
+
+File moduleAdapter = new File(classes, "TestApp$TestModule$$ModuleAdapter.class");
+if (!moduleAdapter.exists()) throw new Exception("No binding generated for module");
+
+File integerBinding = 
+    new File(classes, "TestApp$TestModule$$ModuleAdapter$ProvideIntegerProvidesAdapter.class");
+if (!integerBinding.exists()) throw new Exception("No binding generated for integer()");
+
+File stringBinding =
+    new File(classes, "TestApp$TestModule$$ModuleAdapter$ProvideStringProvidesAdapter.class");
+if (!stringBinding.exists()) throw new Exception("No binding generated for string()");
+
+File injectAdapter = new File(classes, "TestApp$InjectableSubclass$$InjectAdapter.class");
+if (!injectAdapter.exists()) 
+  throw new Exception("No inject adapter generated for InjectableSubclass");
+
+File parentAdapter = 
+    new File(classes, "parentpackage/ParentWithInjectedMember$$ParentAdapter$$test_TestApp$InjectableSubclass.class");
+if (!parentAdapter.exists()) 
+  throw new Exception("No parent adapter generated for ParentWithInjectedMember");
+  
+File grandparentAdapter = 
+    new File(classes, "grandparentpackage/GrandparentWithNoInjectedMembers$$ParentAdapter$$test_TestApp$InjectableSubclass.class");
+if (grandparentAdapter.exists()) 
+  throw new Exception("An unnecessary parent adapter was generated for GrandparentwithNoInjectedMembers.");

--- a/compiler/src/main/java/dagger/internal/codegen/AdapterJavadocs.java
+++ b/compiler/src/main/java/dagger/internal/codegen/AdapterJavadocs.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012 Square, Inc.
+ * Copyright (C) 2013 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +42,10 @@ public final class AdapterJavadocs {
       + "instance provision of types served by {@code @Provides} methods.";
   static final String STATIC_INJECTION_TYPE = ""
       + "A manager for {@code %s}'s injections into static fields.";
+  static final String PARENT_ADAPTER_TYPE = ""
+      + "An internal adapter used to provide InjectAdapters with access to their injected\n"
+      + "type's inheritance hierarchy allowing members injection, linker attachment,/n"
+      + "and dependency collection.";
 
   /** Creates an appropriate javadoc depending on aspects of the type in question. */
   static String bindingTypeDocs(String type, boolean abstrakt, boolean members, boolean dependent) {
@@ -64,5 +69,4 @@ public final class AdapterJavadocs {
     }
     return sb.toString();
   }
-
 }

--- a/core/src/test/java/dagger/internal/FailoverLoaderTest.java
+++ b/core/src/test/java/dagger/internal/FailoverLoaderTest.java
@@ -27,8 +27,8 @@ import org.junit.runners.JUnit4;
 import static org.fest.assertions.Assertions.assertThat;
 
 /**
- * A test case to deal with fall-back to reflection where the concrete type has been generated
- * but the parent has no {@code @Inject} annotation, and so has not been generated.
+ * A test case to deal with fall-back to reflection where an inject adapter has not
+ * been generated.
  */
 @RunWith(JUnit4.class)
 public final class FailoverLoaderTest {


### PR DESCRIPTION
This eliminates the need to fall back to reflection when an injected type has a (non platform) supertype. Previously, if a class had a supertype, we would fall back to reflection unless the supertype had an @Inject annotation. In fact, in order to not fall back to reflection, every (non-platform) ancestor would have to have an @Inject annotation.

This change is particularly relevant to classes with abstract supertypes that do not have members injection. The abstract supertype would have no @Inject annotation, and in its current state, Dagger would fall back to reflection.

Also note that the `ParentAdapters` that are generated only implement `MembersInjector`. That is, they are not Bindings since all we need them for is to do members injection in the parents. Additionally, we only create parent adapters when needed. So, if a class has some ancestors that have members injection and some that do not, adapters will only be generated for those that do.

This _is_ a change in behavior, and its only downside is that Dagger will no longer automatically detect if somebody swaps in a parent type from an upstream dependency without recompiling.
