### PR TITLE
Fixing bazel build for newer versions

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -26,6 +26,7 @@ sh_test(
     name = "jarjar_library_impl_test",
     srcs = ["jarjar_library_impl_test.sh"],
     args = ["$(JAVABASE)"],
+    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
     data = [
         ":jarjar_deploy.jar",
         ":jarjar_library_impl",

--- a/tools/jarjar.bzl
+++ b/tools/jarjar.bzl
@@ -127,6 +127,7 @@ def jarjar_library(name, deps, rules_file):
           "@local_jdk//:jre",
       ],
       outs = [name + ".jar"],
+      toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
       cmd = """
       export JAVA_HOME=$(JAVABASE)
       $(location //tools:jarjar_library_impl) $@ "{deps}" {rules} \


### PR DESCRIPTION
With new version of bazel was getting
```
... $(JAVABASE) not defined
```

for errors

This is the same fix used for https://github.com/bazelbuild/bazel/issues/4268