### PR TITLE
[Feature Proposal] Adding support for @Internal annotation.

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/ErrorMessages.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ErrorMessages.java
@@ -198,6 +198,9 @@ final class ErrorMessages {
   static final String BINDING_METHOD_WITH_SAME_NAME =
       "Cannot have more than one @%s method with the same name in a single module";
 
+  static final String EXPOSING_INTERNAL_DEPENDNECY =
+      "%s is marked as @Internal and should not be exposed on a component.";
+
   static final String INCOMPATIBLE_MODULE_METHODS =
       "A @%1$s may not contain both non-static @%2$s methods and abstract @Binds or @Multibinds "
           + "declarations";

--- a/compiler/src/main/java/dagger/internal/codegen/FactoryGenerator.java
+++ b/compiler/src/main/java/dagger/internal/codegen/FactoryGenerator.java
@@ -28,6 +28,7 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
+import dagger.Internal;
 import dagger.internal.Factory;
 import dagger.internal.MembersInjectors;
 import dagger.internal.Preconditions;
@@ -174,6 +175,9 @@ final class FactoryGenerator extends SourceFileGenerator<ProvisionBinding> {
         if (binding.factoryCreationStrategy() != ENUM_INSTANCE
             || binding.bindingKind() == INJECTION) {
           createMethodBuilder.addTypeVariables(typeParameters);
+        }
+        if (binding.internal()) {
+          createMethodBuilder.addAnnotation(Internal.class);
         }
         List<ParameterSpec> params =
             constructorBuilder.isPresent()

--- a/core/src/main/java/dagger/Internal.java
+++ b/core/src/main/java/dagger/Internal.java
@@ -1,0 +1,9 @@
+package dagger;
+
+import java.lang.annotation.*;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target(METHOD) @Retention(RUNTIME)
+public @interface Internal { }


### PR DESCRIPTION
This PR adds a new `@Internal` annotation that will prevent `@Provides` methods that are marked with `@Internal` from being exposed via component getters.

#### Why This Might Be Useful
Often times there are provides methods in a module to build other types of objects, but these are things you don’t want to provide in the public component API. 

For example - say you have an OkHttpClient, a GSON instance, and a higher level abstraction around the two that you want everyone in the application to use. You can mark the OkHttpClient and GSON providers with `@Internal `to ensure they never accidentally end up in the component public API.

This might seem like a weird thing to guard against, but in a larger codebase with many developers - it’s very easy to expose something that’s not meant to be exposed on a component.

In addition, it’s also possible if you have child scopes define a parent dependency interface (which lists all of the dependencies they need from a parent scope). This is very convenient (since Dagger can implicitly implement the interface), but can also lead to things being exposed on that component that shouldn’t be.

(Alternatively, this can be solved by just not providing these internal dependencies via `@Provides` and instead keeping them as fields in the module. However, this tends to lead to larger modules.)

#### Open Questions
* Is this something that makes sense to do?
* Should this also happen with `inject` methods?  (So having an `@Inject` field for a type that is internal fails the build.)
* I created a new annotation for this, but would it make more sense to add this to @Provides (it would have to be a new field I think - it’s not really appropriate for the existing `Type` enum)? 
* Is the validation happening in the right place?
* What element should the error point to? The component or the provider?

#### TODO (if this is something that would be useful)
* [ ] Documentation
* [ ] Update relevant tests
* [ ] Add support with `@Producer`?

Sorry for leaving this in an unfinished state - I wanted to gauge if it seems like it’s worth having. If so, I’ll follow up with the todos.
