### PR TITLE
Use install:install-file to publish to a local Maven repository

### DIFF
--- a/util/publish-local-snapshot.sh
+++ b/util/publish-local-snapshot.sh
@@ -5,9 +5,7 @@ set -eu
 echo -e "Publishing maven snapshot locally...\n"
 
 bash $(dirname $0)/execute-deploy.sh \
-  "deploy:deploy-file" \
-  "LOCAL-SNAPSHOT" \
-  "local-repo" \
-  "file://$HOME/.m2/repository"
+  "install:install-file" \
+  "LOCAL-SNAPSHOT"
 
 echo -e "Published local snapshot"


### PR DESCRIPTION
This respects the localRepository path configured in
settings.xml rather than hard-coding to ~/.m2/repository.