### PR TITLE
Add polyfill to support more browsers

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,7 @@
       <meta name="description" content="A fast dependency injector for Android and Java." />
       {% assign polymer_root = site.baseurl | append: '/bower_components' %}
       <link href="{{polymer_root}}/normalize.css/normalize.css" rel="stylesheet"/>
+      <script src="{{polymer_root}}/webcomponentsjs/webcomponents-loader.js"></script>
 
       <link rel="import" href="{{polymer_root}}/paper-item/paper-item.html">
       <link rel="import" href="{{polymer_root}}/paper-item/paper-icon-item.html">


### PR DESCRIPTION
Quickfix for TODO 1) from #976, fixes https://github.com/google/dagger/issues/968#issuecomment-352437710.

There should be more time spent on this by a more experienced web developer (@paullewis?), because there's FOUC in non-Blink browsers.

Polymer 2's browser support: https://www.polymer-project.org/2.0/docs/browsers
This PR is live at http://twisterrob.github.io/dagger/

Tested:
* Chrome 63.0.3239.84: all good
* Firefox 57: FOUC
* Edge 40.15063.674.0: FOUC
* IE11: as in screenshot by @murmurmuk