### PR TITLE
Simplify dagger-gwt artifact

### DIFF
--- a/gwt/pom.xml
+++ b/gwt/pom.xml
@@ -40,39 +40,10 @@
       <classifier>sources</classifier>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <classifier>sources</classifier>
+    </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <!--
-        Include JSR 330 sources in dagger-gwt to avoid implicit
-        compilation warnings in downstream projects.
-      -->
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.10</version>
-        <executions>
-          <execution>
-            <id>unpack-jsr330-sources</id>
-            <goals>
-              <goal>unpack</goal>
-            </goals>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>javax.inject</groupId>
-                  <artifactId>javax.inject</artifactId>
-                  <version>${javax.inject.version}</version>
-                  <type>java-source</type>
-                  <overWrite>true</overWrite>
-                  <outputDirectory>${project.build.outputDirectory}/dagger/super/</outputDirectory>
-                </artifactItem>
-              </artifactItems>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/gwt/src/main/resources/javax/inject/Inject.gwt.xml
+++ b/gwt/src/main/resources/javax/inject/Inject.gwt.xml
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2015 Google, Inc.
+ Copyright (C) 2017 Google, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -14,7 +14,5 @@
   limitations under the License.
 -->
 <module>
-  <inherits name="javax.inject.Inject" />
-
   <source path=""/>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,12 @@
       </dependency>
       <dependency>
         <groupId>javax.inject</groupId>
+        <artifactId>javax.inject</artifactId>
+        <classifier>sources</classifier>
+        <version>1</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.inject</groupId>
         <artifactId>javax.inject-tck</artifactId>
         <version>1</version>
       </dependency>


### PR DESCRIPTION
Make it depend on javax.inject sources rather than bundling
them. This was previously done because of sources timestamps
being later than classes timestamps in javax.inject JARs, and
bad JavaC defaults in Gradle (not passing `-sourcepath`, leading
to javax.inject being implicitly recompiled). This has been
fixed in Gradle 2.4 nearly 2 years ago, so we can now just
reference the javax.inject sources JAR as a dependency.

/cc @jnehlmeier @ronshapiro 