### PR TITLE
Minor typo fixes to dagger2 documentation

### DIFF
--- a/index.md
+++ b/index.md
@@ -103,7 +103,7 @@ By convention, `@Provides` methods are named with a `provide` prefix and module 
 
 ### Building the Graph
 
-The `@Inject` and `@Provides`-annotated classes form a graph of objects, linked by their dependencies. Calling code like an application's `main` method or an Android [`Application`](http://developer.android.com/reference/android/app/Application.html) accesses that graph via a well-defined set of roots. In Dagger 2, that set is defined by an interface with methods that have no arguments and return the desired type. By applying the [`@Component`][Component] annotation to such an interface and passing the [module][Module] types to the `module` parameter, Dagger 2 then fully generates an implementation of that contract.
+The `@Inject` and `@Provides`-annotated classes form a graph of objects, linked by their dependencies. Calling code like an application's `main` method or an Android [`Application`](http://developer.android.com/reference/android/app/Application.html) accesses that graph via a well-defined set of roots. In Dagger 2, that set is defined by an interface with methods that have no arguments and return the desired type. By applying the [`@Component`][Component] annotation to such an interface and passing the [module][Module] types to the `modules` parameter, Dagger 2 then fully generates an implementation of that contract.
 
 ```java
 @Component(modules = DripCoffeeModule.class)
@@ -165,7 +165,7 @@ class CoffeeMaker {
 }
 ```
 
-Since Dagger 2 associates scoped instances in the graph with instances of component implementations, the components themselves need to declare which scope they intend to represent. For example, it wouldn't make any sense to have a `@Singleton` binding and a `@RequestScoped` binding in the same component because those scopes have different lifecycles and thus must live in components with different lifecycles. Declaring that a component is associated with a given scope, simply apply the scope annotation to the component interface.
+Since Dagger 2 associates scoped instances in the graph with instances of component implementations, the components themselves need to declare which scope they intend to represent. For example, it wouldn't make any sense to have a `@Singleton` binding and a `@RequestScoped` binding in the same component because those scopes have different lifecycles and thus must live in components with different lifecycles. To declare that a component is associated with a given scope, simply apply the scope annotation to the component interface.
 
 ```java
 @Component(modules = DripCoffeeModule.class)


### PR DESCRIPTION
'module' parameter => 'modules' parameter

also, corrected grammar in a later paragraph