### PR TITLE
A few small modifications to the mvn-deploy script:

### DIFF
--- a/util/mvn-deploy.sh
+++ b/util/mvn-deploy.sh
@@ -34,12 +34,12 @@ fi
 
 mvn "$@" -P '!examples' -P sonatype-oss-release \
     -Dgpg.skip=false -Dgpg.keyname=${key} \
-    clean site:jar deploy
+    clean clean site:jar deploy
 
 # Publish javadocs to gh-pages
 mvn javadoc:aggregate -P!examples -DexcludePackageNames=*.internal
 git clone --quiet --branch gh-pages \
-    https://git@github.com/google/dagger gh-pages > /dev/null
+    https://github.com/google/dagger gh-pages > /dev/null
 cd gh-pages
 cp -r ../target/site/apidocs api/$version_name
 git add api/$version_name


### PR DESCRIPTION
  - When running sonatype-oss-release, compile the code before running site:jar and deploy. For some reason, the new android artifact wasn't finding the necessary android support libraries dependencies in android/target/unpackaged_libs, unless `compile` was run.
  - Clone under the regular https URL, not the git@ user

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=139921707