### PR TITLE
Configure javadoc to use groups and have a release-oriented public API profile.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,31 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <doctitle>Dagger Dependency Injection ${project.version} API</doctitle>
+          <links>
+            <link>http://docs.oracle.com/javaee/7/api</link>
+          </links>
+          <groups>
+            <group>
+              <title>Dagger Packages</title>
+              <packages>dagger</packages>
+            </group>
+            <group>
+              <title>Dagger Producers</title>
+              <packages>dagger.producers</packages>
+            </group>
+            <group>
+              <title>Intrenal APIs (for Generated Code)</title>
+              <packages>dagger.internal:dagger.producers.internal</packages>
+            </group>
+            <group>
+              <title>Compiler APIs</title>
+              <packages>dagger.internal.codegen*</packages>
+            </group>
+            <group>
+              <title>Examples</title>
+              <packages>coffee*:com.example*</packages>
+            </group>
+          </groups>
         </configuration>
       </plugin>
 
@@ -223,6 +248,24 @@
         <module>examples</module>
         <module>producers</module>
       </modules>
+    </profile>
+    <profile>
+      <id>terse-javadocs</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <doctitle>Dagger Dependency Injection ${project.version} Public API</doctitle>
+              <sourceFileIncludes>
+                <sourceFileInclude>dagger/*.java</sourceFileInclude>
+                <sourceFileInclude>dagger/internal/Beta.java</sourceFileInclude>
+                <sourceFileInclude>dagger/producers/*.java</sourceFileInclude>
+              </sourceFileIncludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Configure javadoc to build groups around the different segments, and leave a 'terse-javadocs' profile to use in prparing release (public) API docs.