### PR TITLE
Upgrade build tool version to 26.0.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,8 +14,8 @@
 
 android_sdk_repository(
     name = "androidsdk",
-    api_level = 25,
-    build_tools_version = "25.0.2",
+    api_level = 26,
+    build_tools_version = "26.0.1",
 )
 
 bind(


### PR DESCRIPTION
Currently the build tool version specified in WORKSPACE is:

- api_level = 25,
- build_tools_version = "25.0.2"

To build all targets via 

  `bazel build ...`

would fail with:

>ERROR: /Users/hchar/github/dagger/javatests/dagger/android/support/functional/BUILD:20:1: no such package '@androidsdk//com.android.support': Bazel requires Android build tools version 26.0.1 or newer, 25.0.2 was provided and referenced by '//javatests/dagger/android/support/functional:functional'.
>ERROR: /Users/hchar/github/dagger/javatests/dagger/android/support/functional/BUILD:20:1: no such package '@androidsdk//com.android.support': Bazel requires Android build tools version 26.0.1 or newer, 25.0.2 was provided and referenced by '//javatests/dagger/android/support/functional:functional'.
>ERROR: Analysis of target '//javatests/dagger/android/support/functional:functional' failed; build aborted.

Upgrading to:

+    api_level = 26,
+    build_tools_version = "26.0.1"

fixes the problem.