### PR TITLE
Refactor the `InjectBindingRegistry` to perform validation 

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/BindingGraph.java
+++ b/compiler/src/main/java/dagger/internal/codegen/BindingGraph.java
@@ -394,10 +394,12 @@ abstract class BindingGraph {
 
           case MEMBERS_INJECTION:
             // no explicit deps for members injection, so just look it up
-            return ResolvedBindings.forMembersInjectionBinding(
-                bindingKey,
-                componentDescriptor,
-                injectBindingRegistry.getOrFindMembersInjectionBinding(bindingKey.key()));
+            Optional<MembersInjectionBinding> binding =
+                injectBindingRegistry.getOrFindMembersInjectionBinding(bindingKey.key());
+            return binding.isPresent()
+                ? ResolvedBindings.forMembersInjectionBinding(
+                    bindingKey, componentDescriptor, binding.get())
+                : ResolvedBindings.noBindings(bindingKey, componentDescriptor);
           default:
             throw new AssertionError();
         }

--- a/compiler/src/main/java/dagger/internal/codegen/BindingGraphValidator.java
+++ b/compiler/src/main/java/dagger/internal/codegen/BindingGraphValidator.java
@@ -865,10 +865,13 @@ public class BindingGraphValidator {
               ? REQUIRES_AT_INJECT_CONSTRUCTOR_OR_PROVIDER_FORMAT
               : REQUIRES_AT_INJECT_CONSTRUCTOR_OR_PROVIDER_OR_PRODUCER_FORMAT;
       errorMessage.append(String.format(requiresErrorMessageFormat, keyFormatter.format(key)));
-      if (key.isValidMembersInjectionKey()
-          && !injectBindingRegistry.getOrFindMembersInjectionBinding(key).injectionSites()
-              .isEmpty()) {
-        errorMessage.append(" ").append(ErrorMessages.MEMBERS_INJECTION_DOES_NOT_IMPLY_PROVISION);
+      if (key.isValidMembersInjectionKey()) {
+        Optional<MembersInjectionBinding> membersInjectionBinding =
+            injectBindingRegistry.getOrFindMembersInjectionBinding(key);
+        if (membersInjectionBinding.isPresent()
+            && !membersInjectionBinding.get().injectionSites().isEmpty()) {
+          errorMessage.append(" ").append(ErrorMessages.MEMBERS_INJECTION_DOES_NOT_IMPLY_PROVISION);
+        }
       }
       ImmutableList<String> printableDependencyPath =
           FluentIterable.from(path)

--- a/compiler/src/main/java/dagger/internal/codegen/MembersInjectedTypeValidator.java
+++ b/compiler/src/main/java/dagger/internal/codegen/MembersInjectedTypeValidator.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2015 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dagger.internal.codegen;
+
+import com.google.auto.common.MoreElements;
+import com.google.auto.common.MoreTypes;
+import javax.inject.Inject;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+
+/** Validates the {@code @Inject} fields and methods in a class and its superclasses. */
+final class MembersInjectedTypeValidator {
+  private final InjectFieldValidator fieldValidator;
+  private final InjectMethodValidator methodValidator;
+
+  MembersInjectedTypeValidator(
+      InjectFieldValidator fieldValidator, InjectMethodValidator methodValidator) {
+    this.fieldValidator = fieldValidator;
+    this.methodValidator = methodValidator;
+  }
+
+  ValidationReport<TypeElement> validate(TypeElement typeElement) {
+    // TODO(beder): This element might not be currently compiled, so this error message could be
+    // left in limbo. Find an appropriate way to display the error message in that case.
+    ValidationReport.Builder<TypeElement> builder = ValidationReport.about(typeElement);
+    for (VariableElement element : ElementFilter.fieldsIn(typeElement.getEnclosedElements())) {
+      if (MoreElements.isAnnotationPresent(element, Inject.class)) {
+        ValidationReport<VariableElement> report = fieldValidator.validate(element);
+        if (!report.isClean()) {
+          builder.addSubreport(report);
+        }
+      }
+    }
+    for (ExecutableElement element : ElementFilter.methodsIn(typeElement.getEnclosedElements())) {
+      if (MoreElements.isAnnotationPresent(element, Inject.class)) {
+        ValidationReport<ExecutableElement> report = methodValidator.validate(element);
+        if (!report.isClean()) {
+          builder.addSubreport(report);
+        }
+      }
+    }
+    TypeMirror superclass = typeElement.getSuperclass();
+    if (!superclass.getKind().equals(TypeKind.NONE)) {
+      ValidationReport<TypeElement> report = validate(MoreTypes.asTypeElement(superclass));
+      if (!report.isClean()) {
+        builder.addSubreport(report);
+      }
+    }
+    return builder.build();
+  }
+}


### PR DESCRIPTION
Refactor the `InjectBindingRegistry` to perform validation on the `@Inject` constructors and members injections, so that they get validated when added during construction of the `BindingGraph`.

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=111129042