### PR TITLE
Include DaggerDialogFragment and support counterpart

### DIFF
--- a/java/dagger/android/support/DaggerAppCompatDialogFragment.java
+++ b/java/dagger/android/support/DaggerAppCompatDialogFragment.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2017 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.android.support;
+
+import android.content.Context;
+import android.support.v4.app.Fragment;
+import android.support.v7.app.AppCompatDialogFragment;
+import dagger.android.AndroidInjector;
+import dagger.android.DispatchingAndroidInjector;
+import dagger.internal.Beta;
+import javax.inject.Inject;
+
+/**
+ * A {@link AppCompatDialogFragment} that injects its members in {@link #onAttach(Context)} and can be used to
+ * inject child {@link Fragment}s attached to it. Note that when this fragment gets reattached, its
+ * members will be injected again.
+ */
+@Beta
+public abstract class DaggerAppCompatDialogFragment extends AppCompatDialogFragment implements HasSupportFragmentInjector {
+
+  @Inject DispatchingAndroidInjector<Fragment> childFragmentInjector;
+
+  @Override
+  public void onAttach(Context context) {
+    AndroidSupportInjection.inject(this);
+    super.onAttach(context);
+  }
+
+  @Override
+  public AndroidInjector<Fragment> supportFragmentInjector() {
+    return childFragmentInjector;
+  }
+}

--- a/java/dagger/android/support/DaggerAppCompatDialogFragment.java
+++ b/java/dagger/android/support/DaggerAppCompatDialogFragment.java
@@ -25,7 +25,7 @@ import dagger.internal.Beta;
 import javax.inject.Inject;
 
 /**
- * A {@link AppCompatDialogFragment} that injects its members in {@link #onAttach(Context)} and can be used to
+ * An {@link AppCompatDialogFragment} that injects its members in {@link #onAttach(Context)} and can be used to
  * inject child {@link Fragment}s attached to it. Note that when this fragment gets reattached, its
  * members will be injected again.
  */

--- a/java/dagger/android/support/DaggerDialogFragment.java
+++ b/java/dagger/android/support/DaggerDialogFragment.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2016 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.android;
+
+import android.app.DialogFragment;
+import android.app.Fragment;
+import android.content.Context;
+import dagger.internal.Beta;
+import javax.inject.Inject;
+
+/**
+ * A {@link DialogFragment} that injects its members in {@link #onAttach(Context)} and can be used to
+ * inject child {@link Fragment}s attached to it. Note that when this fragment gets reattached, its
+ * members will be injected again.
+ */
+@Beta
+public abstract class DaggerDialogFragment extends Fragment implements HasFragmentInjector {
+
+  @Inject DispatchingAndroidInjector<Fragment> childFragmentInjector;
+
+  @Override
+  public void onAttach(Context context) {
+    AndroidInjection.inject(this);
+    super.onAttach(context);
+  }
+
+  @Override
+  public AndroidInjector<Fragment> fragmentInjector() {
+    return childFragmentInjector;
+  }
+}

--- a/java/dagger/android/support/DaggerDialogFragment.java
+++ b/java/dagger/android/support/DaggerDialogFragment.java
@@ -28,7 +28,7 @@ import javax.inject.Inject;
  * members will be injected again.
  */
 @Beta
-public abstract class DaggerDialogFragment extends Fragment implements HasFragmentInjector {
+public abstract class DaggerDialogFragment extends DialogFragment implements HasFragmentInjector {
 
   @Inject DispatchingAndroidInjector<Fragment> childFragmentInjector;
 

--- a/javatests/dagger/android/support/functional/AllControllersAreDirectChildrenOfApplication.java
+++ b/javatests/dagger/android/support/functional/AllControllersAreDirectChildrenOfApplication.java
@@ -58,6 +58,7 @@ public final class AllControllersAreDirectChildrenOfApplication extends DaggerAp
         ActivitySubcomponent.class,
         ParentFragmentSubcomponent.class,
         ChildFragmentSubcomponent.class,
+        DialogFragmentSubcomponent.class,
         ServiceSubcomponent.class,
         IntentServiceSubcomponent.class,
         BroadcastReceiverSubcomponent.class,
@@ -88,6 +89,12 @@ public final class AllControllersAreDirectChildrenOfApplication extends DaggerAp
       @FragmentKey(TestChildFragment.class)
       abstract AndroidInjector.Factory<? extends Fragment> bindFactoryForChildFragment(
           ChildFragmentSubcomponent.Builder builder);
+
+      @Binds
+      @IntoMap
+      @FragmentKey(TestDialogFragment.class)
+      abstract AndroidInjector.Factory<? extends Fragment> bindFactoryForDialogFragment(
+          DialogFragmentSubcomponent.Builder builder);
 
       @Binds
       @IntoMap
@@ -157,6 +164,21 @@ public final class AllControllersAreDirectChildrenOfApplication extends DaggerAp
 
       @Subcomponent.Builder
       abstract class Builder extends AndroidInjector.Builder<TestChildFragment> {}
+    }
+
+    @Subcomponent(modules = DialogFragmentSubcomponent.DialogFragmentModule.class)
+    interface DialogFragmentSubcomponent extends AndroidInjector<TestDialogFragment> {
+      @Module
+      abstract class DialogFragmentModule {
+        @Provides
+        @IntoSet
+        static Class<?> addToComponentHierarchy() {
+          return DialogFragmentSubcomponent.class;
+        }
+      }
+
+      @Subcomponent.Builder
+      abstract class Builder extends AndroidInjector.Builder<TestDialogFragment> {}
     }
 
     @Subcomponent(modules = ServiceModule.class)

--- a/javatests/dagger/android/support/functional/ComponentStructureFollowsControllerStructureApplication.java
+++ b/javatests/dagger/android/support/functional/ComponentStructureFollowsControllerStructureApplication.java
@@ -104,7 +104,7 @@ public final class ComponentStructureFollowsControllerStructureApplication
 
     @Subcomponent(modules = ActivitySubcomponent.ActivityModule.class)
     interface ActivitySubcomponent extends AndroidInjector<TestActivity> {
-      @Module(subcomponents = ParentFragmentSubcomponent.class)
+      @Module(subcomponents = {ParentFragmentSubcomponent.class, DialogFragmentSubcomponent.class})
       abstract class ActivityModule {
         @Provides
         @IntoSet
@@ -117,6 +117,12 @@ public final class ComponentStructureFollowsControllerStructureApplication
         @FragmentKey(TestParentFragment.class)
         abstract AndroidInjector.Factory<? extends Fragment> bindFactoryForParentFragment(
             ParentFragmentSubcomponent.Builder builder);
+
+        @Binds
+        @IntoMap
+        @FragmentKey(TestDialogFragment.class)
+        abstract AndroidInjector.Factory<? extends Fragment> bindFactoryForDialogFragment(
+            DialogFragmentSubcomponent.Builder builder);
       }
 
       @Subcomponent.Builder
@@ -156,6 +162,21 @@ public final class ComponentStructureFollowsControllerStructureApplication
           @Subcomponent.Builder
           abstract class Builder extends AndroidInjector.Builder<TestChildFragment> {}
         }
+      }
+
+      @Subcomponent(modules = DialogFragmentSubcomponent.DialogFragmentModule.class)
+      interface DialogFragmentSubcomponent extends AndroidInjector<TestDialogFragment> {
+        @Module
+        abstract class DialogFragmentModule {
+          @Provides
+          @IntoSet
+          static Class<?> addToComponentHierarchy() {
+            return DialogFragmentSubcomponent.class;
+          }
+        }
+
+        @Subcomponent.Builder
+        abstract class Builder extends AndroidInjector.Builder<TestDialogFragment> {}
       }
     }
 

--- a/javatests/dagger/android/support/functional/InjectorsTest.java
+++ b/javatests/dagger/android/support/functional/InjectorsTest.java
@@ -39,6 +39,7 @@ public class InjectorsTest {
   private TestActivity activity;
   private TestParentFragment parentFragment;
   private TestChildFragment childFragment;
+  private TestDialogFragment dialogFragment;
   private TestService service;
   private TestIntentService intentService;
   private TestBroadcastReceiver broadcastReceiver;
@@ -54,6 +55,9 @@ public class InjectorsTest {
     childFragment =
         (TestChildFragment)
             parentFragment.getChildFragmentManager().findFragmentByTag("child-fragment");
+    dialogFragment =
+        (TestParentFragment)
+            activity.getSupportFragmentManager().findFragmentByTag("dialog-fragment");
 
     service = Robolectric.buildService(TestService.class).create().get();
     intentService = Robolectric.buildIntentService(TestIntentService.class).create().get();
@@ -91,6 +95,13 @@ public class InjectorsTest {
                 .ActivitySubcomponent.ParentFragmentSubcomponent.class,
             ComponentStructureFollowsControllerStructureApplication.ApplicationComponent
                 .ActivitySubcomponent.ParentFragmentSubcomponent.ChildFragmentSubcomponent.class);
+    assertThat(dialogFragment.componentHierarchy)
+        .containsExactly(
+            ComponentStructureFollowsControllerStructureApplication.ApplicationComponent.class,
+            ComponentStructureFollowsControllerStructureApplication.ApplicationComponent
+                .ActivitySubcomponent.class,
+            ComponentStructureFollowsControllerStructureApplication.ApplicationComponent
+                .ActivitySubcomponent.DialogFragmentSubcomponent.class);
 
     assertThat(service.componentHierarchy)
         .containsExactly(
@@ -136,6 +147,11 @@ public class InjectorsTest {
             AllControllersAreDirectChildrenOfApplication.ApplicationComponent.class,
             AllControllersAreDirectChildrenOfApplication.ApplicationComponent
                 .ChildFragmentSubcomponent.class);
+    assertThat(dialogFragment.componentHierarchy)
+        .containsExactly(
+            AllControllersAreDirectChildrenOfApplication.ApplicationComponent.class,
+            AllControllersAreDirectChildrenOfApplication.ApplicationComponent
+                .DialogFragmentSubcomponent.class);
 
     assertThat(service.componentHierarchy)
         .containsExactly(
@@ -178,6 +194,10 @@ public class InjectorsTest {
         .containsExactly(
             UsesGeneratedModulesApplication.ApplicationComponent.class,
             UsesGeneratedModulesApplication.DummyChildFragmentSubcomponent.class);
+    assertThat(dialogFragment.componentHierarchy)
+        .containsExactly(
+            UsesGeneratedModulesApplication.ApplicationComponent.class,
+            UsesGeneratedModulesApplication.DummyDialogFragmentSubcomponent.class);
 
     assertThat(service.componentHierarchy)
         .containsExactly(

--- a/javatests/dagger/android/support/functional/TestActivity.java
+++ b/javatests/dagger/android/support/functional/TestActivity.java
@@ -33,7 +33,7 @@ public final class TestActivity extends DaggerAppCompatActivity {
     getSupportFragmentManager()
         .beginTransaction()
         .add(new TestParentFragment(), "parent-fragment")
-        //.add(new TestDialogFragment(), "dialog-fragment")
+        .add(new TestDialogFragment(), "dialog-fragment")
         .commit();
   }
 }

--- a/javatests/dagger/android/support/functional/TestDialogFragment.java
+++ b/javatests/dagger/android/support/functional/TestDialogFragment.java
@@ -16,10 +16,10 @@
 
 package dagger.android.support.functional;
 
-import dagger.android.DaggerDialogFragment;
+import dagger.android.support.DaggerAppCompatDialogFragment;
 import java.util.Set;
 import javax.inject.Inject;
 
-public class TestDialogFragment extends DaggerDialogFragment {
+public class TestDialogFragment extends DaggerAppCompatDialogFragment {
   @Inject Set<Class<?>> componentHierarchy;
 }

--- a/javatests/dagger/android/support/functional/TestDialogFragment.java
+++ b/javatests/dagger/android/support/functional/TestDialogFragment.java
@@ -16,24 +16,10 @@
 
 package dagger.android.support.functional;
 
-import android.os.Bundle;
-import dagger.android.support.DaggerAppCompatActivity;
+import dagger.android.DaggerDialogFragment;
 import java.util.Set;
 import javax.inject.Inject;
 
-public final class TestActivity extends DaggerAppCompatActivity {
+public class TestDialogFragment extends DaggerDialogFragment {
   @Inject Set<Class<?>> componentHierarchy;
-
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-
-    setContentView(R.layout.activity_layout);
-
-    getSupportFragmentManager()
-        .beginTransaction()
-        .add(new TestParentFragment(), "parent-fragment")
-        //.add(new TestDialogFragment(), "dialog-fragment")
-        .commit();
-  }
 }

--- a/javatests/dagger/android/support/functional/UsesGeneratedModulesApplication.java
+++ b/javatests/dagger/android/support/functional/UsesGeneratedModulesApplication.java
@@ -61,6 +61,9 @@ public final class UsesGeneratedModulesApplication extends DaggerApplication {
     @ContributesAndroidInjector(modules = DummyChildFragmentSubcomponent.AddToHierarchy.class)
     abstract TestChildFragment contributeTestChildFragmentInjector();
 
+    @ContributesAndroidInjector(modules = DummyParentFragmentSubcomponent.AddToHierarchy.class)
+    abstract TestDialogFragment contributeTestDialogFragmentInjector();
+
     @ContributesAndroidInjector(modules = DummyServiceSubcomponent.AddToHierarchy.class)
     abstract TestService contributeTestServiceInjector();
 
@@ -116,6 +119,17 @@ public final class UsesGeneratedModulesApplication extends DaggerApplication {
       @IntoSet
       static Class<?> addDummyValueToComponentHierarchy() {
         return DummyChildFragmentSubcomponent.class;
+      }
+    }
+  }
+
+  interface DummyDialogFragmentSubcomponent {
+    @Module
+    abstract class AddToHierarchy {
+      @Provides
+      @IntoSet
+      static Class<?> addDummyValueToComponentHierarchy() {
+        return DummyDialogFragmentSubcomponent.class;
       }
     }
   }


### PR DESCRIPTION
As mentioned in #728 and #847 it would make a lot of sense to include base types for injectable dialog fragments, including the application compatibility library counterpart.

These classes basically clone the `DaggerFragment` classes, I wasn't sure if they should be able to inject child classes or if they should be the "end of the line", and whether the `HasFragmentInjector` interface was enough to provide this.