### PR TITLE
Update Travis to use Android worker, include JDK 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
-language: java
+language: android
 
 jdk:
   - oraclejdk7
   - openjdk7
 
-before_install:
-  - sudo apt-get install -qq libstdc++6:i386 lib32z1
-  - export COMPONENTS=build-tools-19.0.1,android-16
-  - curl -L https://raw.github.com/embarkmobile/android-sdk-installer/version-1/android-sdk-installer | bash /dev/stdin --install=$COMPONENTS
-  - source ~/.android-sdk-installer/env
+android:
+  components:
+    - build-tools-20.0.0
+    - android-16
+  licenses:
+    - android-sdk-license-5be876d5
 
 install: mvn install clean --fail-never --quiet -DskipTests=true -Dinvoker.skip=true
 


### PR DESCRIPTION
The Android worker is a superset of the Java one which includes functionality for automating installation of Android components.
