### PR TITLE
compiler: Shade the resulting jar

### DIFF
--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -139,6 +139,18 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
The compiler has a set of dependencies that may conflict with other
library versions in projects that use it.

This adds the shade plugin which bundles dependencies in the jar
and thus solves this issue.
plugin in order to include the dependencies