### PR TITLE
Remove unnecessary `MembersInjectors.injectMembers` method

### DIFF
--- a/java/dagger/internal/MembersInjectors.java
+++ b/java/dagger/internal/MembersInjectors.java
@@ -44,12 +44,8 @@ public final class MembersInjectors {
     INSTANCE;
 
     @Override public void injectMembers(Object instance) {
-      checkInstanceNotNull(instance);
+      checkNotNull(instance, "Cannot inject members into a null reference");
     }
-  }
-
-  private static void checkInstanceNotNull(Object instance) {
-    checkNotNull(instance, "Cannot inject members into a null reference");
   }
 
   private MembersInjectors() {}

--- a/java/dagger/internal/MembersInjectors.java
+++ b/java/dagger/internal/MembersInjectors.java
@@ -48,7 +48,7 @@ public final class MembersInjectors {
     }
   }
 
-  private void checkInstanceNotNull(Object instance) {
+  private static void checkInstanceNotNull(Object instance) {
     checkNotNull(instance, "Cannot inject members into a null reference");
   }
 

--- a/java/dagger/internal/MembersInjectors.java
+++ b/java/dagger/internal/MembersInjectors.java
@@ -28,15 +28,6 @@ import javax.inject.Inject;
  * @since 2.0
  */
 public final class MembersInjectors {
-  /**
-   * Injects members into {@code instance} using {@code membersInjector}.  This method is a
-   * convenience for cases in which you would want to chain members injection, but can't because
-   * {@link MembersInjector#injectMembers} returns {@code void}.
-   */
-  public static <T> T injectMembers(MembersInjector<T> membersInjector, T instance) {
-    membersInjector.injectMembers(instance);
-    return instance;
-  }
 
   /**
    * Returns a {@link MembersInjector} implementation that injects no members
@@ -57,7 +48,7 @@ public final class MembersInjectors {
     }
   }
 
-  public static void checkInstanceNotNull(Object instance) {
+  private void checkInstanceNotNull(Object instance) {
     checkNotNull(instance, "Cannot inject members into a null reference");
   }
 


### PR DESCRIPTION
~~The last use of the `MembersInjectors` class was removed in [this](https://github.com/google/dagger/commit/e05f921812772eba98ef3b4a1ab6b301f3b25e26#diff-fd8cd7984835e64dceea55e5b84f303cL257) commit, so it isn't used now during code generation.
 (This class is still used in `TypeNames` as a class name constant, which is no longer necessary)~~

Static `MembersInjectors.injectMembers` is no longer used during code generation.