### PR TITLE
Add dagger.android dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ dependencies {
 // Add Dagger dependencies
 dependencies {
   compile 'com.google.dagger:dagger:2.x'
+  compile 'com.google.dagger:dagger-android:2.x' // usefull helpers for android objects Injection
   annotationProcessor 'com.google.dagger:dagger-compiler:2.x'
 }
 ```


### PR DESCRIPTION
I suggest to add dagger.android dependency to readme. I was following this https://google.github.io/dagger/android.html guide and it was not straid forward for me how do add dependency for example for AndroidInjector