### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/android/DispatchingAndroidInjector.java
+++ b/java/dagger/android/DispatchingAndroidInjector.java
@@ -127,9 +127,9 @@ public final class DispatchingAndroidInjector<T> implements AndroidInjector<T> {
     }
     Collections.sort(suggestions);
 
-    return String.format(
-        suggestions.isEmpty() ? NO_SUPERTYPES_BOUND_FORMAT : SUPERTYPES_BOUND_FORMAT,
-        instance.getClass().getCanonicalName(),
-        suggestions);
+    return suggestions.isEmpty()
+        ? String.format(NO_SUPERTYPES_BOUND_FORMAT, instance.getClass().getCanonicalName())
+        : String.format(
+            SUPERTYPES_BOUND_FORMAT, instance.getClass().getCanonicalName(), suggestions);
   }
 }

--- a/javatests/dagger/internal/codegen/OptionalBindingTest.java
+++ b/javatests/dagger/internal/codegen/OptionalBindingTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2016 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static dagger.internal.codegen.Compilers.daggerCompiler;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class OptionalBindingTest {
+  @Test
+  public void provideExplicitOptionalInParent_AndBindsOptionalOfInChild() {
+    JavaFileObject parent =
+        JavaFileObjects.forSourceLines(
+            "test.Parent",
+            "package test;",
+            "",
+            "import dagger.Component;",
+            "import java.util.Optional;",
+            "",
+            "@Component(modules = ParentModule.class)",
+            "interface Parent {",
+            "  Optional<String> optional();",
+            "  Child child();",
+            "}");
+    JavaFileObject parentModule =
+        JavaFileObjects.forSourceLines(
+            "test.ParentModule",
+            "package test;",
+            "",
+            "import dagger.Module;",
+            "import dagger.Provides;",
+            "import java.util.Optional;",
+            "",
+            "@Module",
+            "class ParentModule {",
+            "  @Provides",
+            "  Optional<String> optional() {",
+            "    return Optional.of(new String());",
+            "  }",
+            "}");
+
+    JavaFileObject child =
+        JavaFileObjects.forSourceLines(
+            "test.Child",
+            "package test;",
+            "",
+            "import dagger.Subcomponent;",
+            "import java.util.Optional;",
+            "",
+            "@Subcomponent(modules = ChildModule.class)",
+            "interface Child {",
+            "  Optional<String> optional();",
+            "}");
+    JavaFileObject childModule =
+        JavaFileObjects.forSourceLines(
+            "test.ChildModule",
+            "package test;",
+            "",
+            "import dagger.BindsOptionalOf;",
+            "import dagger.Module;",
+            "",
+            "@Module",
+            "interface ChildModule {",
+            "  @BindsOptionalOf",
+            "  String optionalString();",
+            "}");
+
+    Compilation compilation = daggerCompiler().compile(parent, parentModule, child, childModule);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining("Optional<java.lang.String> is bound multiple times")
+        .inFile(parent)
+        .onLineContaining("interface Parent");
+  }
+}

--- a/util/generate-latest-docs.sh
+++ b/util/generate-latest-docs.sh
@@ -21,7 +21,7 @@ if [ "$TRAVIS_REPO_SLUG" == "google/dagger" ] && \
   unzip "$JAVADOC_JAR" -d api/latest
   rm -rf api/latest/META-INF/
   git add -f api/latest
-  git commit -m "Lastest javadoc on successful travis build $TRAVIS_BUILD_NUMBER auto-pushed to gh-pages"
+  git commit -m "Latest javadoc on successful travis build $TRAVIS_BUILD_NUMBER auto-pushed to gh-pages"
   git push -fq origin gh-pages > /dev/null
 
   echo -e "Published Javadoc to gh-pages.\n"


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> When checking for local contributions, ignore whether the previously resolved binding is for a synthetic binding or not. We should still check for @Provides Set<T> and @Provides @IntoSet T collisions across components (and the same for maps and @Provides Optional<T> + @BindsOptionalOf T).

Fixes https://github.com/google/dagger/issues/975

RELNOTES:
  - Fix a bug where binding collisions were not properly checked across subcomponent boundaries when a parent provided a concrete `Set`/`Map` and a child provided a multibinding contribution with the same key.
  - Also applies to providing a concrete optional binding and `@BindsOptionalOf` declarations.

6c07e3a3b2dc2dbcfc8a257eb07a7b071ece4a8e

-------

<p> Typo: "Lastest" -> "Latest"

43626cf0271f2a03b9b49a5dad5b5da6e2c2aac0

-------

<p> Clean up new violations of ErrorProne's FormatString checker

3046ea24919fcc8ff900dc31a0cf00dfc0775e36