### PR TITLE
Depend on support-fragment instead of support-v4

### DIFF
--- a/java/dagger/android/support/BUILD
+++ b/java/dagger/android/support/BUILD
@@ -35,7 +35,7 @@ android_library(
         "//third_party:jsr305_annotations",
         "@androidsdk//com.android.support:appcompat-v7-25.0.0",
         "@androidsdk//com.android.support:support-annotations-25.0.0",
-        "@androidsdk//com.android.support:support-v4-25.0.0",
+        "@androidsdk//com.android.support:support-fragment-25.0.0",
     ],
 )
 

--- a/java/dagger/example/android/simple/BUILD
+++ b/java/dagger/example/android/simple/BUILD
@@ -28,7 +28,6 @@ android_library(
         "//:dagger_with_compiler",
         "@androidsdk//com.android.support:appcompat-v7-25.0.0",
         "@androidsdk//com.android.support:support-annotations-25.0.0",
-        "@androidsdk//com.android.support:support-v4-25.0.0",
     ],
 )
 

--- a/javatests/dagger/android/support/BUILD
+++ b/javatests/dagger/android/support/BUILD
@@ -32,6 +32,6 @@ GenRobolectricTests(
         "//third_party:junit",
         "//third_party:truth",
         "@androidsdk//com.android.support:appcompat-v7-25.0.0",
-        "@androidsdk//com.android.support:support-v4-25.0.0",
+        "@androidsdk//com.android.support:support-fragment-25.0.0",
     ],
 )

--- a/javatests/dagger/android/support/functional/BUILD
+++ b/javatests/dagger/android/support/functional/BUILD
@@ -31,7 +31,7 @@ android_library(
         "//:dagger_with_compiler",
         "//third_party:guava",
         "@androidsdk//com.android.support:appcompat-v7-25.0.0",
-        "@androidsdk//com.android.support:support-v4-25.0.0",
+        "@androidsdk//com.android.support:support-fragment-25.0.0",
     ],
 )
 
@@ -47,6 +47,6 @@ GenRobolectricTests(
         "//:dagger_with_compiler",
         "//third_party:junit",
         "//third_party:truth",
-        "@androidsdk//com.android.support:support-v4-25.0.0",
+        "@androidsdk//com.android.support:support-fragment-25.0.0",
     ],
 )


### PR DESCRIPTION
It's better to depend on the granular support artifacts instead of `support-v4` to avoid pulling in unnecessary dependencies. Most apps can avoid depending on `support-media-compat` this way.