### PR TITLE
fix link to grpc docs in README

### DIFF
--- a/java/dagger/grpc/server/README.md
+++ b/java/dagger/grpc/server/README.md
@@ -1,10 +1,10 @@
 # Dagger-gRPC on the Server
 
 This package contains the public types used to create gRPC server applications
-using google.github.io/dagger.
+using https://google.github.io/dagger.
 
 It is maintained by the Dagger team.
 
 It is in development, and is planned for open-source release as part of Dagger.
 
-See user documentation at google.github.io/dagger-grpc.
+See user documentation at https://google.github.io/dagger/grpc.


### PR DESCRIPTION
- use correct link address 
- add schema to make link clickable