### PR TITLE
Fix maven warnings about build.plugins.plugin.version of javadoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,7 @@
 
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.3</version>
         <configuration>
           <doctitle>Dagger Dependency Injection ${project.version} API</doctitle>
         </configuration>


### PR DESCRIPTION
This value is determined by actual value used by maven. If necessary we could use [2.10.3,) or LATEST but I doubt that's desired as the rest of the pom seems to stick with a specific version.