### PR TITLE
Moe Sync

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,6 @@ description:
   Java and Android. It is developed by the Java Core Libraries Team at Google.
 
 themeColor: blue
-fixedNav: 'true' # true or false
 
 exclude: [_site, CHANGELOG.md, LICENSE, README.md, Gemfile, Gemfile.lock]
 sass:


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> 

96acf43083bd3f2768340cd8a2bd5e7155a2a7c5

-------

<p> Disable fixed navigation bar.

When users follow a link to an anchor/fragment, the navigation bar blocks the header and part of the text.

bb2925701c7324bdad37ad8c6365abd287dc5fa8