### PR TITLE
Add android proguard specs

### DIFF
--- a/java/dagger/android/BUILD
+++ b/java/dagger/android/BUILD
@@ -38,6 +38,7 @@ android_library(
     srcs = SRCS,
     javacopts = SOURCE_7_TARGET_7 + DOCLINT_HTML_AND_SYNTAX + DOCLINT_REFERENCES,
     manifest = "AndroidManifest.xml",
+    proguard_specs = ["proguard.cfg"],
     deps = [
         "//:dagger_with_compiler",
         "//third_party:auto_value",

--- a/java/dagger/android/proguard.cfg
+++ b/java/dagger/android/proguard.cfg
@@ -1,0 +1,1 @@
+-dontwarn com.google.errorprone.annotations.**


### PR DESCRIPTION
Example test: https://github.com/bazelbuild/bazel/blob/29f2ba82ca7581a68b4cc760d15fc9f89b0ea9b9/src/test/java/com/google/devtools/build/lib/rules/android/AndroidBinaryTest.java#L624

Based on the example test, I set `proguard_specs = ["proguard.cfg"]`.

@ronshapiro Closes https://github.com/google/dagger/issues/1040