### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -206,6 +206,7 @@ java_library(
         "ProvisionDependencyOnProducerBindingValidation.java",
         "Validation.java",
     ],
+    tags = ["maven:merged"],
     deps = CODEGEN_DEPS + [
         ":base",
         ":binding",

--- a/java/dagger/producers/internal/Producers.java
+++ b/java/dagger/producers/internal/Producers.java
@@ -52,19 +52,23 @@ public final class Producers {
   // trigger one in a test.
   public static <T> ListenableFuture<Produced<T>> createFutureProduced(ListenableFuture<T> future) {
     return catchingAsync(
-        transform(
-            future,
-            new Function<T, Produced<T>>() {
-              @Override
-              public Produced<T> apply(final T value) {
-                return Produced.successful(value);
-              }
-            },
-            directExecutor()),
+        transform(future, Producers.<T>resultToProduced(), directExecutor()),
         Throwable.class,
         Producers.<T>futureFallbackForProduced(),
         directExecutor());
+  }
 
+  private static final Function<Object, Produced<Object>> RESULT_TO_PRODUCED =
+      new Function<Object, Produced<Object>>() {
+        @Override
+        public Produced<Object> apply(Object result) {
+          return Produced.successful(result);
+        }
+      };
+
+  @SuppressWarnings({"unchecked", "rawtypes"}) // bivariant implementation
+  private static <T> Function<T, Produced<T>> resultToProduced() {
+    return (Function) RESULT_TO_PRODUCED;
   }
 
   private static final AsyncFunction<Throwable, Produced<Object>> FUTURE_FALLBACK_FOR_PRODUCED =


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Don't consider :internal_validation to be its own library.

f015b359f59d5902d9c618c38b8ad022368bee28

-------

<p> Make the Function for wrapping an object as a Produced instance a singleton, like other similar functions in Producers.

674b094165c7cc2f937cd97db38472ca7b91c8ae