### PR TITLE
Updated test for Truth API change

### DIFF
--- a/core/src/test/java/dagger/internal/MapProviderFactoryTest.java
+++ b/core/src/test/java/dagger/internal/MapProviderFactoryTest.java
@@ -71,7 +71,7 @@ public class MapProviderFactoryTest {
     expectedMap.put("four", p4);
     assert_()
         .that(factory.get().entrySet())
-        .containsExactlyElementsIn(expectedMap.entrySet())
+        .has().exactlyAs(expectedMap.entrySet())
         .inOrder();
   }
 


### PR DESCRIPTION
It looks like the truth assertion library has changed it API slightly and now breaks compilation of this test.
