### PR TITLE
[b/73646178] Dagger: Add @DoNotMock errorprone annotation to Lazy

### DIFF
--- a/java/dagger/BUILD
+++ b/java/dagger/BUILD
@@ -28,7 +28,10 @@ java_library(
     srcs = glob(["**/*.java"]),
     javacopts = SOURCE_7_TARGET_7 + DOCLINT_HTML_AND_SYNTAX,
     exports = ["//third_party:jsr330_inject"],
-    deps = ["//third_party:jsr330_inject"],
+    deps = [
+        "//third_party:jsr330_inject",
+        "//third_party:error_prone_annotations"
+    ],
 )
 
 filegroup(

--- a/java/dagger/Lazy.java
+++ b/java/dagger/Lazy.java
@@ -16,6 +16,8 @@
 
 package dagger;
 
+import com.google.errorprone.annotations.DoNotMock;
+
 /**
  * A handle to a lazily-computed value. Each {@code Lazy} computes its value on
  * the first call to {@link #get()} and remembers that same value for all
@@ -142,6 +144,7 @@ package dagger;
  * Use {@link javax.inject.Singleton @Singleton} to share one instance among all
  * clients, and {@code Lazy} for lazy computation in a single client.
  */
+@DoNotMock
 public interface Lazy<T> {
   /**
    * Return the underlying value, computing the value if necessary. All calls to


### PR DESCRIPTION
Is there an errorprone @BugChecker to test @DoNotMock that already exists in errorprone or its infrastructure already?  Otherwise, I'll see whether it's necessary or how hard it is to write a unit test to test @DoNotMock.

https://groups.google.com/forum/#!msg/error-prone-discuss/ZlqF85kcB_w/kJdMvmb2BAAJ

Thank you!