### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/SimpleMethodBindingExpression.java
+++ b/java/dagger/internal/codegen/SimpleMethodBindingExpression.java
@@ -99,9 +99,7 @@ final class SimpleMethodBindingExpression extends SimpleInvocationBindingExpress
         throw new IllegalStateException();
     }
 
-    return Expression.create(
-        provisionBinding.contributedPrimitiveType().orElse(provisionBinding.key().type()),
-        invocation);
+    return Expression.create(simpleMethodReturnType(), invocation);
   }
 
   private TypeName constructorTypeName(ClassName requestingClass) {
@@ -133,7 +131,7 @@ final class SimpleMethodBindingExpression extends SimpleInvocationBindingExpress
 
   private Expression injectMembers(CodeBlock instance) {
     if (provisionBinding.injectionSites().isEmpty()) {
-      return Expression.create(provisionBinding.key().type(), instance);
+      return Expression.create(simpleMethodReturnType(), instance);
     }
     // Java 7 type inference can't figure out that instance in
     // injectParameterized(Parameterized_Factory.newParameterized()) is Parameterized<T> and not
@@ -161,5 +159,9 @@ final class SimpleMethodBindingExpression extends SimpleInvocationBindingExpress
                 requirement ->
                     componentRequirementFields.getExpression(requirement, requestingClass))
         : Optional.empty();
+  }
+
+  private TypeMirror simpleMethodReturnType() {
+    return provisionBinding.contributedPrimitiveType().orElse(provisionBinding.key().type());
   }
 }

--- a/javatests/dagger/functional/multipackage/PrimitivesAcrossPackagesComponent.java
+++ b/javatests/dagger/functional/multipackage/PrimitivesAcrossPackagesComponent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2018 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.multipackage;
+
+import dagger.Component;
+import dagger.functional.multipackage.primitives.PrimitiveAcrossPackagesModule;
+import javax.inject.Provider;
+
+// b/77150738#comment11
+@Component(modules = PrimitiveAcrossPackagesModule.class)
+interface PrimitivesAcrossPackagesComponent {
+  boolean primitive();
+
+  Provider<Boolean> boxedPrimitive();
+}

--- a/javatests/dagger/functional/multipackage/primitives/PrimitiveAcrossPackagesModule.java
+++ b/javatests/dagger/functional/multipackage/primitives/PrimitiveAcrossPackagesModule.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2018 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.multipackage.primitives;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+public final class PrimitiveAcrossPackagesModule {
+  // This method should be package-private so that a proxy method is created
+  @Provides
+  static boolean primitive() {
+    return false;
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix the expression type for simple method invocations where injection methods are not used.

In Android Mode, Dagger was considering the type of the expression to be boxed, but in reality the expression was a regular primitive. This caused issues with SwitchingProviders, where the expression type must be boxed.

27352d519d043f327f26532baa846d711686395d