### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/CompilerOptions.java
+++ b/java/dagger/internal/codegen/CompilerOptions.java
@@ -48,6 +48,19 @@ abstract class CompilerOptions {
    */
   abstract boolean experimentalAndroidMode();
 
+  /**
+   * Returns true if the experimental Android mode 2 is enabled.
+   *
+   * <p><b>Warning: Do Not use! This flag is for internal, experimental use only!</b>
+   *
+   * <p>Issues related to this flag will not be supported. This flag could break your build,
+   * or cause other unknown issues at runtime.
+   *
+   * <p>If enabled, the generated code will try to reduce class loading due to providers by using
+   * a single {@code Provider} class to replace all factory classes.
+   */
+  abstract boolean experimentalAndroidMode2();
+
   abstract boolean writeProducerNameInToken();
 
   abstract Diagnostic.Kind nullableValidationKind();
@@ -80,6 +93,8 @@ abstract class CompilerOptions {
         .headerCompilation(processingEnv.getOptions().containsKey(HEADER_COMPILATION))
         .experimentalAndroidMode(
             experimentalAndroidModeFeatureStatus(processingEnv).equals(FeatureStatus.ENABLED))
+        .experimentalAndroidMode2(
+            experimentalAndroidMode2FeatureStatus(processingEnv).equals(FeatureStatus.ENABLED))
         .writeProducerNameInToken(
             writeProducerNameInTokenFeatureStatus(processingEnv).equals(FeatureStatus.ENABLED))
         .nullableValidationKind(nullableValidationType(processingEnv).diagnosticKind().get())
@@ -107,6 +122,8 @@ abstract class CompilerOptions {
 
     Builder experimentalAndroidMode(boolean experimentalAndroidMode);
 
+    Builder experimentalAndroidMode2(boolean experimentalAndroidMode2);
+
     Builder writeProducerNameInToken(boolean writeProducerNameInToken);
 
     Builder nullableValidationKind(Diagnostic.Kind kind);
@@ -131,6 +148,8 @@ abstract class CompilerOptions {
   private static final String HEADER_COMPILATION = "experimental_turbine_hjar";
 
   static final String EXPERIMENTAL_ANDROID_MODE = "dagger.experimentalAndroidMode";
+
+  static final String EXPERIMENTAL_ANDROID_MODE2 = "dagger.experimentalAndroidMode2";
 
   static final String WRITE_PRODUCER_NAME_IN_TOKEN_KEY = "dagger.writeProducerNameInToken";
 
@@ -176,6 +195,15 @@ abstract class CompilerOptions {
     return valueOf(
         processingEnv,
         EXPERIMENTAL_ANDROID_MODE,
+        FeatureStatus.DISABLED,
+        EnumSet.allOf(FeatureStatus.class));
+  }
+
+  private static FeatureStatus experimentalAndroidMode2FeatureStatus(
+      ProcessingEnvironment processingEnv) {
+    return valueOf(
+        processingEnv,
+        EXPERIMENTAL_ANDROID_MODE2,
         FeatureStatus.DISABLED,
         EnumSet.allOf(FeatureStatus.class));
   }

--- a/java/dagger/internal/codegen/ComponentProvisionBindingExpression.java
+++ b/java/dagger/internal/codegen/ComponentProvisionBindingExpression.java
@@ -50,7 +50,8 @@ final class ComponentProvisionBindingExpression extends SimpleInvocationBindingE
             componentRequirementFields.getExpression(componentRequirement(), requestingClass),
             binding.bindingElement().get().getSimpleName());
     return Expression.create(
-        binding.key().type(), maybeCheckForNull(binding, compilerOptions, invocation));
+        binding.contributedPrimitiveType().orElse(binding.key().type()),
+        maybeCheckForNull(binding, compilerOptions, invocation));
   }
 
   private ComponentRequirement componentRequirement() {

--- a/java/dagger/internal/codegen/Expression.java
+++ b/java/dagger/internal/codegen/Expression.java
@@ -16,6 +16,7 @@
 
 package dagger.internal.codegen;
 
+import com.google.auto.common.MoreTypes;
 import com.squareup.javapoet.CodeBlock;
 import javax.lang.model.type.TypeMirror;
 
@@ -60,6 +61,16 @@ final class Expression {
   // or just embedding a Types/Elements instance in an Expression.
   Expression castTo(TypeMirror newType) {
     return create(newType, "($T) $L", newType, codeBlock);
+  }
+
+  /**
+   * Returns a new expression that {@link #castTo(TypeMirror)} casts the current expression to its
+   * boxed type if this expression has a primitive type.
+   */
+  Expression box(DaggerTypes types) {
+    return type.getKind().isPrimitive()
+        ? castTo(types.boxedClass(MoreTypes.asPrimitiveType(type)).asType())
+        : this;
   }
 
   /** The {@link TypeMirror type} to which the expression evaluates. */

--- a/java/dagger/internal/codegen/KytheBindingGraphFactory.java
+++ b/java/dagger/internal/codegen/KytheBindingGraphFactory.java
@@ -105,6 +105,7 @@ final class KytheBindingGraphFactory {
             .scopeCycleValidationType(ValidationType.NONE)
             .warnIfInjectionFactoryNotGeneratedUpstream(false)
             .experimentalAndroidMode(false)
+            .experimentalAndroidMode2(false)
             .aheadOfTimeComponents(false)
             .build();
 

--- a/java/dagger/internal/codegen/SimpleMethodBindingExpression.java
+++ b/java/dagger/internal/codegen/SimpleMethodBindingExpression.java
@@ -98,7 +98,10 @@ final class SimpleMethodBindingExpression extends SimpleInvocationBindingExpress
       default:
         throw new IllegalStateException();
     }
-    return Expression.create(provisionBinding.key().type(), invocation);
+
+    return Expression.create(
+        provisionBinding.contributedPrimitiveType().orElse(provisionBinding.key().type()),
+        invocation);
   }
 
   private TypeName constructorTypeName(ClassName requestingClass) {

--- a/java/dagger/internal/codegen/SwitchingProviders.java
+++ b/java/dagger/internal/codegen/SwitchingProviders.java
@@ -141,21 +141,11 @@ final class SwitchingProviders {
     }
 
     private CodeBlock createSwitchCaseCodeBlock(ContributionBinding binding) {
-      Expression instanceExpression =
+      CodeBlock instanceCodeBlock =
           componentBindingExpressions
-              .getDependencyExpression(binding.key(), INSTANCE, owningComponent);
-
-      CodeBlock instanceCodeBlock = instanceExpression.codeBlock();
-
-      // Primitives cannot be cast directly to the method's parameterized type, T. We have to first
-      // cast them to their boxed type.
-      // TODO(user): Shouldn't we be able to rely soley on the instance expression type? However,
-      // that currently fails. Does that indicate that those dependency expression types are wrong?
-      if (binding.contributedPrimitiveType().isPresent()
-          || instanceExpression.type().getKind().isPrimitive()) {
-        TypeName boxedType = TypeName.get(binding.contributedType()).box();
-        instanceCodeBlock = CodeBlock.of("($T) $L", boxedType, instanceCodeBlock);
-      }
+              .getDependencyExpression(binding.key(), INSTANCE, owningComponent)
+              .box(types)
+              .codeBlock();
 
       return CodeBlock.builder()
           // TODO(user): Is there something else more useful than the key?

--- a/javatests/dagger/functional/BoxedPrimitives.java
+++ b/javatests/dagger/functional/BoxedPrimitives.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+import javax.inject.Provider;
+
+interface BoxedPrimitives {
+  interface Dependency {
+    int primitive();
+  }
+
+  @Component(dependencies = Dependency.class)
+  interface ConsumesPrimitiveThroughDependency {
+    Provider<Integer> providerOfBoxedPrimitive();
+  }
+
+  @Module
+  class PrimitiveModule {
+    @Provides
+    static int providePrimitive() {
+      return 1;
+    }
+  }
+
+  @Component(modules = PrimitiveModule.class)
+  interface ConsumesPrimitiveFromProvidesMethod {
+    Provider<Integer> providerOfBoxedPrimitive();
+  }
+
+}

--- a/test_defs.bzl
+++ b/test_defs.bzl
@@ -16,6 +16,7 @@
 # The key will be appended to the generated test names to ensure uniqueness.
 BUILD_VARIANTS = {
     "ExperimentalAndroidMode": ["-Adagger.experimentalAndroidMode=enabled"],
+    "ExperimentalAndroidMode2": ["-Adagger.experimentalAndroidMode2=enabled"],
     "ExperimentalAheadOfTimeComponents": ["-Adagger.experimentalAheadOfTimeComponents=enabled"],
     "ExperimentalAndroidModeAndAheadOfTimeComponents": ["-Adagger.experimentalAndroidMode=enabled",
                                                         "-Adagger.experimentalAheadOfTimeComponents=enabled"],


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add androidExperimentalAndroidMode2

androidExperimentalAndroidMode2 is much more similar to default mode than the original androidExperimentalAndroidMode. In this new mode, virtually everything is the same as default mode except that the initialization of providers is done with a inner static switching provider class instead of separate *_Factory classes.

189150d7fcd0950569c48c428d7baf9da1a3a597

-------

<p> Create Expression.box() to simplify casts to boxed primitive types.

This is a rollforward of fb8b7f2a3dcb378afa7739618fa2ad8313be7b2d which didn't properly update the primitive component dependency methods to have appropriate expression types

b24a21b7cd80d1cfceb53f95a6d817d5e38904cf