### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -82,6 +82,7 @@ java_library(
         "CompilerOptions.java",
         "ContributionType.java",
         "DaggerElements.java",
+        "DaggerGraphs.java",
         "DaggerTypes.java",
         "DiagnosticFormatting.java",
         "Expression.java",

--- a/java/dagger/internal/codegen/BindingDeclaration.java
+++ b/java/dagger/internal/codegen/BindingDeclaration.java
@@ -16,8 +16,6 @@
 
 package dagger.internal.codegen;
 
-import static dagger.internal.codegen.DaggerElements.ENCLOSING_TYPE_ELEMENT;
-
 import dagger.model.Key;
 import java.util.Optional;
 import javax.lang.model.element.Element;
@@ -40,7 +38,7 @@ abstract class BindingDeclaration {
    * #bindingElement()} is empty.
    */
   Optional<TypeElement> bindingTypeElement() {
-    return bindingElement().map(element -> element.accept(ENCLOSING_TYPE_ELEMENT, null));
+    return bindingElement().map(DaggerElements::closestEnclosingTypeElement);
   }
   
   /**

--- a/java/dagger/internal/codegen/DaggerElements.java
+++ b/java/dagger/internal/codegen/DaggerElements.java
@@ -48,7 +48,7 @@ import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
-import javax.lang.model.util.SimpleElementVisitor6;
+import javax.lang.model.util.SimpleElementVisitor8;
 import javax.lang.model.util.Types;
 
 /** Extension of {@link Elements} that adds Dagger-specific methods. */
@@ -83,23 +83,24 @@ final class DaggerElements implements Elements {
     return elements.getTypeElement(name);
   }
 
-  /**
-   * A visitor that returns the input or the closest enclosing element that is a
-   * {@link TypeElement}.
-   */
-  static final ElementVisitor<TypeElement, Void> ENCLOSING_TYPE_ELEMENT =
-      new SimpleElementVisitor6<TypeElement, Void>() {
+  /** Returns the argument or the closest enclosing element that is a {@link TypeElement}. */
+  static TypeElement closestEnclosingTypeElement(Element element) {
+    return element.accept(CLOSEST_ENCLOSING_TYPE_ELEMENT, null);
+  }
+
+  private static final ElementVisitor<TypeElement, Void> CLOSEST_ENCLOSING_TYPE_ELEMENT =
+      new SimpleElementVisitor8<TypeElement, Void>() {
         @Override
-        protected TypeElement defaultAction(Element e, Void p) {
-          return visit(e.getEnclosingElement());
+        protected TypeElement defaultAction(Element element, Void p) {
+          return element.getEnclosingElement().accept(this, null);
         }
-  
+
         @Override
-        public TypeElement visitType(TypeElement e, Void p) {
-          return e;
+        public TypeElement visitType(TypeElement type, Void p) {
+          return type;
         }
       };
-      
+
   /**
    * Returns {@code true} iff the given element has an {@link AnnotationMirror} whose
    * {@linkplain AnnotationMirror#getAnnotationType() annotation type} has the same canonical name

--- a/java/dagger/internal/codegen/DaggerGraphs.java
+++ b/java/dagger/internal/codegen/DaggerGraphs.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2018 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.graph.SuccessorsFunction;
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+/** Utility methods for {@link com.google.common.graph} types. */
+final class DaggerGraphs {
+  /**
+   * Returns a shortest path from {@code nodeU} to {@code nodeV} in {@code graph} as a list of the
+   * nodes visited in sequence, including both {@code nodeU} and {@code nodeV}. (Note that there may
+   * be many possible shortest paths.)
+   *
+   * <p>If {@code nodeV} is not {@link
+   * com.google.common.graph.Graphs#reachableNodes(com.google.common.graph.Graph, Object) reachable}
+   * from {@code nodeU}, the list returned is empty.
+   *
+   * @throws IllegalArgumentException if {@code nodeU} or {@code nodeV} is not present in {@code
+   *     graph}
+   */
+  static <N> ImmutableList<N> shortestPath(SuccessorsFunction<N> graph, N nodeU, N nodeV) {
+    if (nodeU.equals(nodeV)) {
+      return ImmutableList.of(nodeU);
+    }
+    Set<N> successors = ImmutableSet.copyOf(graph.successors(nodeU));
+    if (successors.contains(nodeV)) {
+      return ImmutableList.of(nodeU, nodeV);
+    }
+
+    Map<N, N> visitedNodeToPathPredecessor = new HashMap<>(); // encodes shortest path tree
+    Queue<N> currentNodes = new ArrayDeque<N>();
+    Queue<N> nextNodes = new ArrayDeque<N>();
+    for (N node : successors) {
+      visitedNodeToPathPredecessor.put(node, nodeU);
+    }
+    currentNodes.addAll(successors);
+
+    // Perform a breadth-first traversal starting with the successors of nodeU.
+    while (!currentNodes.isEmpty()) {
+      while (!currentNodes.isEmpty()) {
+        N currentNode = currentNodes.remove();
+        for (N nextNode : graph.successors(currentNode)) {
+          if (visitedNodeToPathPredecessor.containsKey(nextNode)) {
+            continue; // we already have a shortest path to nextNode
+          }
+          visitedNodeToPathPredecessor.put(nextNode, currentNode);
+          if (nextNode.equals(nodeV)) {
+            ImmutableList.Builder<N> builder = ImmutableList.builder();
+            N node = nodeV;
+            builder.add(node);
+            while (!node.equals(nodeU)) {
+              node = visitedNodeToPathPredecessor.get(node);
+              builder.add(node);
+            }
+            return builder.build().reverse();
+          }
+          nextNodes.add(nextNode);
+        }
+      }
+      Queue<N> emptyQueue = currentNodes;
+      currentNodes = nextNodes;
+      nextNodes = emptyQueue; // reusing empty queue faster than allocating new one
+    }
+
+    return ImmutableList.of();
+  }
+
+  private DaggerGraphs() {}
+}

--- a/java/dagger/internal/codegen/SpiDiagnosticReporter.java
+++ b/java/dagger/internal/codegen/SpiDiagnosticReporter.java
@@ -17,13 +17,12 @@
 package dagger.internal.codegen;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static dagger.internal.codegen.DaggerGraphs.shortestPath;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
-import com.google.common.graph.SuccessorsFunction;
 import dagger.model.BindingGraph.BindingNode;
 import dagger.model.BindingGraph.ComponentNode;
 import dagger.model.BindingGraph.DependencyEdge;
@@ -31,12 +30,8 @@ import dagger.model.BindingGraph.Edge;
 import dagger.model.BindingGraph.Node;
 import dagger.model.DependencyRequest;
 import dagger.spi.ValidationItem;
-import java.util.ArrayDeque;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Queue;
 import java.util.Set;
 import javax.annotation.processing.Messager;
 import javax.inject.Inject;
@@ -201,66 +196,5 @@ final class SpiDiagnosticReporter {
 
   private static boolean isInstance(Optional<?> optional, Class<?> clazz) {
     return optional.filter(clazz::isInstance).isPresent();
-  }
-
-  /**
-   * Returns a shortest path from {@code nodeU} to {@code nodeV} in {@code graph} as a list of the
-   * nodes visited in sequence, including both {@code nodeU} and {@code nodeV}. (Note that there may
-   * be many possible shortest paths.)
-   *
-   * <p>If {@code nodeV} is not {@link
-   * com.google.common.graph.Graphs#reachableNodes(com.google.common.graph.Graph, Object) reachable}
-   * from {@code nodeU}, the list returned is empty.
-   *
-   * @throws IllegalArgumentException if {@code nodeU} or {@code nodeV} is not present in {@code
-   *     graph}
-   */
-  // This is copied from common.graph since it is not yet open-sourced.
-  // TODO(ronshapiro): When the API is released and becomes stable, remove this copy.
-  private static <N> ImmutableList<N> shortestPath(SuccessorsFunction<N> graph, N nodeU, N nodeV) {
-    if (nodeU.equals(nodeV)) {
-      return ImmutableList.of(nodeU);
-    }
-    Set<N> successors = ImmutableSet.copyOf(graph.successors(nodeU));
-    if (successors.contains(nodeV)) {
-      return ImmutableList.of(nodeU, nodeV);
-    }
-
-    Map<N, N> visitedNodeToPathPredecessor = new HashMap<>(); // encodes shortest path tree
-    Queue<N> currentNodes = new ArrayDeque<N>();
-    Queue<N> nextNodes = new ArrayDeque<N>();
-    for (N node : successors) {
-      visitedNodeToPathPredecessor.put(node, nodeU);
-    }
-    currentNodes.addAll(successors);
-
-    // Perform a breadth-first traversal starting with the successors of nodeU.
-    while (!currentNodes.isEmpty()) {
-      while (!currentNodes.isEmpty()) {
-        N currentNode = currentNodes.remove();
-        for (N nextNode : graph.successors(currentNode)) {
-          if (visitedNodeToPathPredecessor.containsKey(nextNode)) {
-            continue; // we already have a shortest path to nextNode
-          }
-          visitedNodeToPathPredecessor.put(nextNode, currentNode);
-          if (nextNode.equals(nodeV)) {
-            ImmutableList.Builder<N> builder = ImmutableList.builder();
-            N node = nodeV;
-            builder.add(node);
-            while (!node.equals(nodeU)) {
-              node = visitedNodeToPathPredecessor.get(node);
-              builder.add(node);
-            }
-            return builder.build().reverse();
-          }
-          nextNodes.add(nextNode);
-        }
-      }
-      Queue<N> emptyQueue = currentNodes;
-      currentNodes = nextNodes;
-      nextNodes = emptyQueue; // reusing empty queue faster than allocating new one
-    }
-
-    return ImmutableList.of();
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Get the appropriate Kythe Span for a SubcomponentDeclaration

This was detected by adding some more useful exception messages for null getTree() results

13c958ce2a9e8fd07879e865a4fb165d4b66fd18

-------

<p> Move shortestPath to DaggerGraphs.

917c72d6bf5209a3b0150be18f79f092cfa4bf2a

-------

<p> Add DaggerElements.enclosingTypeElement() so we don't have a nonprivate field.

977ffc7d930efa3ac60e5a449790ee3583b41846