### PR TITLE
Fixes DoubleCheck typo

### DIFF
--- a/core/src/main/java/dagger/internal/DoubleCheck.java
+++ b/core/src/main/java/dagger/internal/DoubleCheck.java
@@ -21,7 +21,7 @@ import javax.inject.Provider;
 import static dagger.internal.Preconditions.checkNotNull;
 
 /**
- * A {@link Lazy} and {@link Provider} implementation that memoizes the value returned from a
+ * A {@link Lazy} and {@link Provider} implementation that memorizes the value returned from a
  * delegate using the double-check idiom described in Item 71 of <i>Effective Java 2</i>.
  */
 public final class DoubleCheck<T> implements Provider<T>, Lazy<T> {


### PR DESCRIPTION
Fixes a small typo for `DoubleCheck's` javadoc: "memoizes" => "memorizes".