### PR TITLE
Moe Sync

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -63,6 +63,7 @@ jarjar_library(
     deps = [
         "//java/dagger/internal/codegen:base",
         "//java/dagger/internal/codegen:binding",
+        "//java/dagger/internal/codegen:internal_validation",
         "//java/dagger/internal/codegen:processor",
         "//java/dagger/internal/codegen:shared-with-spi",
         "//java/dagger/internal/codegen:validation",
@@ -78,6 +79,7 @@ jarjar_library(
     deps = [
         "//java/dagger/internal/codegen:libbase-src.jar",
         "//java/dagger/internal/codegen:libbinding-src.jar",
+        "//java/dagger/internal/codegen:libinternal_validation-src.jar",
         "//java/dagger/internal/codegen:libprocessor-src.jar",
         "//java/dagger/internal/codegen:libshared-with-spi-src.jar",
         "//java/dagger/internal/codegen:libvalidation-src.jar",

--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -198,6 +198,19 @@ java_library(
     ],
 )
 
+java_library(
+    name = "internal_validation",
+    srcs = [
+        "BindingGraphValidationModule.java",
+        "NonNullableRequestForNullableBindingValidation.java",
+        "Validation.java",
+    ],
+    deps = CODEGEN_DEPS + [
+        ":base",
+        ":binding",
+    ],
+)
+
 # Classes that assemble the model of the generated code and write to the Filer
 java_library(
     name = "writing",
@@ -296,6 +309,7 @@ java_library(
     deps = CODEGEN_DEPS + [
         ":base",
         ":binding",
+        ":internal_validation",
         ":writing",
         ":validation",
     ],

--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -203,6 +203,7 @@ java_library(
     srcs = [
         "BindingGraphValidationModule.java",
         "NonNullableRequestForNullableBindingValidation.java",
+        "ProviderDependsOnProducerValidation.java",
         "Validation.java",
     ],
     deps = CODEGEN_DEPS + [

--- a/java/dagger/internal/codegen/BindingGraphValidationModule.java
+++ b/java/dagger/internal/codegen/BindingGraphValidationModule.java
@@ -29,4 +29,9 @@ interface BindingGraphValidationModule {
   @IntoSet
   @Validation
   BindingGraphPlugin nullable(NonNullableRequestForNullableBindingValidation validation);
+
+  @Binds
+  @IntoSet
+  @Validation
+  BindingGraphPlugin providerDependsOnProducer(ProviderDependsOnProducerValidation validation);
 }

--- a/java/dagger/internal/codegen/BindingGraphValidationModule.java
+++ b/java/dagger/internal/codegen/BindingGraphValidationModule.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2018 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen;
+
+import dagger.Binds;
+import dagger.Module;
+import dagger.multibindings.IntoSet;
+import dagger.spi.BindingGraphPlugin;
+
+/** Binds the set of {@link BindingGraphPlugin}s used to implement Dagger validation. */
+@Module
+interface BindingGraphValidationModule {
+
+  @Binds
+  @IntoSet
+  @Validation
+  BindingGraphPlugin nullable(NonNullableRequestForNullableBindingValidation validation);
+}

--- a/java/dagger/internal/codegen/ComponentProcessor.java
+++ b/java/dagger/internal/codegen/ComponentProcessor.java
@@ -97,11 +97,12 @@ public final class ComponentProcessor extends BasicAnnotationProcessor {
 
   @Singleton
   @Component(
-      modules = {
-          BindingMethodValidatorsModule.class,
-          BindingGraphPluginsModule.class,
-          ProcessingStepsModule.class,
-      }
+    modules = {
+      BindingGraphPluginsModule.class,
+      BindingGraphValidationModule.class,
+      BindingMethodValidatorsModule.class,
+      ProcessingStepsModule.class,
+    }
   )
   interface ProcessorComponent {
     void inject(ComponentProcessor processor);

--- a/java/dagger/internal/codegen/ErrorMessages.java
+++ b/java/dagger/internal/codegen/ErrorMessages.java
@@ -112,10 +112,6 @@ final class ErrorMessages {
   static final String INJECT_INTO_PRIVATE_CLASS =
       "Dagger does not support injection into private classes";
 
-  static final String CANNOT_INJECT_WILDCARD_TYPE =
-      "Dagger does not support injecting Provider<T>, Lazy<T> or Produced<T> when T is a wildcard "
-          + "type such as <%s>.";
-
   /*
    * Configuration errors
    *
@@ -255,19 +251,6 @@ final class ErrorMessages {
 
   static final String DEPENDS_ON_PRODUCTION_EXECUTOR_FORMAT =
       "%s may not depend on the production executor.";
-
-  static final String REQUIRES_AT_INJECT_CONSTRUCTOR_OR_PROVIDER_FORMAT =
-      "%s cannot be provided without an @Inject constructor or from an @Provides-annotated method.";
-
-  static final String REQUIRES_PROVIDER_FORMAT =
-      "%s cannot be provided without an @Provides-annotated method.";
-
-  static final String REQUIRES_AT_INJECT_CONSTRUCTOR_OR_PROVIDER_OR_PRODUCER_FORMAT =
-      "%s cannot be provided without an @Inject constructor or from an @Provides- or "
-      + "@Produces-annotated method.";
-
-  static final String REQUIRES_PROVIDER_OR_PRODUCER_FORMAT =
-      "%s cannot be provided without an @Provides- or @Produces-annotated method.";
 
   private static final String PROVISION_MAY_NOT_DEPEND_ON_PRODUCER_TYPE_FORMAT =
       "%s may only be injected in @Produces methods.";

--- a/java/dagger/internal/codegen/ErrorMessages.java
+++ b/java/dagger/internal/codegen/ErrorMessages.java
@@ -253,12 +253,6 @@ final class ErrorMessages {
   static final String MULTIPLE_CONTRIBUTION_TYPES_FOR_KEY_FORMAT =
       "%s has incompatible bindings or declarations:\n";
 
-  static final String PROVIDER_ENTRY_POINT_MAY_NOT_DEPEND_ON_PRODUCER_FORMAT =
-      "%s is a provision entry-point, which cannot depend on a production.";
-
-  static final String PROVIDER_MAY_NOT_DEPEND_ON_PRODUCER_FORMAT =
-      "%s is a provision, which cannot depend on a production.";
-
   static final String DEPENDS_ON_PRODUCTION_EXECUTOR_FORMAT =
       "%s may not depend on the production executor.";
 

--- a/java/dagger/internal/codegen/ErrorMessages.java
+++ b/java/dagger/internal/codegen/ErrorMessages.java
@@ -295,13 +295,6 @@ final class ErrorMessages {
 
   static final String CONTAINS_DEPENDENCY_CYCLE_FORMAT = "Found a dependency cycle:\n%s";
 
-  static String nullableToNonNullable(String typeName, String bindingString) {
-    return String.format(
-            "%s is not nullable, but is being provided by %s",
-            typeName,
-            bindingString);
-  }
-
   static final String CANNOT_RETURN_NULL_FROM_NON_NULLABLE_COMPONENT_METHOD =
       "Cannot return null from a non-@Nullable component method";
 

--- a/java/dagger/internal/codegen/NonNullableRequestForNullableBindingValidation.java
+++ b/java/dagger/internal/codegen/NonNullableRequestForNullableBindingValidation.java
@@ -16,6 +16,7 @@
 
 package dagger.internal.codegen;
 
+import static dagger.internal.codegen.DaggerStreams.instancesOf;
 import static dagger.internal.codegen.DaggerStreams.toImmutableList;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -72,8 +73,7 @@ final class NonNullableRequestForNullableBindingValidation implements BindingGra
     return bindingGraph
         .inEdges(bindingNode)
         .stream()
-        .filter(edge -> edge instanceof DependencyEdge)
-        .map(edge -> (DependencyEdge) edge)
+        .flatMap(instancesOf(DependencyEdge.class))
         .filter(edge -> !edge.dependencyRequest().isNullable())
         .collect(toImmutableList());
   }

--- a/java/dagger/internal/codegen/NonNullableRequestForNullableBindingValidation.java
+++ b/java/dagger/internal/codegen/NonNullableRequestForNullableBindingValidation.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2018 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen;
+
+import static dagger.internal.codegen.DaggerStreams.toImmutableList;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import dagger.model.BindingGraph;
+import dagger.model.BindingGraph.BindingNode;
+import dagger.model.BindingGraph.DependencyEdge;
+import dagger.spi.BindingGraphPlugin;
+import dagger.spi.DiagnosticReporter;
+import javax.inject.Inject;
+
+/**
+ * Reports errors or warnings (depending on the {@code -Adagger.nullableValidation} value) for each
+ * non-nullable dependency request that is satisfied by a nullable binding.
+ */
+final class NonNullableRequestForNullableBindingValidation implements BindingGraphPlugin {
+
+  private final CompilerOptions compilerOptions;
+
+  @Inject
+  NonNullableRequestForNullableBindingValidation(CompilerOptions compilerOptions) {
+    this.compilerOptions = compilerOptions;
+  }
+
+  @Override
+  public void visitGraph(BindingGraph bindingGraph, DiagnosticReporter diagnosticReporter) {
+    for (BindingNode bindingNode : nullableBindings(bindingGraph)) {
+      for (DependencyEdge dependencyEdge : nonNullableDependencies(bindingGraph, bindingNode)) {
+        diagnosticReporter.reportDependency(
+            compilerOptions.nullableValidationKind(),
+            dependencyEdge,
+            nullableToNonNullable(
+                bindingNode.binding().key().toString(),
+                bindingNode.toString())); // will include the @Nullable
+      }
+    }
+  }
+
+  @Override
+  public String pluginName() {
+    return "Dagger/Nullable";
+  }
+
+  private ImmutableList<BindingNode> nullableBindings(BindingGraph bindingGraph) {
+    return bindingGraph
+        .bindingNodes()
+        .stream()
+        .filter(bindingNode -> bindingNode.binding().isNullable())
+        .collect(toImmutableList());
+  }
+
+  private ImmutableList<DependencyEdge> nonNullableDependencies(
+      BindingGraph bindingGraph, BindingNode bindingNode) {
+    return bindingGraph
+        .inEdges(bindingNode)
+        .stream()
+        .filter(edge -> edge instanceof DependencyEdge)
+        .map(edge -> (DependencyEdge) edge)
+        .filter(edge -> !edge.dependencyRequest().isNullable())
+        .collect(toImmutableList());
+  }
+
+  @VisibleForTesting
+  static String nullableToNonNullable(String key, String binding) {
+    return String.format("%s is not nullable, but is being provided by %s", key, binding);
+  }
+}

--- a/java/dagger/internal/codegen/ProviderDependsOnProducerValidation.java
+++ b/java/dagger/internal/codegen/ProviderDependsOnProducerValidation.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2018 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static dagger.internal.codegen.DaggerStreams.instancesOf;
+import static dagger.internal.codegen.RequestKinds.entryPointCanUseProduction;
+import static javax.tools.Diagnostic.Kind.ERROR;
+
+import dagger.model.BindingGraph;
+import dagger.model.BindingGraph.BindingNode;
+import dagger.model.BindingGraph.DependencyEdge;
+import dagger.model.BindingGraph.Node;
+import dagger.spi.BindingGraphPlugin;
+import dagger.spi.DiagnosticReporter;
+import java.util.stream.Stream;
+import javax.inject.Inject;
+
+/**
+ * Reports an error for each dependency of a provision binding that is satisfied by a production
+ * binding.
+ */
+// TODO(b/29509141): Clarify the error.
+final class ProviderDependsOnProducerValidation implements BindingGraphPlugin {
+
+  @Inject
+  ProviderDependsOnProducerValidation() {}
+
+  @Override
+  public String pluginName() {
+    return "Dagger/ProviderDependsOnProducer";
+  }
+
+  @Override
+  public void visitGraph(BindingGraph bindingGraph, DiagnosticReporter diagnosticReporter) {
+    provisionDependenciesOnProductionBindings(bindingGraph)
+        .forEach(
+            provisionDependent ->
+                diagnosticReporter.reportDependency(
+                    ERROR,
+                    provisionDependent,
+                    provisionDependent.isEntryPoint()
+                        ? entryPointErrorMessage(provisionDependent)
+                        : dependencyErrorMessage(provisionDependent, bindingGraph)));
+  }
+
+  private Stream<DependencyEdge> provisionDependenciesOnProductionBindings(
+      BindingGraph bindingGraph) {
+    return bindingGraph
+        .bindingNodes()
+        .stream()
+        .filter(bindingNode -> bindingNode.binding().isProduction())
+        .flatMap(binding -> incomingDependencies(binding, bindingGraph))
+        .filter(edge -> !dependencyCanUseProduction(edge, bindingGraph));
+  }
+
+  /** Returns the dependencies on {@code binding}. */
+  // TODO(dpb): Move to BindingGraph.
+  private Stream<DependencyEdge> incomingDependencies(
+      BindingNode binding, BindingGraph bindingGraph) {
+    return bindingGraph.inEdges(binding).stream().flatMap(instancesOf(DependencyEdge.class));
+  }
+
+  private boolean dependencyCanUseProduction(DependencyEdge edge, BindingGraph bindingGraph) {
+    return edge.isEntryPoint()
+        ? entryPointCanUseProduction(edge.dependencyRequest().kind())
+        : bindingRequestingDependency(edge, bindingGraph).binding().isProduction();
+  }
+
+  /**
+   * Returns the binding that requests a dependency.
+   *
+   * @throws IllegalArgumentException if {@code dependency} is an {@linkplain
+   *     DependencyEdge#isEntryPoint() entry point}.
+   */
+  // TODO(dpb): Move to BindingGraph.
+  private BindingNode bindingRequestingDependency(
+      DependencyEdge dependency, BindingGraph bindingGraph) {
+    checkArgument(!dependency.isEntryPoint());
+    Node source = bindingGraph.incidentNodes(dependency).source();
+    verify(
+        source instanceof BindingNode,
+        "expected source of %s to be a binding node, but was: %s",
+        dependency,
+        source);
+    return (BindingNode) source;
+  }
+
+  private String entryPointErrorMessage(DependencyEdge entryPoint) {
+    return String.format(
+        "%s is a provision entry-point, which cannot depend on a production.",
+        entryPoint.dependencyRequest().key());
+  }
+
+  private String dependencyErrorMessage(
+      DependencyEdge dependencyOnProduction, BindingGraph bindingGraph) {
+    return String.format(
+        "%s is a provision, which cannot depend on a production.",
+        bindingRequestingDependency(dependencyOnProduction, bindingGraph).binding().key());
+  }
+}

--- a/java/dagger/internal/codegen/RequestKinds.java
+++ b/java/dagger/internal/codegen/RequestKinds.java
@@ -165,5 +165,25 @@ final class RequestKinds {
     return Optional.ofNullable(FRAMEWORK_CLASSES.get(requestKind));
   }
 
+  /**
+   * Returns {@code true} if entry points with the given request kind may be satisfied with a
+   * production binding.
+   */
+  static boolean entryPointCanUseProduction(RequestKind requestKind) {
+    switch (requestKind) {
+      case INSTANCE:
+      case PROVIDER:
+      case LAZY:
+      case PROVIDER_OF_LAZY:
+      case MEMBERS_INJECTION:
+        return false;
+      case PRODUCER:
+      case PRODUCED:
+      case FUTURE:
+        return true;
+    }
+    throw new AssertionError();
+  }
+
   private RequestKinds() {}
 }

--- a/java/dagger/internal/codegen/Validation.java
+++ b/java/dagger/internal/codegen/Validation.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2018 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import javax.inject.Qualifier;
+
+/**
+ * Qualifier annotation for the {@link dagger.spi.BindingGraphPlugin}s that are used to implement
+ * core Dagger validation.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Qualifier
+@interface Validation {}

--- a/java/dagger/model/BindingGraph.java
+++ b/java/dagger/model/BindingGraph.java
@@ -17,6 +17,7 @@
 package dagger.model;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Sets.intersection;
 import static com.google.common.graph.Graphs.inducedSubgraph;
 import static com.google.common.graph.Graphs.reachableNodes;
@@ -37,6 +38,7 @@ import dagger.model.BindingGraph.Edge;
 import dagger.model.BindingGraph.Node;
 import dagger.multibindings.Multibinds;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
@@ -295,10 +297,18 @@ public final class BindingGraph extends ForwardingNetwork<Node, Edge> {
   @DoNotMock("Use Dagger-supplied implementations")
   public abstract static class BindingNode implements Node {
     static BindingNode create(
-        ComponentPath component, Binding binding, Iterable<Element> associatedDeclarations) {
-      return new AutoValue_BindingGraph_BindingNode(
-          component, binding, ImmutableSet.copyOf(associatedDeclarations));
+        ComponentPath component,
+        Binding binding,
+        Iterable<Element> associatedDeclarations,
+        Supplier<String> toStringFunction) {
+      BindingNode bindingNode =
+          new AutoValue_BindingGraph_BindingNode(
+              component, binding, ImmutableSet.copyOf(associatedDeclarations));
+      bindingNode.toStringFunction = checkNotNull(toStringFunction);
+      return bindingNode;
     }
+
+    private Supplier<String> toStringFunction;
 
     /** The component that owns the {@link #binding()}. */
     @Override
@@ -318,6 +328,11 @@ public final class BindingGraph extends ForwardingNetwork<Node, Edge> {
      * </ul>
      */
     public abstract ImmutableSet<Element> associatedDeclarations();
+
+    @Override
+    public String toString() {
+      return toStringFunction.get();
+    }
   }
 
   /**

--- a/java/dagger/model/BindingGraphProxies.java
+++ b/java/dagger/model/BindingGraphProxies.java
@@ -24,6 +24,7 @@ import dagger.model.BindingGraph.DependencyEdge;
 import dagger.model.BindingGraph.Edge;
 import dagger.model.BindingGraph.Node;
 import dagger.model.BindingGraph.SubcomponentBuilderBindingEdge;
+import java.util.function.Supplier;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
@@ -41,8 +42,11 @@ public final class BindingGraphProxies {
 
   /** Creates a new {@link BindingNode}. */
   public static BindingNode bindingNode(
-      ComponentPath component, Binding binding, Iterable<Element> associatedDeclarations) {
-    return BindingNode.create(component, binding, associatedDeclarations);
+      ComponentPath component,
+      Binding binding,
+      Iterable<Element> associatedDeclarations,
+      Supplier<String> toStringFunction) {
+    return BindingNode.create(component, binding, associatedDeclarations, toStringFunction);
   }
 
   /** Creates a new {@link ComponentNode}. */

--- a/javatests/dagger/functional/ComponentWithReusableBindings.java
+++ b/javatests/dagger/functional/ComponentWithReusableBindings.java
@@ -39,6 +39,9 @@ interface ComponentWithReusableBindings {
 
   ChildTwo childTwo();
 
+  // b/77150738
+  int primitive();
+
   @Subcomponent
   interface ChildOne {
     @InParent
@@ -71,6 +74,13 @@ interface ComponentWithReusableBindings {
     @InChildren
     static Object inChildren() {
       return new Object();
+    }
+
+    // b/77150738
+    @Provides
+    @Reusable
+    static int primitive() {
+      return 0;
     }
   }
 }

--- a/javatests/dagger/internal/codegen/BUILD
+++ b/javatests/dagger/internal/codegen/BUILD
@@ -29,6 +29,7 @@ GenJavaTests(
         "//java/dagger:core",
         "//java/dagger/internal/codegen:base",
         "//java/dagger/internal/codegen:binding",
+        "//java/dagger/internal/codegen:internal_validation",
         "//java/dagger/internal/codegen:processor",
         "//java/dagger/internal/codegen:validation",
         "//java/dagger/internal/codegen:writing",

--- a/javatests/dagger/internal/codegen/GraphValidationTest.java
+++ b/javatests/dagger/internal/codegen/GraphValidationTest.java
@@ -128,8 +128,9 @@ public class GraphValidationTest {
         "    A getA();",
         "  }",
         "}");
-    String expectedError = "test.TestClass.A cannot be provided without an "
-        + "@Inject constructor or from an @Provides-annotated method.";
+    String expectedError =
+        "test.TestClass.A cannot be provided without an @Inject constructor or an "
+            + "@Provides-annotated method.";
     assertAbout(javaSource()).that(component)
         .processedWith(new ComponentProcessor())
         .failsToCompile()
@@ -159,9 +160,10 @@ public class GraphValidationTest {
         "    B getB();",
         "  }",
         "}");
-    String expectedError = "test.TestClass.B cannot be provided without an "
-        + "@Inject constructor or from an @Provides-annotated method. "
-        + "This type supports members injection but cannot be implicitly provided.";
+    String expectedError =
+        "test.TestClass.B cannot be provided without an @Inject constructor or an "
+            + "@Provides-annotated method. This type supports members injection but cannot be "
+            + "implicitly provided.";
     assertAbout(javaSource()).that(component)
         .processedWith(new ComponentProcessor())
         .failsToCompile()
@@ -1365,8 +1367,8 @@ public class GraphValidationTest {
         .withErrorContaining(
             Joiner.on("\n      ")
                 .join(
-                    "java.lang.String cannot be provided without an @Inject constructor or from "
-                        + "an @Provides-annotated method.",
+                    "java.lang.String cannot be provided without an @Inject constructor or an "
+                        + "@Provides-annotated method.",
                     "java.lang.String is injected at",
                     "    TestImplementation.<init>(missingBinding)",
                     "TestImplementation is injected at",

--- a/javatests/dagger/internal/codegen/GraphValidationTest.java
+++ b/javatests/dagger/internal/codegen/GraphValidationTest.java
@@ -22,7 +22,7 @@ import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 import static com.google.testing.compile.JavaSourcesSubject.assertThat;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 import static dagger.internal.codegen.Compilers.daggerCompiler;
-import static dagger.internal.codegen.ErrorMessages.nullableToNonNullable;
+import static dagger.internal.codegen.NonNullableRequestForNullableBindingValidation.nullableToNonNullable;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;

--- a/javatests/dagger/internal/codegen/ProductionGraphValidationTest.java
+++ b/javatests/dagger/internal/codegen/ProductionGraphValidationTest.java
@@ -78,12 +78,15 @@ public class ProductionGraphValidationTest {
         "    return null;",
         "  }",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(EXECUTOR_MODULE, module, component))
+    assertAbout(javaSources())
+        .that(ImmutableList.of(EXECUTOR_MODULE, module, component))
         .processedWith(new ComponentProcessor())
         .failsToCompile()
-        .withErrorContaining("test.Bar cannot be provided without an @Inject constructor or from "
-            + "an @Provides- or @Produces-annotated method.")
-            .in(component).onLine(8);
+        .withErrorContaining(
+            "test.Bar cannot be provided without an @Inject constructor or an @Provides- or "
+                + "@Produces-annotated method.")
+        .in(component)
+        .onLine(8);
   }
 
   @Test public void componentProductionWithNoDependencyChain() {

--- a/javatests/dagger/internal/codegen/SubcomponentValidationTest.java
+++ b/javatests/dagger/internal/codegen/SubcomponentValidationTest.java
@@ -239,7 +239,7 @@ public class SubcomponentValidationTest {
         .failsToCompile()
         .withErrorContaining(
             "[test.ChildComponent.getString()] "
-                + "java.lang.Integer cannot be provided without an @Inject constructor or from an "
+                + "java.lang.Integer cannot be provided without an @Inject constructor or an "
                 + "@Provides-annotated method")
         .in(componentFile)
         .onLine(6);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Move validation of non-nullable requests for nullable bindings to an internal implementation of BindingGraphPlugin. Add infrastructure to run internal plugins as part of validation, before running external plugins.

5bbc247fd4307ef2cf6fe4a0ca859fa2d1080466

-------

<p> Move validation of provisions depending on productions to an internal validation BindingGraphPlugin.

bb0c1702e3d4ac5cd0c0a813e69dc1b7ce790725

-------

<p> Inline the "FooKey cannot be provided without ..." error message formats to simplify their logic.

1683ed4d09e92cda6fddc4e419cc45e62cb4a84e

-------

<p> Support single-checked primitive types in Android mode

7d61a4c2a6d4b24c8929805420285d82f0b555a8