### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/BindingGraphFactory.java
+++ b/java/dagger/internal/codegen/BindingGraphFactory.java
@@ -211,7 +211,8 @@ final class BindingGraphFactory {
         subgraphs.build(),
         getScopesRequiringReleasableReferenceManagers(
             releasableReferenceManagerBindings, resolvedContributionBindingsMap.keySet()),
-        requestResolver.getOwnedModules());
+        requestResolver.getOwnedModules(),
+        requestResolver.getFactoryMethod());
   }
 
   /**
@@ -321,6 +322,20 @@ final class BindingGraphFactory {
       this.delegateMultibindingDeclarations =
           multibindingContributionsByMultibindingKey(delegateDeclarations.values());
       subcomponentsToResolve.addAll(componentDescriptor.subcomponentsFromEntryPoints());
+    }
+
+    /** Returns the optional factory method for this component. */
+    Optional<ExecutableElement> getFactoryMethod() {
+      return parentResolver
+          .map(
+              parent -> {
+                return parent
+                    .componentDescriptor
+                    .subcomponentsByFactoryMethod()
+                    .inverse()
+                    .get(componentDescriptor);
+              })
+          .map(method -> method.methodElement());
     }
 
     /**

--- a/java/dagger/internal/codegen/ComponentBuilder.java
+++ b/java/dagger/internal/codegen/ComponentBuilder.java
@@ -75,13 +75,20 @@ final class ComponentBuilder {
     return builderFields;
   }
 
-  static ComponentBuilder create(
+  static Optional<ComponentBuilder> create(
       ClassName componentName,
       BindingGraph graph,
       SubcomponentNames subcomponentNames,
       Elements elements,
       Types types) {
-    return new Creator(componentName, graph, subcomponentNames, elements, types).create();
+    return hasBuilder(graph.componentDescriptor())
+        ? Optional.of(
+            new Creator(componentName, graph, subcomponentNames, elements, types).create())
+        : Optional.empty();
+  }
+
+  private static boolean hasBuilder(ComponentDescriptor component) {
+    return component.kind().isTopLevel() || component.builderSpec().isPresent();
   }
 
   private static final class Creator {

--- a/java/dagger/internal/codegen/ComponentWriter.java
+++ b/java/dagger/internal/codegen/ComponentWriter.java
@@ -82,7 +82,6 @@ abstract class ComponentWriter {
     return new RootComponentWriter(
             types,
             elements,
-            compilerOptions,
             graph,
             generatedComponentModel,
             subcomponentNames,
@@ -122,7 +121,6 @@ abstract class ComponentWriter {
 
   private final Elements elements;
   private final DaggerTypes types;
-  private final CompilerOptions compilerOptions;
   private final BindingGraph graph;
   private final SubcomponentNames subcomponentNames;
   private final ComponentBindingExpressions bindingExpressions;
@@ -135,7 +133,6 @@ abstract class ComponentWriter {
   private ComponentWriter(
       DaggerTypes types,
       Elements elements,
-      CompilerOptions compilerOptions,
       BindingGraph graph,
       GeneratedComponentModel generatedComponentModel,
       SubcomponentNames subcomponentNames,
@@ -145,7 +142,6 @@ abstract class ComponentWriter {
       Optional<ComponentBuilder> builder) {
     this.types = types;
     this.elements = elements;
-    this.compilerOptions = compilerOptions;
     this.graph = graph;
     this.subcomponentNames = subcomponentNames;
     this.generatedComponentModel = generatedComponentModel;
@@ -278,7 +274,6 @@ abstract class ComponentWriter {
     RootComponentWriter(
         DaggerTypes types,
         Elements elements,
-        CompilerOptions compilerOptions,
         BindingGraph graph,
         GeneratedComponentModel generatedComponentModel,
         SubcomponentNames subcomponentNames,
@@ -289,7 +284,6 @@ abstract class ComponentWriter {
       super(
           types,
           elements,
-          compilerOptions,
           graph,
           generatedComponentModel,
           subcomponentNames,
@@ -359,7 +353,6 @@ abstract class ComponentWriter {
       super(
           parent.types,
           parent.elements,
-          parent.compilerOptions,
           graph,
           generatedComponentModel,
           parent.subcomponentNames,

--- a/java/dagger/internal/codegen/ComponentWriter.java
+++ b/java/dagger/internal/codegen/ComponentWriter.java
@@ -18,17 +18,12 @@ package dagger.internal.codegen;
 
 import static com.google.auto.common.MoreElements.getLocalAndInheritedMethods;
 import static com.google.auto.common.MoreTypes.asDeclared;
-import static com.google.auto.common.MoreTypes.asExecutable;
-import static com.google.auto.common.MoreTypes.asTypeElement;
-import static com.google.common.base.CaseFormat.LOWER_CAMEL;
-import static com.google.common.base.CaseFormat.UPPER_CAMEL;
 import static com.google.common.base.Preconditions.checkState;
 import static com.squareup.javapoet.MethodSpec.constructorBuilder;
 import static com.squareup.javapoet.MethodSpec.methodBuilder;
 import static dagger.internal.codegen.AnnotationSpecs.Suppression.UNCHECKED;
 import static dagger.internal.codegen.CodeBlocks.toParametersCodeBlock;
-import static dagger.internal.codegen.DaggerStreams.toImmutableSet;
-import static dagger.internal.codegen.GeneratedComponentModel.FieldSpecKind.COMPONENT_REQUIREMENT_FIELD;
+import static dagger.internal.codegen.DaggerStreams.toImmutableList;
 import static dagger.internal.codegen.GeneratedComponentModel.MethodSpecKind.BUILDER_METHOD;
 import static dagger.internal.codegen.GeneratedComponentModel.MethodSpecKind.COMPONENT_METHOD;
 import static dagger.internal.codegen.GeneratedComponentModel.MethodSpecKind.CONSTRUCTOR;
@@ -41,23 +36,20 @@ import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.element.Modifier.STATIC;
 
 import com.google.auto.common.MoreTypes;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimaps;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
-import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.TypeSpec;
-import dagger.internal.Preconditions;
 import dagger.internal.codegen.ComponentDescriptor.ComponentMethodDescriptor;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.util.Elements;
 
@@ -73,7 +65,10 @@ abstract class ComponentWriter {
     GeneratedComponentModel generatedComponentModel = GeneratedComponentModel.forComponent(name);
     SubcomponentNames subcomponentNames = new SubcomponentNames(graph, keyFactory);
     OptionalFactories optionalFactories = new OptionalFactories();
-    ComponentRequirementFields componentRequirementFields = new ComponentRequirementFields();
+    Optional<ComponentBuilder> builder =
+        ComponentBuilder.create(name, graph, subcomponentNames, elements, types);
+    ComponentRequirementFields componentRequirementFields =
+        new ComponentRequirementFields(graph, generatedComponentModel, builder);
     ComponentBindingExpressions bindingExpressions =
         new ComponentBindingExpressions(
             graph,
@@ -93,7 +88,8 @@ abstract class ComponentWriter {
             subcomponentNames,
             optionalFactories,
             bindingExpressions,
-            componentRequirementFields)
+            componentRequirementFields,
+            builder)
         .write();
   }
 
@@ -104,8 +100,12 @@ abstract class ComponentWriter {
             parent.subcomponentNames.get(childGraph.componentDescriptor()) + "Impl");
     GeneratedComponentModel childGeneratedComponentModel =
         GeneratedComponentModel.forSubcomponent(childName);
+    Optional<ComponentBuilder> childBuilder =
+        ComponentBuilder.create(
+            childName, childGraph, parent.subcomponentNames, parent.elements, parent.types);
     ComponentRequirementFields childComponentRequirementFields =
-        parent.componentRequirementFields.forChildComponent();
+        parent.componentRequirementFields.forChildComponent(
+            childGraph, childGeneratedComponentModel, childBuilder);
     ComponentBindingExpressions childBindingExpressions =
         parent.bindingExpressions.forChildComponent(
             childGraph, childGeneratedComponentModel, childComponentRequirementFields);
@@ -114,7 +114,8 @@ abstract class ComponentWriter {
             childGraph,
             childGeneratedComponentModel,
             childBindingExpressions,
-            childComponentRequirementFields)
+            childComponentRequirementFields,
+            childBuilder)
         .write()
         .build();
   }
@@ -127,17 +128,9 @@ abstract class ComponentWriter {
   private final ComponentBindingExpressions bindingExpressions;
   private final ComponentRequirementFields componentRequirementFields;
   private final GeneratedComponentModel generatedComponentModel;
-  private final ComponentRequirementField.Factory componentRequirementFieldFactory;
-  private final MethodSpec.Builder constructor = constructorBuilder().addModifiers(PRIVATE);
   private final OptionalFactories optionalFactories;
-  private ComponentBuilder builder;
+  private final Optional<ComponentBuilder> builder;
   private boolean done;
-
-  /**
-   * For each component requirement, the builder field. This map is empty for subcomponents that do
-   * not use a builder.
-   */
-  private final ImmutableMap<ComponentRequirement, FieldSpec> builderFields;
 
   private ComponentWriter(
       DaggerTypes types,
@@ -148,7 +141,8 @@ abstract class ComponentWriter {
       SubcomponentNames subcomponentNames,
       OptionalFactories optionalFactories,
       ComponentBindingExpressions bindingExpressions,
-      ComponentRequirementFields componentRequirementFields) {
+      ComponentRequirementFields componentRequirementFields,
+      Optional<ComponentBuilder> builder) {
     this.types = types;
     this.elements = elements;
     this.compilerOptions = compilerOptions;
@@ -157,18 +151,8 @@ abstract class ComponentWriter {
     this.generatedComponentModel = generatedComponentModel;
     this.optionalFactories = optionalFactories;
     this.bindingExpressions = bindingExpressions;
-    // TODO(dpb): Allow ComponentBuilder.create to return a no-op object
-    if (hasBuilder(graph)) {
-      builder =
-          ComponentBuilder.create(
-              generatedComponentModel.name(), graph, subcomponentNames, elements, types);
-      builderFields = builder.builderFields();
-    } else {
-      builderFields = ImmutableMap.of();
-    }
     this.componentRequirementFields = componentRequirementFields;
-    this.componentRequirementFieldFactory =
-        new ComponentRequirementField.Factory(generatedComponentModel, builderFields);
+    this.builder = builder;
   }
 
   /**
@@ -179,39 +163,22 @@ abstract class ComponentWriter {
   protected final TypeSpec.Builder write() {
     checkState(!done, "ComponentWriter has already been generated.");
     generatedComponentModel.addSupertype(graph.componentType());
-    if (hasBuilder(graph)) {
-      addBuilder();
-    }
+    builder.map(ComponentBuilder::typeSpec).ifPresent(this::addBuilderClass);
 
     getLocalAndInheritedMethods(
             graph.componentDescriptor().componentDefinitionType(), types, elements)
         .forEach(method -> generatedComponentModel.claimMethodName(method.getSimpleName()));
 
     addFactoryMethods();
-    createComponentRequirementFields();
     addInterfaceMethods();
     addSubcomponents();
-    addInitializeMethods();
-    generatedComponentModel.addMethod(CONSTRUCTOR, constructor.build());
+    addConstructor();
+
     if (graph.componentDescriptor().kind().isTopLevel()) {
       optionalFactories.addMembers(generatedComponentModel);
     }
     done = true;
     return generatedComponentModel.generate();
-  }
-
-  private static boolean hasBuilder(BindingGraph graph) {
-    ComponentDescriptor component = graph.componentDescriptor();
-    return component.kind().isTopLevel() || component.builderSpec().isPresent();
-  }
-
-  /**
-   * Adds a builder type.
-   */
-  private void addBuilder() {
-    addBuilderClass(builder.typeSpec());
-
-    constructor.addParameter(builder.name(), "builder");
   }
 
   /**
@@ -222,14 +189,6 @@ abstract class ComponentWriter {
 
   /** Adds component factory methods. */
   protected abstract void addFactoryMethods();
-
-  private void createComponentRequirementFields() {
-    builderFields
-        .keySet()
-        .stream()
-        .map(componentRequirementFieldFactory::forBuilderField)
-        .forEach(componentRequirementFields::add);
-  }
 
   private void addInterfaceMethods() {
     /* Each component method may have been declared by several supertypes. We want to implement only
@@ -257,10 +216,21 @@ abstract class ComponentWriter {
 
   private static final int INITIALIZATIONS_PER_INITIALIZE_METHOD = 100;
 
-  private void addInitializeMethods() {
+  private void addConstructor() {
     List<List<CodeBlock>> partitions =
         Lists.partition(
             generatedComponentModel.getInitializations(), INITIALIZATIONS_PER_INITIALIZE_METHOD);
+
+    ImmutableList<ParameterSpec> constructorParameters = constructorParameters();
+    MethodSpec.Builder constructor =
+        constructorBuilder().addModifiers(PRIVATE).addParameters(constructorParameters);
+
+    ImmutableList<ParameterSpec> initializeParameters = initializeParameters();
+    CodeBlock initializeParametersCodeBlock =
+        constructorParameters
+            .stream()
+            .map(param -> CodeBlock.of("$N", param))
+            .collect(toParametersCodeBlock());
 
     UniqueNameSet methodNames = new UniqueNameSet();
     for (List<CodeBlock> partition : partitions) {
@@ -274,13 +244,30 @@ abstract class ComponentWriter {
                * separate fields and initilization as we do now. */
               .addAnnotation(AnnotationSpecs.suppressWarnings(UNCHECKED))
               .addCode(CodeBlocks.concat(partition));
-      if (hasBuilder(graph)) {
-        initializeMethod.addParameter(builder.name(), "builder", FINAL);
-        constructor.addStatement("$L(builder)", methodName);
-      } else {
-        constructor.addStatement("$L()", methodName);
-      }
+      initializeMethod.addParameters(initializeParameters);
+      constructor.addStatement("$L($L)", methodName, initializeParametersCodeBlock);
       generatedComponentModel.addMethod(INITIALIZE_METHOD, initializeMethod.build());
+    }
+    generatedComponentModel.addMethod(CONSTRUCTOR, constructor.build());
+  }
+
+  /** Returns the list of {@link ParameterSpec}s for the initialze methods. */
+  private ImmutableList<ParameterSpec> initializeParameters() {
+    return constructorParameters()
+        .stream()
+        .map(param -> param.toBuilder().addModifiers(FINAL).build())
+        .collect(toImmutableList());
+  }
+
+  /** Returns the list of {@link ParameterSpec}s for the constructor. */
+  private ImmutableList<ParameterSpec> constructorParameters() {
+    if (builder.isPresent()) {
+      return ImmutableList.of(ParameterSpec.builder(builder.get().name(), "builder").build());
+    } else if (graph.factoryMethod().isPresent()) {
+      return getFactoryMethodParameterSpecs(graph);
+    } else {
+      throw new AssertionError(
+          "Expected either a component builder or factory method but found neither.");
     }
   }
 
@@ -297,7 +284,8 @@ abstract class ComponentWriter {
         SubcomponentNames subcomponentNames,
         OptionalFactories optionalFactories,
         ComponentBindingExpressions bindingExpressions,
-        ComponentRequirementFields componentRequirementFields) {
+        ComponentRequirementFields componentRequirementFields,
+        Optional<ComponentBuilder> builder) {
       super(
           types,
           elements,
@@ -307,7 +295,8 @@ abstract class ComponentWriter {
           subcomponentNames,
           optionalFactories,
           bindingExpressions,
-          componentRequirementFields);
+          componentRequirementFields,
+          builder);
     }
 
     @Override
@@ -325,8 +314,8 @@ abstract class ComponentWriter {
               .returns(
                   builderSpec().isPresent()
                       ? ClassName.get(builderSpec().get().builderDefinitionType())
-                      : super.builder.name())
-              .addStatement("return new $T()", super.builder.name())
+                      : super.builder.get().name())
+              .addStatement("return new $T()", super.builder.get().name())
               .build();
       super.generatedComponentModel.addMethod(BUILDER_METHOD, builderFactoryMethod);
       if (canInstantiateAllRequirements()) {
@@ -365,7 +354,8 @@ abstract class ComponentWriter {
         BindingGraph graph,
         GeneratedComponentModel generatedComponentModel,
         ComponentBindingExpressions bindingExpressions,
-        ComponentRequirementFields componentRequirementFields) {
+        ComponentRequirementFields componentRequirementFields,
+        Optional<ComponentBuilder> builder) {
       super(
           parent.types,
           parent.elements,
@@ -375,7 +365,8 @@ abstract class ComponentWriter {
           parent.subcomponentNames,
           parent.optionalFactories,
           bindingExpressions,
-          componentRequirementFields);
+          componentRequirementFields,
+          builder);
       this.parent = parent;
     }
 
@@ -388,84 +379,35 @@ abstract class ComponentWriter {
     protected void addFactoryMethods() {
       // The parent's factory method to create this subcomponent if the
       // subcomponent was not added via {@link dagger.Module#subcomponents()}.
-      Optional.ofNullable(
-              parent
-                  .graph
-                  .componentDescriptor()
-                  .subcomponentsByFactoryMethod()
-                  .inverse()
-                  .get(super.graph.componentDescriptor()))
-          .map(method -> method.methodElement())
-          .ifPresent(this::createSubcomponentFactoryMethod);
+      super.graph.factoryMethod().ifPresent(this::createSubcomponentFactoryMethod);
     }
 
     private void createSubcomponentFactoryMethod(ExecutableElement factoryMethod) {
       parent.generatedComponentModel.addMethod(
           COMPONENT_METHOD,
-          MethodSpec.overriding(factoryMethod, parentType(), parent.types)
+          MethodSpec.overriding(factoryMethod, parentType(), super.types)
               .addStatement(
                   "return new $T($L)",
                   super.generatedComponentModel.name(),
-                  factoryMethod
-                      .getParameters()
+                  getFactoryMethodParameterSpecs(super.graph)
                       .stream()
-                      .map(param -> CodeBlock.of("$L", param.getSimpleName()))
+                      .map(param -> CodeBlock.of("$N", param))
                       .collect(toParametersCodeBlock()))
               .build());
-
-      writeSubcomponentConstructorFor(factoryMethod);
-    }
-
-    private void writeSubcomponentConstructorFor(ExecutableElement factoryMethod) {
-      Set<ComponentRequirement> modules =
-          asExecutable(super.types.asMemberOf(parentType(), factoryMethod))
-              .getParameterTypes()
-              .stream()
-              .map(param -> ComponentRequirement.forModule(asTypeElement(param).asType()))
-              .collect(toImmutableSet());
-
-      for (ComponentRequirement module : modules) {
-        FieldSpec field = createSubcomponentModuleField(module);
-        super.constructor
-            .addParameter(field.type, field.name)
-            .addStatement("this.$1N = $2T.checkNotNull($1N)", field, Preconditions.class);
-      }
-
-      Set<ComponentRequirement> remainingModules =
-          super.graph
-              .componentRequirements()
-              .stream()
-              .filter(requirement -> requirement.kind().equals(ComponentRequirement.Kind.MODULE))
-              .filter(requirement -> !modules.contains(requirement))
-              .collect(toImmutableSet());
-
-      for (ComponentRequirement module : remainingModules) {
-        FieldSpec field = createSubcomponentModuleField(module);
-        super.constructor.addStatement("this.$N = new $T()", field, field.type);
-      }
-    }
-
-    // TODO(user): We shouldn't have to create these manually. They should be created lazily
-    // by ComponentRequirementFields, similar to how it's done for ComponentBindingExpressions.
-    private FieldSpec createSubcomponentModuleField(ComponentRequirement module) {
-      TypeElement moduleElement = module.typeElement();
-      String fieldName =
-          super.generatedComponentModel.getUniqueFieldName(
-              UPPER_CAMEL.to(LOWER_CAMEL, moduleElement.getSimpleName().toString()));
-      FieldSpec contributionField =
-          FieldSpec.builder(ClassName.get(moduleElement), fieldName)
-              .addModifiers(PRIVATE, FINAL).build();
-
-      super.generatedComponentModel.addField(COMPONENT_REQUIREMENT_FIELD, contributionField);
-      super.componentRequirementFields.add(
-          ComponentRequirementField.componentField(
-              module, contributionField, super.generatedComponentModel.name()));
-
-      return contributionField;
     }
 
     private DeclaredType parentType() {
       return asDeclared(parent.graph.componentType().asType());
     }
+  }
+
+  /** Returns the list of {@link ParameterSpec}s for the corresponding graph's factory method. */
+  private static ImmutableList<ParameterSpec> getFactoryMethodParameterSpecs(BindingGraph graph) {
+    return graph
+        .factoryMethodParameters()
+        .values()
+        .stream()
+        .map(ParameterSpec::get)
+        .collect(toImmutableList());
   }
 }

--- a/javatests/dagger/internal/codegen/SubcomponentValidationTest.java
+++ b/javatests/dagger/internal/codegen/SubcomponentValidationTest.java
@@ -467,10 +467,10 @@ public class SubcomponentValidationTest {
             .addLines(
                 "",
                 "  private final class ChildComponentImpl implements ChildComponent {",
-                "    private final ChildModule childModule;",
+                "    private ChildModule childModule;",
                 "",
                 "    private ChildComponentImpl() {",
-                "      this.childModule = new ChildModule();",
+                "      initialize();",
                 "    }",
                 "")
             .addLinesIn(
@@ -497,6 +497,11 @@ public class SubcomponentValidationTest {
                 "              DaggerParentComponent.this.getDep1(),",
                 "              DaggerParentComponent.this.getDep2()));")
             .addLines(
+                "    }",
+                "",
+                "    @SuppressWarnings(\"unchecked\")",
+                "    private void initialize() {",
+                "      this.childModule = new ChildModule();",
                 "    }",
                 "",
                 "    @Override",


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make ComponentRequirementField creation lazy.

This CL allows ComponentRequirementFields to be created lazily. This cleans up some of the code in ComponentWriter because it no longer needs to ensure that it manually creates each ComponentRequirementField before using it.

a04e918d1efa04dc41a9bc3bfeef28bca5246693

-------

<p> remove unused CompilerOptions parameter when creating ComponentWriters.

9be787fc4bb28caafeb536e69140dd32cefa1dfe