### PR TITLE
Eliminate extra newlines.

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/writer/JavaWriter.java
+++ b/compiler/src/main/java/dagger/internal/codegen/writer/JavaWriter.java
@@ -132,6 +132,7 @@ public final class JavaWriter {
 
     ImmutableSet<String> declaredSimpleNames = declaredSimpleNamesBuilder.build();
 
+    boolean hasImports = false;
     BiMap<String, ClassName> importedClassIndex = HashBiMap.create();
     for (ClassName className : importCandidates) {
       if (!(className.packageName().equals(packageName)
@@ -148,18 +149,25 @@ public final class JavaWriter {
         if (importCandidate.isPresent()) {
           appendable.append("import ").append(importCandidate.get().canonicalName()).append(";\n");
           importedClassIndex.put(importCandidate.get().simpleName(), importCandidate.get());
+          hasImports = true;
         }
       }
     }
 
-    appendable.append('\n');
+    if (hasImports) {
+      appendable.append('\n');
+    }
 
     CompilationUnitContext context =
         new CompilationUnitContext(packageName, ImmutableSet.copyOf(importedClassIndex.values()));
 
     // write types
-    for (TypeWriter typeWriter : typeWriters) {
-      typeWriter.write(appendable, context.createSubcontext(typeNames)).append('\n');
+    for (int i = 0; i < typeWriters.size(); i++) {
+      if (i > 0) {
+        appendable.append('\n');
+      }
+      TypeWriter typeWriter = typeWriters.get(i);
+      typeWriter.write(appendable, context.createSubcontext(typeNames));
     }
     return appendable;
   }

--- a/compiler/src/test/java/dagger/internal/codegen/writer/JavaWriterTest.java
+++ b/compiler/src/test/java/dagger/internal/codegen/writer/JavaWriterTest.java
@@ -15,6 +15,7 @@
  */
 package dagger.internal.codegen.writer;
 
+import java.util.concurrent.Executor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -29,5 +30,50 @@ public class JavaWriterTest {
     topClass.addNestedClass("Middle").addNestedClass("Bottom");
     topClass.addField(ClassName.create("some.other.pkg", "Bottom"), "field");
     assertThat(topClass.toString()).doesNotContain("import some.other.pkg.Bottom;");
+  }
+
+  @Test public void zeroImportsSingleNewline() {
+    JavaWriter javaWriter = JavaWriter.inPackage("test");
+    javaWriter.addClass("Top");
+
+    String expected = ""
+        + "package test;\n"
+        + "\n"
+        + "class Top {";
+
+    assertThat(javaWriter.toString()).startsWith(expected);
+  }
+
+  @Test public void newlineBetweenImports() {
+    JavaWriter javaWriter = JavaWriter.inPackage("test");
+    ClassWriter topClass = javaWriter.addClass("Top");
+    topClass.addField(Executor.class, "executor");
+
+    String expected = ""
+        + "package test;\n"
+        + "\n"
+        + "import java.util.concurrent.Executor;\n"
+        + "\n"
+        + "class Top {";
+
+    assertThat(javaWriter.toString()).startsWith(expected);
+  }
+
+  @Test public void newlinesBetweenTypes() {
+    JavaWriter javaWriter = JavaWriter.inPackage("test");
+    javaWriter.addClass("Top");
+    javaWriter.addClass("Middle");
+    javaWriter.addClass("Bottom");
+
+    String expected = ""
+        + "package test;\n"
+        + "\n"
+        + "class Top {}\n"
+        + "\n"
+        + "class Middle {}\n"
+        + "\n"
+        + "class Bottom {}\n";
+
+    assertThat(javaWriter.toString()).isEqualTo(expected);
   }
 }


### PR DESCRIPTION
- No additional trailing newline after the last type in a file.
- No additional newline between package and types when there are no imports.
