### PR TITLE
Fix README license based on http://google.github.io/dagger/users-guide

### DIFF
--- a/users-guide.md
+++ b/users-guide.md
@@ -511,8 +511,7 @@ compiler plugin:
 ## License
 
 ```
-Copyright 2014 Google, Inc.
-Copyright 2012 Square, Inc.
+Copyright 2012 The Dagger Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
-------------
Created by MOE: https://github.com/google/moe

GITHUB_PULL_REQUEST_URL=http://github.com/google/dagger/pull/438
ORIGINAL_AUTHO

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=131173405