### PR TITLE
Reproduction example for mvn-compiler-plugin bug

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -31,6 +31,7 @@
 
   <modules>
     <module>simple</module>
+    <module>repro</module>
   </modules>
 
   <!-- Travis CI currently has a problem building Android so we disable this profile -->

--- a/examples/repro/pom.xml
+++ b/examples/repro/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>dagger-example-parent</artifactId>
+    <groupId>com.google.dagger.example</groupId>
+    <version>2.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>repro</artifactId>
+  <name>Example: reproduction of recompilation failure</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.2</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <compilerArgument>-Werror</compilerArgument>
+          <compilerArgument>-Xlint:all</compilerArgument>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.dagger</groupId>
+      <artifactId>dagger</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.dagger</groupId>
+      <artifactId>dagger-compiler</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+</project>

--- a/examples/repro/src/main/java/repro/ReproComponent.java
+++ b/examples/repro/src/main/java/repro/ReproComponent.java
@@ -1,0 +1,8 @@
+package repro;
+
+import dagger.Component;
+
+@Component(modules = ReproModule.class)
+public interface ReproComponent {
+  String value();
+}

--- a/examples/repro/src/main/java/repro/ReproModule.java
+++ b/examples/repro/src/main/java/repro/ReproModule.java
@@ -1,0 +1,12 @@
+package repro;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+public class ReproModule {
+  @Provides
+  String theValue() {
+    return "";
+  }
+}


### PR DESCRIPTION
Using the maven-compiler-plugin with java 1.8.0_25 to compile twice in a
row results in an esoteric compiler exception:

```
An exception has occurred in the compiler (1.8.0_25). Please file a bug at the Java Developer Connection (http://java.sun.com/webapps/bugreport)  after checking the Bug Parade for duplicates. Include your program and the following diagnostic in your report.  Thank you.
java.lang.IllegalStateException: endPosTable already set
	at com.sun.tools.javac.util.DiagnosticSource.setEndPosTable(DiagnosticSource.java:136)
	at com.sun.tools.javac.util.Log.setEndPosTable(Log.java:350)
	at com.sun.tools.javac.main.JavaCompiler.parse(JavaCompiler.java:667)
	at com.sun.tools.javac.main.JavaCompiler.parseFiles(JavaCompiler.java:950)
	at com.sun.tools.javac.processing.JavacProcessingEnvironment$Round.<init>(JavacProcessingEnvironment.java:892)
	at com.sun.tools.javac.processing.JavacProcessingEnvironment$Round.next(JavacProcessingEnvironment.java:921)
	at com.sun.tools.javac.processing.JavacProcessingEnvironment.doProcessing(JavacProcessingEnvironment.java:1187)
	at com.sun.tools.javac.main.JavaCompiler.processAnnotations(JavaCompiler.java:1170)
	at com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:856)
```

To reproduce:
- be using jdk-1.8.0_25

```
mvn clean -pl examples/repro
mvn compile -pl examples/repro
!!
```

I haven't tried with other minor versions of the JDK because I don't have them installed and I'm tethering from my phone :)