### PR TITLE
Remove Module doc reference to ObjectGraph.

### DIFF
--- a/java/dagger/Module.java
+++ b/java/dagger/Module.java
@@ -32,7 +32,7 @@ public @interface Module {
    * Additional {@code @Module}-annotated classes from which this module is
    * composed. The de-duplicated contributions of the modules in
    * {@code includes}, and of their inclusions recursively, are all contributed
-   * to the object graph.
+   * to the component.
    */
   Class<?>[] includes() default {};
 


### PR DESCRIPTION
I'm not sure what the best wording for this is, but it seems like the copied doc from Dagger 1 may need an update here.