### PR TITLE
Fix link to Javadoc

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,7 +32,7 @@
           <a href="https://github.com/google/dagger" target="_blank"></a>
         </paper-item>
         <paper-item label="Javadoc" icon="open-in-browser">
-          <a href="/api/latest/" target="_blank"></a>
+          <a href="api/latest/" target="_blank"></a>
         </paper-item>
         <h4>Resources</h4>
         <paper-item label="Stack Overflow" icon="open-in-browser">


### PR DESCRIPTION
Currently the Javadoc link on the site doesn't resolve to the right place. This makes it relative, so it does.
