### PR TITLE
Fix annotation equivalence for Keys in Dagger 2.

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/AnnotationValues.java
+++ b/compiler/src/main/java/dagger/internal/codegen/AnnotationValues.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2014 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dagger.internal.codegen;
+
+import com.google.common.base.Equivalence;
+import com.google.common.collect.Sets;
+import java.util.List;
+import java.util.Map;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.util.SimpleAnnotationValueVisitor6;
+
+/**
+ * A utility class for working with {@link AnnotationValue} instances.
+ *
+ * @author Christian Gruber
+ */
+final class AnnotationValues {
+  private static final Equivalence<AnnotationValue> ANNOTATION_VALUE_EQUIVALENCE =
+      new Equivalence<AnnotationValue>() {
+        @Override protected boolean doEquivalent(AnnotationValue left, AnnotationValue right) {
+          return left.accept(new SimpleAnnotationValueVisitor6<Boolean, AnnotationValue>() {
+            // LHS is not an annotation or array of annotation values, so just test equality.
+            @Override protected Boolean defaultAction(Object left, AnnotationValue right) {
+              return left.equals(right.accept(
+                  new SimpleAnnotationValueVisitor6<Object, Void>() {
+                    @Override protected Object defaultAction(Object object, Void unused) {
+                      return object;
+                    }
+                  }, null));
+            }
+
+            // LHS is an annotation mirror so test equivalence for RHS annotation mirrors
+            // and false for other types.
+            @Override public Boolean visitAnnotation(AnnotationMirror left, AnnotationValue right) {
+              return right.accept(
+                  new SimpleAnnotationValueVisitor6<Boolean, AnnotationMirror>() {
+                    @Override protected Boolean defaultAction(Object right, AnnotationMirror left) {
+                      return false; // Not an annotation mirror, so can't be equal to such.
+                    }
+                    @Override
+                    public Boolean visitAnnotation(AnnotationMirror right, AnnotationMirror left) {
+                      return AnnotationMirrors.equivalence().equivalent(left, right);
+                    }
+                  }, left);
+            }
+
+            // LHS is a list of annotation values have to collect-test equivalences, or false
+            // for any other types.
+            @Override
+            public Boolean visitArray(List<? extends AnnotationValue> left, AnnotationValue right) {
+              return right.accept(
+                  new SimpleAnnotationValueVisitor6<Boolean, List<? extends AnnotationValue>>() {
+                    @Override protected Boolean defaultAction(
+                        Object ignored, List<? extends AnnotationValue> alsoIgnored) {
+                      return false; // Not an annotation mirror, so can't be equal to such.
+                    }
+
+                    @Override public Boolean visitArray(
+                        List<? extends AnnotationValue> right ,
+                        List<? extends AnnotationValue> left) {
+                      return AnnotationValues.equivalence().pairwise().equivalent(
+                          (List<AnnotationValue>) left, (List<AnnotationValue>) right);
+                    }
+                  }, left);
+            }
+          }, right);
+        }
+
+        @Override protected int doHash(AnnotationValue value) {
+          return value.accept(new SimpleAnnotationValueVisitor6<Integer, Void>() {
+            @Override public Integer visitAnnotation(AnnotationMirror value, Void ignore) {
+              return AnnotationMirrors.equivalence().hash(value);
+            }
+
+            @SuppressWarnings("unchecked") // safe covariant cast
+            @Override public Integer visitArray(
+                List<? extends AnnotationValue> values, Void ignore) {
+              return AnnotationValues.equivalence().pairwise().hash((List<AnnotationValue>) values);
+            }
+
+            @Override protected Integer defaultAction(Object value, Void ignored) {
+              return value.hashCode();
+            }
+          }, null);
+        }
+      };
+
+  static Equivalence<AnnotationValue> equivalence() {
+    return ANNOTATION_VALUE_EQUIVALENCE;
+  }
+
+  private AnnotationValues() {}
+}

--- a/compiler/src/main/java/dagger/internal/codegen/DependencyRequest.java
+++ b/compiler/src/main/java/dagger/internal/codegen/DependencyRequest.java
@@ -119,33 +119,34 @@ abstract class DependencyRequest {
 
     private DependencyRequest newDependencyRequest(Element requestElement, TypeMirror type,
         Optional<AnnotationMirror> qualifier) {
-      if (elements.getTypeElement(Provider.class.getCanonicalName())
-          .equals(types.asElement(type))) {
-        DeclaredType providerType = (DeclaredType) type;
+      if (isTypeOf(Provider.class, type)) {
         return new AutoValue_DependencyRequest(Kind.PROVIDER,
-            keyFactory.forQualifiedType(qualifier,
-                Iterables.getOnlyElement(providerType.getTypeArguments())),
+            qualifiedTypeForParameter(qualifier, (DeclaredType) type),
             requestElement);
-      } else if (elements.getTypeElement(Lazy.class.getCanonicalName())
-          .equals(types.asElement(type))) {
-        DeclaredType lazyType = (DeclaredType) type;
+      } else if (isTypeOf(Lazy.class, type)) {
         return new AutoValue_DependencyRequest(Kind.LAZY,
-            keyFactory.forQualifiedType(qualifier,
-                Iterables.getOnlyElement(lazyType.getTypeArguments())),
+            qualifiedTypeForParameter(qualifier, (DeclaredType) type),
             requestElement);
-      } else if (elements.getTypeElement(MembersInjector.class.getCanonicalName())
-          .equals(types.asElement(type))) {
+      } else if (isTypeOf(MembersInjector.class, type)) {
         checkArgument(!qualifier.isPresent());
-        DeclaredType membersInjectorType = (DeclaredType) type;
         return new AutoValue_DependencyRequest(Kind.MEMBERS_INJECTOR,
-            keyFactory.forQualifiedType(qualifier,
-                Iterables.getOnlyElement(membersInjectorType.getTypeArguments())),
+            qualifiedTypeForParameter(qualifier, (DeclaredType) type),
             requestElement);
       } else {
         return new AutoValue_DependencyRequest(Kind.INSTANCE,
             keyFactory.forQualifiedType(qualifier, type),
             requestElement);
       }
+    }
+
+    private Key qualifiedTypeForParameter(
+        Optional<AnnotationMirror> qualifier, DeclaredType type) {
+      return keyFactory.forQualifiedType(qualifier,
+          Iterables.getOnlyElement(type.getTypeArguments()));
+    }
+
+    private boolean isTypeOf(Class<?> type, TypeMirror mirror) {
+      return elements.getTypeElement(type.getCanonicalName()).equals(types.asElement(mirror));
     }
   }
 }

--- a/compiler/src/main/java/dagger/internal/codegen/Key.java
+++ b/compiler/src/main/java/dagger/internal/codegen/Key.java
@@ -17,6 +17,7 @@ package dagger.internal.codegen;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Equivalence;
+import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import dagger.Provides;
@@ -50,8 +51,12 @@ abstract class Key {
   /**
    * A {@link javax.inject.Qualifier} annotation that provides a unique namespace prefix
    * for the type of this key.
+   *
+   * Despite documentation in {@link AnnotationMirror}, equals and hashCode aren't implemented
+   * to represent logical equality, so {@link MoreTypes#annotationMirrorEquivalence()}
+   * provides this facility.
    */
-  abstract Optional<AnnotationMirror> qualifier();
+  abstract Optional<Equivalence.Wrapper<AnnotationMirror>> wrappedQualifier();
 
   /**
    * The type represented by this key.
@@ -60,6 +65,15 @@ abstract class Key {
    * logical equality, so {@link MoreTypes#equivalence()} wraps this type.
    */
   abstract Equivalence.Wrapper<TypeMirror> wrappedType();
+
+  Optional<AnnotationMirror> qualifier() {
+    return wrappedQualifier().transform(
+        new Function<Equivalence.Wrapper<AnnotationMirror>, AnnotationMirror>() {
+          @Override public AnnotationMirror apply(Equivalence.Wrapper<AnnotationMirror> wrapper) {
+            return wrapper.get();
+          }
+        });
+  }
 
   TypeMirror type() {
     return wrappedType().get();
@@ -101,15 +115,15 @@ abstract class Key {
       Optional<AnnotationMirror> qualifier = getQualifier(e);
       switch (providesAnnotation.type()) {
         case UNIQUE:
-          return new AutoValue_Key(qualifier, MoreTypes.equivalence().wrap(returnType));
+          return new AutoValue_Key(rewrap(qualifier), MoreTypes.equivalence().wrap(returnType));
         case SET:
           TypeMirror setType = types.getDeclaredType(getSetElement(), returnType);
-          return new AutoValue_Key(qualifier, MoreTypes.equivalence().wrap(setType));
+          return new AutoValue_Key(rewrap(qualifier), MoreTypes.equivalence().wrap(setType));
         case SET_VALUES:
           // TODO(gak): do we want to allow people to use "covariant return" here?
           checkArgument(returnType.getKind().equals(DECLARED));
           checkArgument(((DeclaredType) returnType).asElement().equals(getSetElement()));
-          return new AutoValue_Key(qualifier, MoreTypes.equivalence().wrap(returnType));
+          return new AutoValue_Key(rewrap(qualifier), MoreTypes.equivalence().wrap(returnType));
         default:
           throw new AssertionError();
       }
@@ -121,17 +135,26 @@ abstract class Key {
       checkArgument(!getQualifier(e).isPresent());
       // Must use the enclosing element.  The return type is void for constructors(?!)
       TypeMirror type = e.getEnclosingElement().asType();
-      return new AutoValue_Key(Optional.<AnnotationMirror>absent(),
+      return new AutoValue_Key(
+          Optional.<Equivalence.Wrapper<AnnotationMirror>>absent(),
           MoreTypes.equivalence().wrap(type));
     }
 
     Key forType(TypeMirror type) {
-      return new AutoValue_Key(Optional.<AnnotationMirror>absent(),
+      return new AutoValue_Key(
+          Optional.<Equivalence.Wrapper<AnnotationMirror>>absent(),
           MoreTypes.equivalence().wrap(normalize(type)));
     }
 
     Key forQualifiedType(Optional<AnnotationMirror> qualifier, TypeMirror type) {
-      return new AutoValue_Key(qualifier, MoreTypes.equivalence().wrap(normalize(type)));
+      return new AutoValue_Key(rewrap(qualifier), MoreTypes.equivalence().wrap(normalize(type)));
+    }
+
+    private Optional<Equivalence.Wrapper<AnnotationMirror>>
+        rewrap(Optional<AnnotationMirror> qualifier) {
+      return qualifier.isPresent()
+          ? Optional.of(AnnotationMirrors.equivalence().wrap(qualifier.get()))
+          : Optional.<Equivalence.Wrapper<AnnotationMirror>>absent();
     }
   }
 }

--- a/compiler/src/test/java/dagger/internal/codegen/AnnotationMirrorsTest.java
+++ b/compiler/src/test/java/dagger/internal/codegen/AnnotationMirrorsTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2014 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dagger.internal.codegen;
+
+import com.google.common.testing.EquivalenceTester;
+import com.google.testing.compile.CompilationRule;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.SimpleAnnotationValueVisitor6;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static dagger.internal.codegen.AnnotationMirrorsTest.SimpleEnum.BLAH;
+import static dagger.internal.codegen.AnnotationMirrorsTest.SimpleEnum.FOO;
+import static org.truth0.Truth.ASSERT;
+
+/**
+ * Tests {@link AnnotationMirrors}.
+ */
+@RunWith(JUnit4.class)
+public class AnnotationMirrorsTest {
+  @Rule public CompilationRule compilationRule = new CompilationRule();
+
+  private Elements elements;
+
+  @Before public void setUp() {
+    this.elements = compilationRule.getElements();
+  }
+
+  enum SimpleEnum{
+    BLAH, FOO
+  }
+
+  @interface Outer {
+    SimpleEnum value();
+  }
+
+  @Outer(BLAH) static class TestClassBlah {}
+  @Outer(BLAH) static class TestClassBlah2 {}
+  @Outer(FOO) static class TestClassFoo {}
+
+  @interface DefaultingOuter {
+    SimpleEnum value() default SimpleEnum.BLAH;
+  }
+
+  @DefaultingOuter class TestWithDefaultingOuterDefault {}
+  @DefaultingOuter(BLAH) class TestWithDefaultingOuterBlah {}
+  @DefaultingOuter(FOO) class TestWithDefaultingOuterFoo {}
+
+  @interface SimpleAnnotation {}
+
+  @interface AnnotatedOuter {
+    DefaultingOuter value();
+  }
+
+  @AnnotatedOuter(@DefaultingOuter) class TestDefaultNestedAnnotated {}
+  @AnnotatedOuter(@DefaultingOuter(BLAH)) class TestBlahNestedAnnotated {}
+  @AnnotatedOuter(@DefaultingOuter(FOO)) class TestFooNestedAnnotated {}
+
+  @interface OuterWithValueArray {
+    DefaultingOuter[] value() default {};
+  }
+
+  @OuterWithValueArray class TestValueArrayWithDefault {}
+  @OuterWithValueArray({}) class TestValueArrayWithEmpty {}
+
+  @OuterWithValueArray({@DefaultingOuter}) class TestValueArrayWithOneDefault {}
+  @OuterWithValueArray(@DefaultingOuter(BLAH)) class TestValueArrayWithOneBlah {}
+  @OuterWithValueArray(@DefaultingOuter(FOO)) class TestValueArrayWithOneFoo {}
+
+  @OuterWithValueArray({@DefaultingOuter(FOO), @DefaultingOuter})
+  class TestValueArrayWithFooAndDefaultBlah {}
+  @OuterWithValueArray({@DefaultingOuter(FOO), @DefaultingOuter(BLAH)})
+  class TestValueArrayWithFooBlah {}
+  @OuterWithValueArray({@DefaultingOuter(FOO), @DefaultingOuter(BLAH)})
+  class TestValueArrayWithFooBlah2 {} // Different instances than on TestValueArrayWithFooBlah.
+  @OuterWithValueArray({@DefaultingOuter(BLAH), @DefaultingOuter(FOO)})
+  class TestValueArrayWithBlahFoo {}
+
+
+  @Test public void testEquivalences() {
+    EquivalenceTester<AnnotationMirror> tester =
+        EquivalenceTester.of(AnnotationMirrors.equivalence());
+
+    tester.addEquivalenceGroup(
+        annotationOn(TestClassBlah.class),
+        annotationOn(TestClassBlah2.class));
+
+    tester.addEquivalenceGroup(
+        annotationOn(TestClassFoo.class));
+
+    tester.addEquivalenceGroup(
+        annotationOn(TestWithDefaultingOuterDefault.class),
+        annotationOn(TestWithDefaultingOuterBlah.class));
+
+    tester.addEquivalenceGroup(
+        annotationOn(TestWithDefaultingOuterFoo.class));
+
+    tester.addEquivalenceGroup(
+        annotationOn(TestDefaultNestedAnnotated.class),
+        annotationOn(TestBlahNestedAnnotated.class));
+
+    tester.addEquivalenceGroup(
+        annotationOn(TestFooNestedAnnotated.class));
+
+    tester.addEquivalenceGroup(
+        annotationOn(TestValueArrayWithDefault.class),
+        annotationOn(TestValueArrayWithEmpty.class));
+
+    tester.addEquivalenceGroup(
+        annotationOn(TestValueArrayWithOneDefault.class),
+        annotationOn(TestValueArrayWithOneBlah.class));
+
+    tester.addEquivalenceGroup(
+        annotationOn(TestValueArrayWithOneFoo.class));
+
+    tester.addEquivalenceGroup(
+        annotationOn(TestValueArrayWithFooAndDefaultBlah.class),
+        annotationOn(TestValueArrayWithFooBlah.class),
+        annotationOn(TestValueArrayWithFooBlah2.class));
+
+    tester.addEquivalenceGroup(
+        annotationOn(TestValueArrayWithBlahFoo.class));
+
+    tester.test();
+  }
+
+  @interface Stringy {
+    String value() default "default";
+  }
+
+  @Stringy class StringyUnset {}
+  @Stringy("foo") class StringySet {}
+
+  @Test public void testGetDefaultValuesUnset() {
+    ASSERT.that(annotationOn(StringyUnset.class).getElementValues()).isEmpty();
+    Iterable<AnnotationValue> values = AnnotationMirrors.getAnnotationValuesWithDefaults(
+        annotationOn(StringyUnset.class));
+    String value = getOnlyElement(values).accept(new SimpleAnnotationValueVisitor6<String, Void>() {
+          @Override public String visitString(String value, Void ignored) {
+            return value;
+          }
+        }, null);
+    ASSERT.that(value).isEqualTo("default");
+  }
+
+  @Test public void testGetDefaultValuesSet() {
+    Iterable<AnnotationValue> values = AnnotationMirrors.getAnnotationValuesWithDefaults(
+        annotationOn(StringySet.class));
+    String value = getOnlyElement(values).accept(new SimpleAnnotationValueVisitor6<String, Void>() {
+          @Override public String visitString(String value, Void ignored) {
+            return value;
+          }
+        }, null);
+    ASSERT.that(value).isEqualTo("foo");
+  }
+
+  private AnnotationMirror annotationOn(Class<?> clazz) {
+    return getOnlyElement(elements.getTypeElement(clazz.getCanonicalName()).getAnnotationMirrors());
+  }
+}


### PR DESCRIPTION
---

Created by MOE: http://code.google.com/p/moe-java
MOE_MIGRATED_REVID=69332953
