### PR TITLE
DOC: update links in multibindings.md

### DIFF
--- a/multibindings.md
+++ b/multibindings.md
@@ -451,9 +451,9 @@ class ChildModule {
 
 [`@AutoAnnotation`]: https://github.com/google/auto/blob/master/value/src/main/java/com/google/auto/value/AutoAnnotation.java
 [`dagger.mapkeys`]: https://google.github.io/dagger/api/latest/dagger/multibindings/package-summary.html
-[`@ElementsIntoSet`]: http://google.github.io/dagger/api/latest/dagger/multibindings/ElementsIntoSet.html
-[`@IntoMap`]: http://google.github.io/dagger/api/latest/dagger/multibindings/IntoMap.html
-[`@IntoSet`]: http://google.github.io/dagger/api/latest/dagger/multibindings/IntoSet.html
-[`@MapKey`]: http://google.github.io/dagger/api/latest/dagger/MapKey.html
-[`@Multibinds`]: http://google.github.io/dagger/api/latest/dagger/multibindings/Multibinds.html
+[`@ElementsIntoSet`]: https://google.github.io/dagger/api/latest/dagger/multibindings/ElementsIntoSet.html
+[`@IntoMap`]: https://google.github.io/dagger/api/latest/dagger/multibindings/IntoMap.html
+[`@IntoSet`]: https://google.github.io/dagger/api/latest/dagger/multibindings/IntoSet.html
+[`@MapKey`]: https://google.github.io/dagger/api/latest/dagger/MapKey.html
+[`@Multibinds`]: https://google.github.io/dagger/api/latest/dagger/multibindings/Multibinds.html
 

--- a/multibindings.md
+++ b/multibindings.md
@@ -112,7 +112,7 @@ value each time you query the map.
 ### Simple map keys
 
 For maps with keys that are strings, `Class<?>`, or boxed primitives, use one of
-the standard annotations in [`dagger.mapkeys`]:
+the standard annotations in [`dagger.multibindings`]:
 
 ```java
 @Module
@@ -450,7 +450,7 @@ class ChildModule {
 <!-- References -->
 
 [`@AutoAnnotation`]: https://github.com/google/auto/blob/master/value/src/main/java/com/google/auto/value/AutoAnnotation.java
-[`dagger.mapkeys`]: http://google.github.io/dagger/api/latest/dagger/mapkeys/package-summary.html
+[`dagger.mapkeys`]: https://google.github.io/dagger/api/latest/dagger/multibindings/package-summary.html
 [`@ElementsIntoSet`]: http://google.github.io/dagger/api/latest/dagger/multibindings/ElementsIntoSet.html
 [`@IntoMap`]: http://google.github.io/dagger/api/latest/dagger/multibindings/IntoMap.html
 [`@IntoSet`]: http://google.github.io/dagger/api/latest/dagger/multibindings/IntoSet.html


### PR DESCRIPTION
`dagger.mapkeys` package seems to have been renamed to `dagger.multibindings` for some time now so I updated the corresponding link.  
Also updated all github links' scheme to https.