### PR TITLE
fix android doc bug: change override method activityInjector to fragmentInjector

### DIFF
--- a/android.md
+++ b/android.md
@@ -207,7 +207,7 @@ public class YourActivity extends Activity
   }
 
   @Override
-  public AndroidInjector<Fragment> activityInjector() {
+  public AndroidInjector<Fragment> fragmentInjector() {
     return fragmentInjector;
   }
 }


### PR DESCRIPTION
The android doc page has a slip of a pen.
```
public class YourActivity extends Activity
    implements HasFragmentInjector {
  @Inject DispatchingAndroidInjector<Fragment> fragmentInjector;

  @Override
  public void onCreate(Bundle savedInstanceState) {
    AndroidInjection.inject(this);
    super.onCreate(savedInstanceState);
    // ...
  }

  @Override
  public AndroidInjector<Fragment> activityInjector() {
    return fragmentInjector;
  }
}
```
the method name of `HasFragmentInjector ` interface is `fragmentInjector()`.