### PR TITLE
Add proguard configuration info

### DIFF
--- a/android.md
+++ b/android.md
@@ -35,7 +35,7 @@ Dagger assumes that users on Android will use ProGuard.
 
 ## Recommended ProGuard Settings
 
-If you don't use [Error Prone](https://github.com/google/error-prone), add the following to your proguard configuration:
+Dagger uses [Error Prone](https://github.com/google/error-prone) annotations. If you don't use it, you may want add the following to your proguard configuration:
 
 ```
 -dontwarn com.google.errorprone.annotations.*

--- a/android.md
+++ b/android.md
@@ -35,8 +35,11 @@ Dagger assumes that users on Android will use ProGuard.
 
 ## Recommended ProGuard Settings
 
-Watch this space for ProGuard settings that are relevant to applications using
-Dagger.
+If you don't use [Error Prone](https://github.com/google/error-prone), add the following to your proguard configuration:
+
+```
+-dontwarn com.google.errorprone.annotations.*
+```
 
 ## `dagger.android`
 


### PR DESCRIPTION
As mentioned here, this proguard configuration is needed if error-prone is not available in the classpath. 
https://github.com/google/dagger/issues/645