### PR TITLE
Change documentation for using Dagger with Maven

### DIFF
--- a/index.md
+++ b/index.md
@@ -291,21 +291,13 @@ In a Maven project, one would include the runtime in the dependencies section of
     <artifactId>dagger</artifactId>
     <version>{{site.dagger.version}}</version>
   </dependency>
+  <dependency>
+    <groupId>{{site.dagger.groupId}}</groupId>
+    <artifactId>dagger-compiler</artifactId>
+    <version>{{site.dagger.version}}</version>
+    <optional>true</optional>
+  </dependency>
 </dependencies>
-<build>
-  <plugins>
-    <plugin>
-      <artifactId>maven-compiler-plugin</artifactId>
-      <dependencies>
-        <dependency>
-          <groupId>{{site.dagger.groupId}}</groupId>
-          <artifactId>dagger-compiler</artifactId>
-          <version>{{site.dagger.version}}</version>
-        </dependency>
-      </dependencies>
-    </plugin>
-  </plugins>
-</build>
 ```
 
 ## License


### PR DESCRIPTION
Adding dagger-compiler as a dependency of maven-compiler-plugin doesn't seem to work, or at least it didn't for me which leads me to believe that it might not work for others as well.