### PR TITLE
Make nav bar of Github Pages site scrollable

### DIFF
--- a/static/main.scss
+++ b/static/main.scss
@@ -59,6 +59,7 @@ pre {
 
 nav {
   padding: 0 16px;
+  overflow-y: scroll;
 }
 
 #fork-button {


### PR DESCRIPTION
Make nav bar scrollable by adding CSS property `overflow-y: scroll;`

Proof:

Chrome | Safari | Firefox
---|---|---
![chrome](https://cloud.githubusercontent.com/assets/1626673/23297022/0ce13bda-fa78-11e6-9c64-973957b006a1.png) | ![safari](https://cloud.githubusercontent.com/assets/1626673/23297023/0ce27202-fa78-11e6-93ee-97e585f023d1.png) | ![firefox](https://cloud.githubusercontent.com/assets/1626673/23297024/0ce2c176-fa78-11e6-9e17-f7d13fc6d350.png)

Haven't been able to test on other browsers or OSes

Fixes #583 