### PR TITLE
Optimize set and map binding creation.

### DIFF
--- a/core/src/main/java/dagger/internal/Collections.java
+++ b/core/src/main/java/dagger/internal/Collections.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2014 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dagger.internal;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+
+final class Collections {
+  private Collections() {
+  }
+
+  /**
+   * Creates a {@link LinkedHashSet} instance, with a high enough "initial capacity" that it
+   * <em>should</em> hold {@code expectedSize} elements without growth. The load factor is set at
+   * {@code 1f} under the assumption this will be filled and wrapped in an unmodifiable wrapper.
+   */
+  static <E> LinkedHashSet<E> newLinkedHashSetWithExpectedSize(int expectedSize) {
+    return new LinkedHashSet<E>(calculateInitialCapacity(expectedSize), 1f);
+  }
+
+  /**
+   * Creates a {@link LinkedHashMap} instance, with a high enough "initial capacity" that it
+   * <em>should</em> hold {@code expectedSize} elements without growth. The load factor is set at
+   * {@code 1f} under the assumption this will be filled and wrapped in an unmodifiable wrapper.
+   */
+  static <K, V> LinkedHashMap<K, V> newLinkedHashMapWithExpectedSize(int expectedSize) {
+    return new LinkedHashMap<K, V>(calculateInitialCapacity(expectedSize), 1f);
+  }
+
+  private static int calculateInitialCapacity(int expectedSize) {
+    return (expectedSize < 3)
+        ? expectedSize + 1
+        : (expectedSize < (1 << (Integer.SIZE - 2)))
+            ? expectedSize + expectedSize / 3
+            : Integer.MAX_VALUE;
+  }
+}

--- a/core/src/main/java/dagger/internal/MapFactory.java
+++ b/core/src/main/java/dagger/internal/MapFactory.java
@@ -16,14 +16,12 @@
 package dagger.internal;
 
 import dagger.Factory;
-
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
-
 import javax.inject.Provider;
+
+import static dagger.internal.Collections.newLinkedHashMapWithExpectedSize;
+import static java.util.Collections.unmodifiableMap;
 
 /**
  * A {@link Factory} implementation used to implement {@link Map} bindings. This factory returns a
@@ -33,11 +31,11 @@ import javax.inject.Provider;
  * @since 2.0
  *
  */
-public class MapFactory<K, V> implements Factory<Map<K, V>> {
+public final class MapFactory<K, V> implements Factory<Map<K, V>> {
   private final Map<K, Provider<V>> contributingMap;
-  
+
   private MapFactory(Map<K, Provider<V>> map) {
-    this.contributingMap = Collections.unmodifiableMap(map);
+    this.contributingMap = unmodifiableMap(map);
   }
 
   /**
@@ -51,14 +49,13 @@ public class MapFactory<K, V> implements Factory<Map<K, V>> {
   /**
    * Returns a {@code Map<K, V>} whose iteration order is that of the elements
    * given by each of the providers, which are invoked in the order given at creation.
-   *
    */
   @Override
   public Map<K, V> get() {
-    LinkedHashMap<K, V> result = new LinkedHashMap<K, V>();
+    Map<K, V> result = newLinkedHashMapWithExpectedSize(contributingMap.size());
     for (Entry<K, Provider<V>> entry: contributingMap.entrySet()) {
       result.put(entry.getKey(), entry.getValue().get());
     }
-    return result;
+    return unmodifiableMap(result);
   }
 }

--- a/core/src/main/java/dagger/internal/MapProviderFactory.java
+++ b/core/src/main/java/dagger/internal/MapProviderFactory.java
@@ -16,10 +16,12 @@
 package dagger.internal;
 
 import dagger.Factory;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.inject.Provider;
+
+import static dagger.internal.Collections.newLinkedHashMapWithExpectedSize;
+import static java.util.Collections.unmodifiableMap;
 
 /**
  * A {@link Factory} implementation used to implement {@link Map} bindings. This factory returns a
@@ -29,7 +31,7 @@ import javax.inject.Provider;
  * @since 2.0
  *
  */
-public class MapProviderFactory<K, V> implements Factory<Map<K, Provider<V>>> {
+public final class MapProviderFactory<K, V> implements Factory<Map<K, Provider<V>>> {
   private final Map<K, Provider<V>> contributingMap;
 
   /**
@@ -40,7 +42,7 @@ public class MapProviderFactory<K, V> implements Factory<Map<K, Provider<V>>> {
   }
 
   private MapProviderFactory(LinkedHashMap<K, Provider<V>> contributingMap) {
-    this.contributingMap = Collections.unmodifiableMap(contributingMap);
+    this.contributingMap = unmodifiableMap(contributingMap);
   }
 
   /**
@@ -56,7 +58,7 @@ public class MapProviderFactory<K, V> implements Factory<Map<K, Provider<V>>> {
   /**
    * A builder to help build the {@link MapProviderFactory}
    */
-  public static class Builder<K, V> {
+  public static final class Builder<K, V> {
     private final LinkedHashMap<K, Provider<V>> mapBuilder;
 
     private Builder(int size) {
@@ -84,17 +86,6 @@ public class MapProviderFactory<K, V> implements Factory<Map<K, Provider<V>>> {
 
       this.mapBuilder.put(key, providerOfValue);
       return this;
-    }
-
-    private static <K, V> LinkedHashMap<K, Provider<V>> newLinkedHashMapWithExpectedSize(
-        int expectedSize) {
-      if (expectedSize < 0) {
-        throw new IllegalArgumentException("The expected size of map cannot be negative.");
-      }
-      int initialCapacity = (expectedSize < 3) ? expectedSize + 1
-          : (expectedSize < (1 << (Integer.SIZE - 2))) ? expectedSize + expectedSize / 3
-              : Integer.MAX_VALUE;
-      return new LinkedHashMap<K, Provider<V>>(initialCapacity);
     }
   }
 }

--- a/core/src/main/java/dagger/internal/SetFactory.java
+++ b/core/src/main/java/dagger/internal/SetFactory.java
@@ -17,11 +17,11 @@ package dagger.internal;
 
 import dagger.Factory;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import javax.inject.Provider;
 
+import static dagger.internal.Collections.newLinkedHashSetWithExpectedSize;
 import static java.util.Collections.unmodifiableSet;
 
 /**
@@ -93,16 +93,5 @@ public final class SetFactory<T> implements Factory<Set<T>> {
       }
     }
     return unmodifiableSet(result);
-  }
-
-  // TODO(gak): consider whether (expectedSize, 1.0f) is better for this use case since callers are
-  // typically only going to iterate
-  private static <E> LinkedHashSet<E> newLinkedHashSetWithExpectedSize(int expectedSize) {
-    int initialCapacity = (expectedSize < 3)
-        ? expectedSize + 1
-        : (expectedSize < (1 << (Integer.SIZE - 2)))
-            ? expectedSize + expectedSize / 3
-            : Integer.MAX_VALUE;
-    return new LinkedHashSet<E>(initialCapacity);
   }
 }


### PR DESCRIPTION
- Use a pre-sized map when resolving map value instances.
- Use a list of bindings rather than a set of bindings for passing along the collection of contributors to a set binding.
