### PR TITLE
Fix broken links in docs

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,31 +26,31 @@
           <a href="{{ site.url }}/"></a>
         </paper-item>
         <paper-item label="User's Guide">
-          <a href="{{ site.url }}/dagger/users-guide.html"></a>
+          <a href="{{ site.url }}/users-guide.html"></a>
         </paper-item>
         <paper-item label="Migrating from Dagger 1">
-          <a href="{{ site.url }}/dagger/dagger-1-migration.html"></a>
+          <a href="{{ site.url }}/dagger-1-migration.html"></a>
         </paper-item>
         <paper-item label="Android">
-          <a href="{{ site.url }}/dagger/android.html"></a>
+          <a href="{{ site.url }}/android.html"></a>
         </paper-item>
         <paper-item label="Multibinding Sets and Maps">
-          <a href="{{ site.url }}/dagger/multibindings.html"></a>
+          <a href="{{ site.url }}/multibindings.html"></a>
         </paper-item>
         <paper-item label="Subcomponents">
-          <a href="{{ site.url }}/dagger/subcomponents.html"></a>
+          <a href="{{ site.url }}/subcomponents.html"></a>
         </paper-item>
         <paper-item label="Producers">
-          <a href="{{ site.url }}/dagger/producers.html"></a>
+          <a href="{{ site.url }}/producers.html"></a>
         </paper-item>
         <paper-item label="Testing">
-          <a href="{{ site.url }}/dagger/testing.html"></a>
+          <a href="{{ site.url }}/testing.html"></a>
         </paper-item>
         <paper-item label="Resources">
-          <a href="{{ site.url }}/dagger/resources.html"></a>
+          <a href="{{ site.url }}/resources.html"></a>
         </paper-item>
         <paper-item label="FAQ">
-          <a href="{{ site.url }}/dagger/faq.html"></a>
+          <a href="{{ site.url }}/faq.html"></a>
         </paper-item>
         <h4>Project Pages</h4>
         <paper-item label="GitHub" icon="open-in-browser">
@@ -63,10 +63,10 @@
           <a href="{{ site.url }}/api/latest/" target="_blank"></a>
         </paper-item>
         <paper-item label="Releases &amp; Versioning">
-          <a href="{{ site.url }}/dagger/releases-and-versioning.html"></a>
+          <a href="{{ site.url }}/releases-and-versioning.html"></a>
         </paper-item>
         <paper-item label="Release Steps">
-          <a href="{{ site.url }}/dagger/release.html"></a>
+          <a href="{{ site.url }}/release.html"></a>
         </paper-item>
         <h4>Resources</h4>
         <paper-item label="Stack Overflow" icon="open-in-browser">


### PR DESCRIPTION
Recent commit 06a063d broke a load of links in the docs. This fixes them.