### PR TITLE
No error when a component dependency extends multiple interfaces

### DIFF
--- a/compiler/src/main/java/dagger/internal/codegen/ComponentDescriptor.java
+++ b/compiler/src/main/java/dagger/internal/codegen/ComponentDescriptor.java
@@ -51,6 +51,7 @@ import dagger.producers.ProductionComponent;
 import dagger.producers.ProductionSubcomponent;
 import java.lang.annotation.Annotation;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +64,6 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
@@ -451,10 +451,15 @@ abstract class ComponentDescriptor {
           ImmutableMap.builder();
 
       for (TypeElement componentDependency : componentDependencyTypes) {
-        List<ExecutableElement> dependencyMethods =
-            ElementFilter.methodsIn(elements.getAllMembers(componentDependency));
+        Set<ExecutableElement> dependencyMethods =
+            MoreElements.getLocalAndInheritedMethods(componentDependency, elements);
+        Set<MethodSignatureWithReturnType> methodSignatures = new HashSet<>();
         for (ExecutableElement dependencyMethod : dependencyMethods) {
-          if (isComponentContributionMethod(elements, dependencyMethod)) {
+          MethodSignatureWithReturnType methodSignature =
+              MethodSignatureWithReturnType.fromExecutableElement(dependencyMethod);
+          if (!methodSignatures.contains(methodSignature)
+              && isComponentContributionMethod(elements, dependencyMethod)) {
+            methodSignatures.add(methodSignature);
             dependencyMethodIndex.put(dependencyMethod, componentDependency);
           }
         }

--- a/compiler/src/main/java/dagger/internal/codegen/MethodSignature.java
+++ b/compiler/src/main/java/dagger/internal/codegen/MethodSignature.java
@@ -1,13 +1,16 @@
 package dagger.internal.codegen;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.auto.common.MoreTypes;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Equivalence;
 import com.google.common.collect.ImmutableList;
+
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeMirror;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 @AutoValue
 abstract class MethodSignature {
@@ -29,5 +32,21 @@ abstract class MethodSignature {
         methodName,
         parameters.build(),
         thrownTypes.build());
+  }
+
+  static MethodSignature fromExecutableElement(ExecutableElement executableElement) {
+    checkNotNull(executableElement);
+    ImmutableList.Builder<Equivalence.Wrapper<TypeMirror>> parameters = ImmutableList.builder();
+    ImmutableList.Builder<Equivalence.Wrapper<TypeMirror>> thrownTypes = ImmutableList.builder();
+    for (TypeParameterElement parameter : executableElement.getTypeParameters()) {
+      parameters.add(MoreTypes.equivalence().wrap(parameter.asType()));
+    }
+    for (TypeMirror thrownType : executableElement.getThrownTypes()) {
+      thrownTypes.add(MoreTypes.equivalence().wrap(thrownType));
+    }
+    return new AutoValue_MethodSignature(
+            executableElement.getSimpleName().toString(),
+            parameters.build(),
+            thrownTypes.build());
   }
 }

--- a/compiler/src/main/java/dagger/internal/codegen/MethodSignatureWithReturnType.java
+++ b/compiler/src/main/java/dagger/internal/codegen/MethodSignatureWithReturnType.java
@@ -1,0 +1,26 @@
+package dagger.internal.codegen;
+
+import com.google.auto.common.MoreTypes;
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Equivalence;
+
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.type.TypeMirror;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static dagger.internal.codegen.InjectionAnnotations.getQualifier;
+import static dagger.internal.codegen.MoreAnnotationMirrors.wrapOptionalInEquivalence;
+
+/**
+ * Unlike {@link MethodSignature}, this class also contains the return type.
+ */
+@AutoValue
+abstract class MethodSignatureWithReturnType {
+  abstract MethodSignature methodSignature();
+  abstract Equivalence.Wrapper<TypeMirror> returnType();
+  static MethodSignatureWithReturnType fromExecutableElement(ExecutableElement executableElement) {
+    checkNotNull(executableElement);
+    return new AutoValue_MethodSignatureWithReturnType(MethodSignature.fromExecutableElement(executableElement),
+        MoreTypes.equivalence().wrap(executableElement.getReturnType()));
+    }
+}


### PR DESCRIPTION
- Update ComponentDescriptor so that it doesn’t create two dependentMethods for method M just because the component’s dependency interface extends from two interfaces that both declare method M. This addresses the bug documented in https://github.com/williamlian/daggerbug. See Main.java to best understand the issue.
- Created `MethodSignatureWithReturnType`. This is used by `ComponentDescriptor` to help find duplicate methods+qualifiers.
- Update BindingGraph so it doesn't perform a redundant check. (just something off-tangent that came up in the review)
- Adds new unit test to enforce the new behavior. Lots of additional unit tests to ensure I'm not causing a regression.

I messed up the rebase of https://github.com/google/dagger/pull/429/commits. So I've created a separate pull request.
