### PR TITLE
Remove ref to non-existent @Response annotation.

### DIFF
--- a/producers/src/main/java/dagger/producers/ProductionComponent.java
+++ b/producers/src/main/java/dagger/producers/ProductionComponent.java
@@ -45,10 +45,9 @@ import static java.lang.annotation.ElementType.TYPE;
  * Production methods have no arguments and return either a {@link ListenableFuture} or
  * {@link Producer} of a type that is {@link Inject injected}, {@link Provides provided}, or
  * {@link Produces produced}. Each may have a {@link Qualifier} annotation as well. The following
- * are all valid production method declarations: <pre><code>
+ * are valid production method declarations: <pre><code>
  *   ListenableFuture<SomeType> getSomeType();
  *   {@literal Producer<Set<SomeType>>} getSomeTypes();
- *   {@literal @Response ListenableFuture<Html>} getResponse();
  * </code></pre>
  *
  * <h2>Exceptions</h2>


### PR DESCRIPTION
Remove ref to non-existent @Response annotation in
ProductionComponent. This was a source of confusion in trying to read
the JavaDoc. I believe it is a vestige of a prior design, but never
implemented, but I defer to the reviewers.