### PR TITLE
Render generic type arguments in javadoc

### DIFF
--- a/core/src/main/java/dagger/MapKey.java
+++ b/core/src/main/java/dagger/MapKey.java
@@ -54,7 +54,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * class SomeInjectedType {
  *   {@literal @}Inject
- *   SomeInjectedType(Map<SomeEnum, Integer> map) {
+ *   {@literal SomeInjectedType(Map<SomeEnum, Integer>} map) {
  *     assert map.get(SomeEnum.FOO) == 2;
  *   }
  * }
@@ -89,7 +89,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * class SomeInjectedType {
  *   {@literal @}Inject
- *   SomeInjectedType(Map<MyMapKey, Integer> map) {
+ *   {@literal SomeInjectedType(Map<MyMapKey, Integer>} map) {
  *     assert map.get(new MyMapKeyImpl("foo", MyEnum.BAR)) == 2;
  *   }
  * }


### PR DESCRIPTION
Favor @literal javadoc tags over XML escape characters. Indent lines
with a @literal tag by one less space so that the HTML output is
aligned nicely.