### PR TITLE
Updates README for v2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Square, Google, and other contributors.
 
 ## Status
 
-  - ***Release Version:* 2.2**
-  - ***Snapshot Version:* 2.3-SNAPSHOT**
+  - ***Release Version:* 2.5**
+  - ***Snapshot Version:* 2.5-SNAPSHOT**
 
 Dagger is currently in active development, primarily internally at Google,
 with regular pushes to the open-source community. Snapshot releases are
 auto-deployed to sonatype's central maven repository on a clean build with
-the version `2.3-SNAPSHOT`.
+the version `2.5-SNAPSHOT`.
 
 ## Documentation
 
@@ -39,9 +39,9 @@ mailing list.
 
 ## Installation
 
-You will need to include the `dagger-2.1.jar` in your application's runtime.
+You will need to include the `dagger-2.5.jar` in your application's runtime.
 In order to activate code generation and generate implementations to manage
-your graph you will need to include `dagger-compiler-2.1.jar` in your build
+your graph you will need to include `dagger-compiler-2.5.jar` in your build
 at compile time.
 
 In a Maven project, include the `dagger` artifact in the dependencies section
@@ -53,12 +53,12 @@ of your `pom.xml` and the `dagger-compiler` artifact as either an `optional` or
   <dependency>
     <groupId>com.google.dagger</groupId>
     <artifactId>dagger</artifactId>
-    <version>2.2</version>
+    <version>2.5</version>
   </dependency>
   <dependency>
     <groupId>com.google.dagger</groupId>
     <artifactId>dagger-compiler</artifactId>
-    <version>2.2</version>
+    <version>2.5</version>
     <optional>true</optional>
   </dependency>
 </dependencies>
@@ -72,7 +72,7 @@ parallelizable execution graphs), then add this to your maven configuration:
   <dependency>
     <groupId>com.google.dagger</groupId>
     <artifactId>dagger-producers</artifactId>
-    <version>2.2</version>
+    <version>2.5</version>
   </dependency>
 </dependencies>
 ```


### PR DESCRIPTION
It looks like the latest version has been on maven central for a few days, and the README wasn't updated with the latest version information.

It doesn't look like 2.5-SNAPSHOT was updated to 2.6-SNAPSHOT yet, so I left the current release and snapshot versions that same (2.5, 2.5-SNAPSHOT).