### PR TITLE
Add espresso example to demo swapping dependenices for espresso tests

### DIFF
--- a/java/dagger/example/android/espresso/main/AndroidManifest.xml
+++ b/java/dagger/example/android/espresso/main/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.example.android.espresso">
+
+  <uses-sdk
+    android:minSdkVersion="14"
+    android:targetSdkVersion="24"/>
+
+  <application
+    android:label="Espresso Dagger"
+    android:name="dagger.example.android.espresso.main.MainApplication"
+    android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+    <activity android:name="dagger.example.android.espresso.main.MainActivity">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+  </application>
+
+</manifest>

--- a/java/dagger/example/android/espresso/main/ApiClient.java
+++ b/java/dagger/example/android/espresso/main/ApiClient.java
@@ -1,0 +1,5 @@
+package dagger.example.android.espresso.main;
+
+public interface ApiClient {
+  String getRemoteResource();
+}

--- a/java/dagger/example/android/espresso/main/BUILD
+++ b/java/dagger/example/android/espresso/main/BUILD
@@ -1,0 +1,24 @@
+package(default_visibility = ["//:src"])
+
+android_library(
+    name = "main_lib",
+    srcs = glob(["*.java"]),
+    manifest = "AndroidManifest.xml",
+    resource_files = glob(["res/**"]),
+    deps = [
+        "//:android",
+        "//:android-support",
+        "//:dagger_with_compiler",
+        "@androidsdk//com.android.support:appcompat-v7-25.0.0",
+        "@androidsdk//com.android.support:support-annotations-25.0.0",
+        "@androidsdk//com.android.support:support-v4-25.0.0",
+    ],
+)
+
+android_binary(
+    name = "espresso_main",
+    manifest = "AndroidManifest.xml",
+    deps = [
+        "//java/dagger/example/android/espresso/main:main_lib"
+    ]
+)

--- a/java/dagger/example/android/espresso/main/MainActivity.java
+++ b/java/dagger/example/android/espresso/main/MainActivity.java
@@ -1,0 +1,50 @@
+package dagger.example.android.espresso.main;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.TextView;
+import dagger.Binds;
+import dagger.android.ActivityKey;
+import dagger.android.AndroidInjector;
+import dagger.android.support.DaggerAppCompatActivity;
+import dagger.multibindings.IntoMap;
+import javax.inject.Inject;
+
+public class MainActivity extends DaggerAppCompatActivity {
+
+  private static final String TAG = MainActivity.class.getSimpleName();
+
+  @dagger.Subcomponent
+  public interface Component extends AndroidInjector<MainActivity> {
+
+    @dagger.Subcomponent.Builder
+    abstract class Builder extends AndroidInjector.Builder<MainActivity> {}
+  }
+
+  @dagger.Module(subcomponents = Component.class)
+  public abstract class Module {
+
+    @Binds
+    @IntoMap
+    @ActivityKey(MainActivity.class)
+    abstract AndroidInjector.Factory<? extends Activity> bind(
+        MainActivity.Component.Builder builder);
+  }
+
+  @Inject
+  ApiClient apiClient;
+
+  @Inject
+  void logInjection() {
+    Log.i(TAG, "Injecting " + MainActivity.class.getSimpleName());
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
+    TextView textView = (TextView) findViewById(R.id.textView);
+    textView.setText(apiClient.getRemoteResource());
+  }
+}

--- a/java/dagger/example/android/espresso/main/MainApplication.java
+++ b/java/dagger/example/android/espresso/main/MainApplication.java
@@ -1,0 +1,33 @@
+package dagger.example.android.espresso.main;
+
+import android.util.Log;
+import dagger.android.AndroidInjector;
+import dagger.android.DaggerApplication;
+import dagger.android.support.AndroidSupportInjectionModule;
+import javax.inject.Inject;
+
+public class MainApplication extends DaggerApplication {
+
+  private static final String TAG = MainApplication.class.getSimpleName();
+
+  @dagger.Component(
+      modules = {AndroidSupportInjectionModule.class, MainActivity.Module.class, NetworkingModule.class}
+  )
+  /* @ApplicationScoped and/or @Singleton */
+  public interface Component extends AndroidInjector<MainApplication> {
+
+    @dagger.Component.Builder
+    abstract class Builder extends AndroidInjector.Builder<MainApplication> {
+    }
+  }
+
+  @Inject
+  void logInjection() {
+    Log.i(TAG, "Injecting " + MainApplication.class.getSimpleName());
+  }
+
+  @Override
+  protected AndroidInjector<MainApplication> applicationInjector() {
+    return DaggerMainApplication_Component.builder().create(this);
+  }
+}

--- a/java/dagger/example/android/espresso/main/NetworkingModule.java
+++ b/java/dagger/example/android/espresso/main/NetworkingModule.java
@@ -1,0 +1,16 @@
+package dagger.example.android.espresso.main;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+public class NetworkingModule {
+  @Provides ApiClient provideApiClient() {
+    return new ApiClient() {
+      @Override
+      public String getRemoteResource() {
+        return "remote resource";
+      }
+    };
+  }
+}

--- a/java/dagger/example/android/espresso/main/res/layout/activity_main.xml
+++ b/java/dagger/example/android/espresso/main/res/layout/activity_main.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+  android:id="@+id/textView"
+  android:textColor="@android:color/primary_text_light"
+  style="@style/TextAppearance.AppCompat.Display4"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
+</TextView>

--- a/java/dagger/example/android/espresso/package-info.java
+++ b/java/dagger/example/android/espresso/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2017 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * An application (with a build variant) that demonstrates how to swap out dependencies for testing
+ * purposes. The main package holds the code for the stubbable application and the stubbed package holds
+ * the code for the stubbed build variant of the application.
+ *
+ * This example follows the testing guidelines outlined in <a href="https://google.github.io/dagger/testing.html">
+ *   the Testing section of the documentation</a>.
+ */
+package dagger.example.android.espresso;
+

--- a/java/dagger/example/android/espresso/stubbed/AndroidManifest.xml
+++ b/java/dagger/example/android/espresso/stubbed/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.example.android.espresso.stubbed">
+
+  <uses-sdk
+    android:minSdkVersion="14"
+    android:targetSdkVersion="24" />
+  <application
+    android:name="dagger.example.android.espresso.stubbed.StubbedApplication"
+    android:label="Stubbed Espresso Dagger"
+    android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+    <activity android:name="dagger.example.android.espresso.main.MainActivity">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+  </application>
+</manifest>

--- a/java/dagger/example/android/espresso/stubbed/BUILD
+++ b/java/dagger/example/android/espresso/stubbed/BUILD
@@ -1,0 +1,25 @@
+package(default_visibility = ["//:src"])
+
+android_library(
+    name = "stubbed_lib",
+    srcs = glob(["*.java"]),
+    manifest = 'AndroidManifest.xml',
+    deps = [
+        "//:android",
+        "//:android-support",
+        "//:dagger_with_compiler",
+        "@androidsdk//com.android.support:appcompat-v7-25.0.0",
+        "@androidsdk//com.android.support:support-annotations-25.0.0",
+        "@androidsdk//com.android.support:support-v4-25.0.0",
+        "//java/dagger/example/android/espresso/main:main_lib"
+    ],
+)
+
+android_binary(
+    name = "espresso_stubbed",    
+    manifest = 'AndroidManifest.xml',
+    manifest_merger = "android",
+    deps = [
+        "//java/dagger/example/android/espresso/stubbed:stubbed_lib",
+    ]
+)

--- a/java/dagger/example/android/espresso/stubbed/StubNetworkingModule.java
+++ b/java/dagger/example/android/espresso/stubbed/StubNetworkingModule.java
@@ -1,0 +1,18 @@
+package dagger.example.android.espresso.stubbed;
+
+import dagger.Module;
+import dagger.Provides;
+import dagger.example.android.espresso.main.ApiClient;
+
+@Module
+public class StubNetworkingModule {
+  @Provides
+  ApiClient provideApiClient() {
+    return new ApiClient() {
+      @Override
+      public String getRemoteResource() {
+        return "stub remote resource";
+      }
+    };
+  }
+}

--- a/java/dagger/example/android/espresso/stubbed/StubbedApplication.java
+++ b/java/dagger/example/android/espresso/stubbed/StubbedApplication.java
@@ -1,0 +1,20 @@
+package dagger.example.android.espresso.stubbed;
+
+import dagger.android.AndroidInjector;
+import dagger.android.support.AndroidSupportInjectionModule;
+import dagger.example.android.espresso.main.MainActivity;
+import dagger.example.android.espresso.main.MainApplication;
+
+public class StubbedApplication extends MainApplication {
+
+  @dagger.Component(modules = {AndroidSupportInjectionModule.class, MainActivity.Module.class, StubNetworkingModule.class}) interface Component extends MainApplication.Component {
+    @dagger.Component.Builder
+    abstract class Builder extends AndroidInjector.Builder<MainApplication> {
+    }
+  }
+
+  @Override
+  protected AndroidInjector<MainApplication> applicationInjector() {
+    return DaggerStubbedApplication_Component.builder().create(this);
+  }
+}

--- a/java/dagger/example/android/espresso/stubbed/tests/BUILD
+++ b/java/dagger/example/android/espresso/stubbed/tests/BUILD
@@ -1,0 +1,13 @@
+android_library(
+    name = "android_tests",
+        srcs = glob(["*Test.java"]),
+        deps = [
+            "@junit_junit//jar",
+            "@org_hamcrest_hamcrest_core//jar",
+            "@androidsdk//com.android.support.test.espresso:espresso-core-2.2.2",
+            "@androidsdk//com.android.support.test:runner-0.5",
+            "@androidsdk//com.android.support.test:rules-0.5",
+            "//java/dagger/example/android/espresso/stubbed:stubbed_lib",
+            "//java/dagger/example/android/espresso/main:main_lib" 
+        ],
+)

--- a/java/dagger/example/android/espresso/stubbed/tests/MainActivityTest.java
+++ b/java/dagger/example/android/espresso/stubbed/tests/MainActivityTest.java
@@ -1,0 +1,28 @@
+package dagger.example.android.espresso.stubbed.tests;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import dagger.example.android.espresso.main.MainActivity;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import dagger.example.android.espresso.stubbed.R;
+
+@RunWith(AndroidJUnit4.class)
+public class MainActivityTest {
+
+  @Rule
+  public ActivityTestRule<MainActivity> activityActivityTestRule = new ActivityTestRule<>(
+      MainActivity.class);
+
+  @Test
+  public void activityDisplaysRemoteResource() throws Exception {
+    onView(withId(R.id.textView))
+        .check(matches(withText("stub remote resource")));
+  }
+}


### PR DESCRIPTION
This addresses #571 and #564

Currently, it doesn't look like there's support for instrumentation tests with Bazel (see the commit message [here](https://github.com/bazelbuild/bazel/commit/4b3f9dbf813d7a5def8aac844a3a1023f04fd61a), so as @ronshapiro suggested [here](https://github.com/google/dagger/issues/571#issuecomment-301316541), I'm not going to worry about that part. Moreover, the manifest merger doesn't appear to work as advertised, so there is some duplication between main and stubbed variant manifests. 