### PR TITLE
Add @SuppressWarnings("uncheced") for every generate component

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/ComponentGenerator.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ComponentGenerator.java
@@ -211,6 +211,7 @@ final class ComponentGenerator extends SourceFileGenerator<BindingGraph> {
     JavaWriter writer = JavaWriter.inPackage(componentName.packageName());
 
     ClassWriter componentWriter = writer.addClass(componentName.simpleName());
+    componentWriter.annotate(SuppressWarnings.class).setValue("unchecked");
     componentWriter.annotate(Generated.class).setValue(ComponentProcessor.class.getCanonicalName());
     componentWriter.addModifiers(PUBLIC, FINAL);
     checkState(componentDefinitionType.getModifiers().contains(ABSTRACT));


### PR DESCRIPTION
Too many build warning came out while building generate classed with dagger2, all related to generics detected.