### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/android/ActivityKey.java
+++ b/java/dagger/android/ActivityKey.java
@@ -21,11 +21,13 @@ import static java.lang.annotation.ElementType.METHOD;
 import android.app.Activity;
 import dagger.MapKey;
 import dagger.internal.Beta;
+import java.lang.annotation.Documented;
 import java.lang.annotation.Target;
 
 /** {@link MapKey} annotation to key bindings by a type of an {@link Activity}. */
 @Beta
 @MapKey
+@Documented
 @Target(METHOD)
 public @interface ActivityKey {
   Class<? extends Activity> value();

--- a/java/dagger/android/BroadcastReceiverKey.java
+++ b/java/dagger/android/BroadcastReceiverKey.java
@@ -21,11 +21,13 @@ import static java.lang.annotation.ElementType.METHOD;
 import android.content.BroadcastReceiver;
 import dagger.MapKey;
 import dagger.internal.Beta;
+import java.lang.annotation.Documented;
 import java.lang.annotation.Target;
 
 /** {@link MapKey} annotation to key bindings by a type of a {@link BroadcastReceiver}. */
 @Beta
 @MapKey
+@Documented
 @Target(METHOD)
 public @interface BroadcastReceiverKey {
   Class<? extends BroadcastReceiver> value();

--- a/java/dagger/android/ContentProviderKey.java
+++ b/java/dagger/android/ContentProviderKey.java
@@ -21,11 +21,13 @@ import static java.lang.annotation.ElementType.METHOD;
 import android.content.ContentProvider;
 import dagger.MapKey;
 import dagger.internal.Beta;
+import java.lang.annotation.Documented;
 import java.lang.annotation.Target;
 
 /** {@link MapKey} annotation to key bindings by a type of a {@link ContentProvider}. */
 @Beta
 @MapKey
+@Documented
 @Target(METHOD)
 public @interface ContentProviderKey {
   Class<? extends ContentProvider> value();

--- a/java/dagger/android/FragmentKey.java
+++ b/java/dagger/android/FragmentKey.java
@@ -21,11 +21,13 @@ import static java.lang.annotation.ElementType.METHOD;
 import android.app.Fragment;
 import dagger.MapKey;
 import dagger.internal.Beta;
+import java.lang.annotation.Documented;
 import java.lang.annotation.Target;
 
 /** {@link MapKey} annotation to key bindings by a type of a {@link Fragment}. */
 @Beta
 @MapKey
+@Documented
 @Target(METHOD)
 public @interface FragmentKey {
   Class<? extends Fragment> value();

--- a/java/dagger/android/ServiceKey.java
+++ b/java/dagger/android/ServiceKey.java
@@ -21,11 +21,13 @@ import static java.lang.annotation.ElementType.METHOD;
 import android.app.Service;
 import dagger.MapKey;
 import dagger.internal.Beta;
+import java.lang.annotation.Documented;
 import java.lang.annotation.Target;
 
 /** {@link MapKey} annotation to key bindings by a type of a {@link Service}. */
 @Beta
 @MapKey
+@Documented
 @Target(METHOD)
 public @interface ServiceKey {
   Class<? extends Service> value();

--- a/java/dagger/android/support/FragmentKey.java
+++ b/java/dagger/android/support/FragmentKey.java
@@ -21,11 +21,13 @@ import static java.lang.annotation.ElementType.METHOD;
 import android.support.v4.app.Fragment;
 import dagger.MapKey;
 import dagger.internal.Beta;
+import java.lang.annotation.Documented;
 import java.lang.annotation.Target;
 
 /** {@link MapKey} annotation to key bindings by a type of a {@link Fragment}. */
 @Beta
 @MapKey
+@Documented
 @Target(METHOD)
 public @interface FragmentKey {
   Class<? extends Fragment> value();

--- a/java/dagger/internal/codegen/Scopes.java
+++ b/java/dagger/internal/codegen/Scopes.java
@@ -68,12 +68,9 @@ final class Scopes {
    *
    * <p>It's readable source because it has had common package prefixes removed, e.g.
    * {@code @javax.inject.Singleton} is returned as {@code @Singleton}.
-   *
-   * <p>Does not return any annotation values, since {@link javax.inject.Scope @Scope} annotations
-   * are not supposed to have any.
    */
   static String getReadableSource(Scope scope) {
-    return stripCommonTypePrefixes("@" + scope.scopeAnnotationElement().getQualifiedName());
+    return stripCommonTypePrefixes(scope.toString());
   }
 
   /** Returns all of the associated scopes for a source code element. */

--- a/javatests/dagger/internal/codegen/CanReleaseReferencesValidatorTest.java
+++ b/javatests/dagger/internal/codegen/CanReleaseReferencesValidatorTest.java
@@ -16,10 +16,10 @@
 
 package dagger.internal.codegen;
 
-import static com.google.common.truth.Truth.assertAbout;
-import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static dagger.internal.codegen.Compilers.daggerCompiler;
 
-import com.google.auto.value.processor.AutoAnnotationProcessor;
+import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
@@ -43,12 +43,8 @@ public final class CanReleaseReferencesValidatorTest {
             "@CanReleaseReferences",
             "@Retention(RetentionPolicy.SOURCE)",
             "@interface Metadata {}");
-    assertAbout(javaSource())
-        .that(annotation)
-        .processedWith(new ComponentProcessor(), new AutoAnnotationProcessor())
-        .failsToCompile()
-        .withErrorContaining("SOURCE")
-        .in(annotation)
-        .onLine(8);
+    Compilation compilation = daggerCompiler().compile(annotation);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining("SOURCE").inFile(annotation).onLine(8);
   }
 }

--- a/javatests/dagger/internal/codegen/Compilers.java
+++ b/javatests/dagger/internal/codegen/Compilers.java
@@ -25,6 +25,7 @@ import com.google.auto.value.processor.AutoAnnotationProcessor;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.testing.compile.Compiler;
+import javax.annotation.processing.Processor;
 
 /** {@link Compiler} instances for testing Dagger. */
 final class Compilers {
@@ -39,8 +40,14 @@ final class Compilers {
               .filter(jar -> !jar.contains(GUAVA))
               .collect(joining(PATH_SEPARATOR.value())));
 
-  /** Returns a compiler that runs the Dagger processor. */
-  static Compiler daggerCompiler() {
-    return javac().withProcessors(new ComponentProcessor(), new AutoAnnotationProcessor());
+  /**
+   * Returns a compiler that runs the Dagger and {@code @AutoAnnotation} processors, along with
+   * extras.
+   */
+  static Compiler daggerCompiler(Processor... extraProcessors) {
+    ImmutableList.Builder<Processor> processors = ImmutableList.builder();
+    processors.add(new ComponentProcessor(), new AutoAnnotationProcessor());
+    processors.add(extraProcessors);
+    return javac().withProcessors(processors.build());
   }
 }

--- a/javatests/dagger/internal/codegen/ComponentProcessorTest.java
+++ b/javatests/dagger/internal/codegen/ComponentProcessorTest.java
@@ -21,6 +21,7 @@ import static com.google.testing.compile.Compiler.javac;
 import static dagger.internal.codegen.CodeBlocks.stringLiteral;
 import static dagger.internal.codegen.CompilerMode.DEFAULT_MODE;
 import static dagger.internal.codegen.CompilerMode.EXPERIMENTAL_ANDROID_MODE;
+import static dagger.internal.codegen.Compilers.daggerCompiler;
 import static dagger.internal.codegen.GeneratedLines.GENERATED_ANNOTATION;
 import static dagger.internal.codegen.GeneratedLines.IMPORT_GENERATED_ANNOTATION;
 
@@ -29,10 +30,8 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.testing.compile.Compilation;
-import com.google.testing.compile.Compiler;
 import com.google.testing.compile.JavaFileObjects;
 import com.squareup.javapoet.CodeBlock;
 import dagger.MembersInjector;
@@ -2518,10 +2517,6 @@ public class ComponentProcessorTest {
     assertThat(compilation)
         .generatedSourceFile("test.DaggerParent")
         .containsElementsIn(expectedPattern);
-  }
-
-  private static Compiler daggerCompiler(Processor... extraProcessors) {
-    return javac().withProcessors(Lists.asList(new ComponentProcessor(), extraProcessors));
   }
 
   /**

--- a/javatests/dagger/internal/codegen/DaggerModuleMethodSubject.java
+++ b/javatests/dagger/internal/codegen/DaggerModuleMethodSubject.java
@@ -17,13 +17,15 @@
 package dagger.internal.codegen;
 
 import static com.google.common.truth.Truth.assertAbout;
-import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static dagger.internal.codegen.Compilers.daggerCompiler;
 
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.Subject;
 import com.google.common.truth.Truth;
+import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import dagger.Module;
 import dagger.producers.ProducerModule;
@@ -143,12 +145,12 @@ final class DaggerModuleMethodSubject extends Subject<DaggerModuleMethodSubject,
   void hasError(String errorSubstring) {
     String source = moduleSource();
     JavaFileObject module = JavaFileObjects.forSourceLines("test.TestModule", source);
-    assertAbout(javaSources())
-        .that(FluentIterable.from(additionalSources).append(module))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(errorSubstring)
-        .in(module)
+    Compilation compilation =
+        daggerCompiler().compile(FluentIterable.from(additionalSources).append(module));
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(errorSubstring)
+        .inFile(module)
         .onLine(methodLine(source));
   }
 

--- a/javatests/dagger/internal/codegen/ForReleasableReferencesValidatorTest.java
+++ b/javatests/dagger/internal/codegen/ForReleasableReferencesValidatorTest.java
@@ -16,10 +16,10 @@
 
 package dagger.internal.codegen;
 
-import static com.google.common.truth.Truth.assertAbout;
-import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static dagger.internal.codegen.Compilers.daggerCompiler;
 
-import com.google.common.collect.ImmutableList;
+import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
@@ -48,15 +48,14 @@ public class ForReleasableReferencesValidatorTest {
             "interface Injects {",
             "  @ForReleasableReferences(NotAScope.class) ReleasableReferenceManager manager();",
             "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(notAScope, injects))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
+    Compilation compilation = daggerCompiler().compile(notAScope, injects);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
             "The value of @ForReleasableReferences must be a reference-releasing scope. "
                 + "Did you mean to annotate test.NotAScope with @javax.inject.Scope and "
                 + "@dagger.releasablereferences.CanReleaseReferences?")
-        .in(injects)
+        .inFile(injects)
         .onLine(7)
         .atColumn(3);
   }
@@ -87,15 +86,14 @@ public class ForReleasableReferencesValidatorTest {
             "interface Injects {",
             "  @ForReleasableReferences(TestScope.class) ReleasableReferenceManager manager();",
             "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(testScope, injects))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
+    Compilation compilation = daggerCompiler().compile(testScope, injects);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
             "The value of @ForReleasableReferences must be a reference-releasing scope. "
                 + "Did you mean to annotate test.TestScope with "
                 + "@dagger.releasablereferences.CanReleaseReferences?")
-        .in(injects)
+        .inFile(injects)
         .onLine(7)
         .atColumn(3);
   }

--- a/javatests/dagger/internal/codegen/InjectConstructorFactoryGeneratorTest.java
+++ b/javatests/dagger/internal/codegen/InjectConstructorFactoryGeneratorTest.java
@@ -17,8 +17,10 @@
 package dagger.internal.codegen;
 
 import static com.google.common.truth.Truth.assertAbout;
+import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
+import static dagger.internal.codegen.Compilers.daggerCompiler;
 import static dagger.internal.codegen.ErrorMessages.ABSTRACT_INJECT_METHOD;
 import static dagger.internal.codegen.ErrorMessages.CHECKED_EXCEPTIONS_ON_CONSTRUCTORS;
 import static dagger.internal.codegen.ErrorMessages.FINAL_INJECT_FIELD;
@@ -39,6 +41,7 @@ import static dagger.internal.codegen.GeneratedLines.GENERATED_ANNOTATION;
 import static dagger.internal.codegen.GeneratedLines.IMPORT_GENERATED_ANNOTATION;
 
 import com.google.common.collect.ImmutableList;
+import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
@@ -86,10 +89,12 @@ public final class InjectConstructorFactoryGeneratorTest {
         "class PrivateConstructor {",
         "  @Inject private PrivateConstructor() {}",
         "}");
-    assertAbout(javaSource()).that(file)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(INJECT_ON_PRIVATE_CONSTRUCTOR).in(file).onLine(6);
+    Compilation compilation = daggerCompiler().compile(file);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(INJECT_ON_PRIVATE_CONSTRUCTOR)
+        .inFile(file)
+        .onLine(6);
   }
 
   @Test public void injectConstructorOnInnerClass() {
@@ -103,10 +108,12 @@ public final class InjectConstructorFactoryGeneratorTest {
         "    @Inject InnerClass() {}",
         "  }",
         "}");
-    assertAbout(javaSource()).that(file)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(INJECT_CONSTRUCTOR_ON_INNER_CLASS).in(file).onLine(7);
+    Compilation compilation = daggerCompiler().compile(file);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(INJECT_CONSTRUCTOR_ON_INNER_CLASS)
+        .inFile(file)
+        .onLine(7);
   }
 
   @Test public void injectConstructorOnAbstractClass() {
@@ -118,10 +125,12 @@ public final class InjectConstructorFactoryGeneratorTest {
         "abstract class AbstractClass {",
         "  @Inject AbstractClass() {}",
         "}");
-    assertAbout(javaSource()).that(file)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(INJECT_CONSTRUCTOR_ON_ABSTRACT_CLASS).in(file).onLine(6);
+    Compilation compilation = daggerCompiler().compile(file);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(INJECT_CONSTRUCTOR_ON_ABSTRACT_CLASS)
+        .inFile(file)
+        .onLine(6);
   }
 
   @Test public void injectConstructorOnGenericClass() {
@@ -544,11 +553,10 @@ public final class InjectConstructorFactoryGeneratorTest {
         "  TooManyInjectConstructors(int i) {}",
         "  @Inject TooManyInjectConstructors(String s) {}",
         "}");
-    assertAbout(javaSource()).that(file)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(MULTIPLE_INJECT_CONSTRUCTORS).in(file).onLine(6)
-        .and().withErrorContaining(MULTIPLE_INJECT_CONSTRUCTORS).in(file).onLine(8);
+    Compilation compilation = daggerCompiler().compile(file);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(MULTIPLE_INJECT_CONSTRUCTORS).inFile(file).onLine(6);
+    assertThat(compilation).hadErrorContaining(MULTIPLE_INJECT_CONSTRUCTORS).inFile(file).onLine(8);
   }
 
   @Test public void multipleQualifiersOnInjectConstructorParameter() {
@@ -560,10 +568,11 @@ public final class InjectConstructorFactoryGeneratorTest {
         "class MultipleQualifierConstructorParam {",
         "  @Inject MultipleQualifierConstructorParam(@QualifierA @QualifierB String s) {}",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(file, QUALIFIER_A, QUALIFIER_B))
-        .processedWith(new ComponentProcessor()).failsToCompile()
-        // for whatever reason, javac only reports the error once on the constructor
-        .withErrorContaining(MULTIPLE_QUALIFIERS).in(file).onLine(6);
+    Compilation compilation = daggerCompiler().compile(file, QUALIFIER_A, QUALIFIER_B);
+    assertThat(compilation).failed();
+
+    // for whatever reason, javac only reports the error once on the constructor
+    assertThat(compilation).hadErrorContaining(MULTIPLE_QUALIFIERS).inFile(file).onLine(6);
   }
 
   @Test public void injectConstructorOnClassWithMultipleScopes() {
@@ -575,10 +584,10 @@ public final class InjectConstructorFactoryGeneratorTest {
         "@ScopeA @ScopeB class MultipleScopeClass {",
         "  @Inject MultipleScopeClass() {}",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(file, SCOPE_A, SCOPE_B))
-        .processedWith(new ComponentProcessor()).failsToCompile()
-        .withErrorContaining(MULTIPLE_SCOPES).in(file).onLine(5).atColumn(1)
-        .and().withErrorContaining(MULTIPLE_SCOPES).in(file).onLine(5).atColumn(9);
+    Compilation compilation = daggerCompiler().compile(file, SCOPE_A, SCOPE_B);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(MULTIPLE_SCOPES).inFile(file).onLine(5).atColumn(1);
+    assertThat(compilation).hadErrorContaining(MULTIPLE_SCOPES).inFile(file).onLine(5).atColumn(9);
   }
 
   @Test public void injectConstructorWithQualifier() {
@@ -593,10 +602,16 @@ public final class InjectConstructorFactoryGeneratorTest {
         "  @QualifierB",
         "  MultipleScopeClass() {}",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(file, QUALIFIER_A, QUALIFIER_B))
-        .processedWith(new ComponentProcessor()).failsToCompile()
-        .withErrorContaining(QUALIFIER_ON_INJECT_CONSTRUCTOR).in(file).onLine(7)
-        .and().withErrorContaining(QUALIFIER_ON_INJECT_CONSTRUCTOR).in(file).onLine(8);
+    Compilation compilation = daggerCompiler().compile(file, QUALIFIER_A, QUALIFIER_B);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(QUALIFIER_ON_INJECT_CONSTRUCTOR)
+        .inFile(file)
+        .onLine(7);
+    assertThat(compilation)
+        .hadErrorContaining(QUALIFIER_ON_INJECT_CONSTRUCTOR)
+        .inFile(file)
+        .onLine(8);
   }
 
   @Test public void injectConstructorWithCheckedExceptionsError() {
@@ -608,9 +623,12 @@ public final class InjectConstructorFactoryGeneratorTest {
         "class CheckedExceptionClass {",
         "  @Inject CheckedExceptionClass() throws Exception {}",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(file))
-        .processedWith(new ComponentProcessor()).failsToCompile()
-        .withErrorContaining(CHECKED_EXCEPTIONS_ON_CONSTRUCTORS).in(file).onLine(6);
+    Compilation compilation = daggerCompiler().compile(file);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(CHECKED_EXCEPTIONS_ON_CONSTRUCTORS)
+        .inFile(file)
+        .onLine(6);
   }
 
   @Test public void injectConstructorWithCheckedExceptionsWarning() {
@@ -622,11 +640,13 @@ public final class InjectConstructorFactoryGeneratorTest {
         "class CheckedExceptionClass {",
         "  @Inject CheckedExceptionClass() throws Exception {}",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(file))
-        .withCompilerOptions("-Adagger.privateMemberValidation=WARNING")
-        .processedWith(new ComponentProcessor())
-        .compilesWithoutError()
-        .withWarningContaining(CHECKED_EXCEPTIONS_ON_CONSTRUCTORS).in(file).onLine(6);
+    Compilation compilation =
+        daggerCompiler().withOptions("-Adagger.privateMemberValidation=WARNING").compile(file);
+    assertThat(compilation).succeeded();
+    assertThat(compilation)
+        .hadWarningContaining(CHECKED_EXCEPTIONS_ON_CONSTRUCTORS)
+        .inFile(file)
+        .onLine(6);
   }
 
   @Test public void privateInjectClassError() {
@@ -640,11 +660,9 @@ public final class InjectConstructorFactoryGeneratorTest {
         "    @Inject InnerClass() {}",
         "  }",
         "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(file))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(INJECT_INTO_PRIVATE_CLASS).in(file).onLine(7);
+    Compilation compilation = daggerCompiler().compile(file);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(INJECT_INTO_PRIVATE_CLASS).inFile(file).onLine(7);
   }
 
   @Test public void privateInjectClassWarning() {
@@ -658,12 +676,10 @@ public final class InjectConstructorFactoryGeneratorTest {
         "    @Inject InnerClass() {}",
         "  }",
         "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(file))
-        .withCompilerOptions("-Adagger.privateMemberValidation=WARNING")
-        .processedWith(new ComponentProcessor())
-        .compilesWithoutError()
-        .withWarningContaining(INJECT_INTO_PRIVATE_CLASS).in(file).onLine(7);
+    Compilation compilation =
+        daggerCompiler().withOptions("-Adagger.privateMemberValidation=WARNING").compile(file);
+    assertThat(compilation).succeeded();
+    assertThat(compilation).hadWarningContaining(INJECT_INTO_PRIVATE_CLASS).inFile(file).onLine(7);
   }
 
   @Test public void nestedInPrivateInjectClassError() {
@@ -679,11 +695,9 @@ public final class InjectConstructorFactoryGeneratorTest {
         "    }",
         "  }",
         "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(file))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(INJECT_INTO_PRIVATE_CLASS).in(file).onLine(8);
+    Compilation compilation = daggerCompiler().compile(file);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(INJECT_INTO_PRIVATE_CLASS).inFile(file).onLine(8);
   }
 
   @Test public void nestedInPrivateInjectClassWarning() {
@@ -699,12 +713,10 @@ public final class InjectConstructorFactoryGeneratorTest {
         "    }",
         "  }",
         "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(file))
-        .withCompilerOptions("-Adagger.privateMemberValidation=WARNING")
-        .processedWith(new ComponentProcessor())
-        .compilesWithoutError()
-        .withWarningContaining(INJECT_INTO_PRIVATE_CLASS).in(file).onLine(8);
+    Compilation compilation =
+        daggerCompiler().withOptions("-Adagger.privateMemberValidation=WARNING").compile(file);
+    assertThat(compilation).succeeded();
+    assertThat(compilation).hadWarningContaining(INJECT_INTO_PRIVATE_CLASS).inFile(file).onLine(8);
   }
 
   @Test public void finalInjectField() {
@@ -716,10 +728,9 @@ public final class InjectConstructorFactoryGeneratorTest {
         "class FinalInjectField {",
         "  @Inject final String s;",
         "}");
-    assertAbout(javaSource()).that(file)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(FINAL_INJECT_FIELD).in(file).onLine(6);
+    Compilation compilation = daggerCompiler().compile(file);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(FINAL_INJECT_FIELD).inFile(file).onLine(6);
   }
 
   @Test public void privateInjectFieldError() {
@@ -731,10 +742,9 @@ public final class InjectConstructorFactoryGeneratorTest {
         "class PrivateInjectField {",
         "  @Inject private String s;",
         "}");
-    assertAbout(javaSource()).that(file)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(PRIVATE_INJECT_FIELD).in(file).onLine(6);
+    Compilation compilation = daggerCompiler().compile(file);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(PRIVATE_INJECT_FIELD).inFile(file).onLine(6);
   }
 
   @Test public void privateInjectFieldWarning() {
@@ -746,10 +756,9 @@ public final class InjectConstructorFactoryGeneratorTest {
         "class PrivateInjectField {",
         "  @Inject private String s;",
         "}");
-    assertAbout(javaSource()).that(file)
-        .withCompilerOptions("-Adagger.privateMemberValidation=WARNING")
-        .processedWith(new ComponentProcessor())
-        .compilesWithoutError(); // TODO: Verify warning message when supported
+    Compilation compilation =
+        daggerCompiler().withOptions("-Adagger.privateMemberValidation=WARNING").compile(file);
+    assertThat(compilation).succeeded(); // TODO: Verify warning message when supported
   }
 
   @Test public void staticInjectFieldError() {
@@ -761,10 +770,9 @@ public final class InjectConstructorFactoryGeneratorTest {
         "class StaticInjectField {",
         "  @Inject static String s;",
         "}");
-    assertAbout(javaSource()).that(file)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(STATIC_INJECT_FIELD).in(file).onLine(6);
+    Compilation compilation = daggerCompiler().compile(file);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(STATIC_INJECT_FIELD).inFile(file).onLine(6);
   }
 
   @Test public void staticInjectFieldWarning() {
@@ -776,10 +784,9 @@ public final class InjectConstructorFactoryGeneratorTest {
         "class StaticInjectField {",
         "  @Inject static String s;",
         "}");
-    assertAbout(javaSource()).that(file)
-        .withCompilerOptions("-Adagger.staticMemberValidation=WARNING")
-        .processedWith(new ComponentProcessor())
-        .compilesWithoutError(); // TODO: Verify warning message when supported
+    Compilation compilation =
+        daggerCompiler().withOptions("-Adagger.staticMemberValidation=WARNING").compile(file);
+    assertThat(compilation).succeeded(); // TODO: Verify warning message when supported
   }
 
   @Test public void multipleQualifiersOnField() {
@@ -791,10 +798,18 @@ public final class InjectConstructorFactoryGeneratorTest {
         "class MultipleQualifierInjectField {",
         "  @Inject @QualifierA @QualifierB String s;",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(file, QUALIFIER_A, QUALIFIER_B))
-        .processedWith(new ComponentProcessor()).failsToCompile()
-        .withErrorContaining(MULTIPLE_QUALIFIERS).in(file).onLine(6).atColumn(11)
-        .and().withErrorContaining(MULTIPLE_QUALIFIERS).in(file).onLine(6).atColumn(23);
+    Compilation compilation = daggerCompiler().compile(file, QUALIFIER_A, QUALIFIER_B);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(MULTIPLE_QUALIFIERS)
+        .inFile(file)
+        .onLine(6)
+        .atColumn(11);
+    assertThat(compilation)
+        .hadErrorContaining(MULTIPLE_QUALIFIERS)
+        .inFile(file)
+        .onLine(6)
+        .atColumn(23);
   }
 
   @Test public void abstractInjectMethod() {
@@ -806,10 +821,9 @@ public final class InjectConstructorFactoryGeneratorTest {
         "abstract class AbstractInjectMethod {",
         "  @Inject abstract void method();",
         "}");
-    assertAbout(javaSource()).that(file)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(ABSTRACT_INJECT_METHOD).in(file).onLine(6);
+    Compilation compilation = daggerCompiler().compile(file);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(ABSTRACT_INJECT_METHOD).inFile(file).onLine(6);
   }
 
   @Test public void privateInjectMethodError() {
@@ -821,10 +835,9 @@ public final class InjectConstructorFactoryGeneratorTest {
         "class PrivateInjectMethod {",
         "  @Inject private void method(){}",
         "}");
-    assertAbout(javaSource()).that(file)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(PRIVATE_INJECT_METHOD).in(file).onLine(6);
+    Compilation compilation = daggerCompiler().compile(file);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(PRIVATE_INJECT_METHOD).inFile(file).onLine(6);
   }
 
   @Test public void privateInjectMethodWarning() {
@@ -836,10 +849,9 @@ public final class InjectConstructorFactoryGeneratorTest {
         "class PrivateInjectMethod {",
         "  @Inject private void method(){}",
         "}");
-    assertAbout(javaSource()).that(file)
-        .withCompilerOptions("-Adagger.privateMemberValidation=WARNING")
-        .processedWith(new ComponentProcessor())
-        .compilesWithoutError(); // TODO: Verify warning message when supported
+    Compilation compilation =
+        daggerCompiler().withOptions("-Adagger.privateMemberValidation=WARNING").compile(file);
+    assertThat(compilation).succeeded(); // TODO: Verify warning message when supported
   }
 
   @Test public void staticInjectMethodError() {
@@ -851,10 +863,9 @@ public final class InjectConstructorFactoryGeneratorTest {
         "class StaticInjectMethod {",
         "  @Inject static void method(){}",
         "}");
-    assertAbout(javaSource()).that(file)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(STATIC_INJECT_METHOD).in(file).onLine(6);
+    Compilation compilation = daggerCompiler().compile(file);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(STATIC_INJECT_METHOD).inFile(file).onLine(6);
   }
 
   @Test public void staticInjectMethodWarning() {
@@ -866,10 +877,9 @@ public final class InjectConstructorFactoryGeneratorTest {
         "class StaticInjectMethod {",
         "  @Inject static void method(){}",
         "}");
-    assertAbout(javaSource()).that(file)
-        .withCompilerOptions("-Adagger.staticMemberValidation=WARNING")
-        .processedWith(new ComponentProcessor())
-        .compilesWithoutError(); // TODO: Verify warning message when supported
+    Compilation compilation =
+        daggerCompiler().withOptions("-Adagger.staticMemberValidation=WARNING").compile(file);
+    assertThat(compilation).succeeded(); // TODO: Verify warning message when supported
   }
 
   @Test public void genericInjectMethod() {
@@ -881,10 +891,9 @@ public final class InjectConstructorFactoryGeneratorTest {
         "class AbstractInjectMethod {",
         "  @Inject <T> void method();",
         "}");
-    assertAbout(javaSource()).that(file)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(GENERIC_INJECT_METHOD).in(file).onLine(6);
+    Compilation compilation = daggerCompiler().compile(file);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(GENERIC_INJECT_METHOD).inFile(file).onLine(6);
   }
 
   @Test public void multipleQualifiersOnInjectMethodParameter() {
@@ -896,11 +905,9 @@ public final class InjectConstructorFactoryGeneratorTest {
         "class MultipleQualifierMethodParam {",
         "  @Inject void method(@QualifierA @QualifierB String s) {}",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(file, QUALIFIER_A, QUALIFIER_B))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        // for whatever reason, javac only reports the error once on the method
-        .withErrorContaining(MULTIPLE_QUALIFIERS).in(file).onLine(6);
+    Compilation compilation = daggerCompiler().compile(file, QUALIFIER_A, QUALIFIER_B);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(MULTIPLE_QUALIFIERS).inFile(file).onLine(6);
   }
 
   @Test public void injectConstructorDependsOnProduced() {
@@ -913,10 +920,10 @@ public final class InjectConstructorFactoryGeneratorTest {
         "final class A {",
         "  @Inject A(Produced<String> str) {}",
         "}");
-    assertAbout(javaSource()).that(aFile)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining("Produced may only be injected in @Produces methods");
+    Compilation compilation = daggerCompiler().compile(aFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining("Produced may only be injected in @Produces methods");
   }
 
   @Test public void injectConstructorDependsOnProducer() {
@@ -929,10 +936,10 @@ public final class InjectConstructorFactoryGeneratorTest {
         "final class A {",
         "  @Inject A(Producer<String> str) {}",
         "}");
-    assertAbout(javaSource()).that(aFile)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining("Producer may only be injected in @Produces methods");
+    Compilation compilation = daggerCompiler().compile(aFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining("Producer may only be injected in @Produces methods");
   }
 
   @Test public void injectFieldDependsOnProduced() {
@@ -945,10 +952,10 @@ public final class InjectConstructorFactoryGeneratorTest {
         "final class A {",
         "  @Inject Produced<String> str;",
         "}");
-    assertAbout(javaSource()).that(aFile)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining("Produced may only be injected in @Produces methods");
+    Compilation compilation = daggerCompiler().compile(aFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining("Produced may only be injected in @Produces methods");
   }
 
   @Test public void injectFieldDependsOnProducer() {
@@ -961,10 +968,10 @@ public final class InjectConstructorFactoryGeneratorTest {
         "final class A {",
         "  @Inject Producer<String> str;",
         "}");
-    assertAbout(javaSource()).that(aFile)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining("Producer may only be injected in @Produces methods");
+    Compilation compilation = daggerCompiler().compile(aFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining("Producer may only be injected in @Produces methods");
   }
 
   @Test public void injectMethodDependsOnProduced() {
@@ -977,10 +984,10 @@ public final class InjectConstructorFactoryGeneratorTest {
         "final class A {",
         "  @Inject void inject(Produced<String> str) {}",
         "}");
-    assertAbout(javaSource()).that(aFile)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining("Produced may only be injected in @Produces methods");
+    Compilation compilation = daggerCompiler().compile(aFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining("Produced may only be injected in @Produces methods");
   }
 
   @Test public void injectMethodDependsOnProducer() {
@@ -993,10 +1000,10 @@ public final class InjectConstructorFactoryGeneratorTest {
         "final class A {",
         "  @Inject void inject(Producer<String> str) {}",
         "}");
-    assertAbout(javaSource()).that(aFile)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining("Producer may only be injected in @Produces methods");
+    Compilation compilation = daggerCompiler().compile(aFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining("Producer may only be injected in @Produces methods");
   }
 
   @Test public void injectConstructor() {

--- a/javatests/dagger/internal/codegen/MapBindingComponentProcessorTest.java
+++ b/javatests/dagger/internal/codegen/MapBindingComponentProcessorTest.java
@@ -16,13 +16,10 @@
 
 package dagger.internal.codegen;
 
-import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.CompilationSubject.assertThat;
-import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 import static dagger.internal.codegen.Compilers.daggerCompiler;
 import static dagger.internal.codegen.GeneratedLines.GENERATED_ANNOTATION;
 
-import com.google.common.collect.ImmutableList;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import java.util.Collection;
@@ -1127,18 +1124,13 @@ public class MapBindingComponentProcessorTest {
             "interface TestComponent {",
             "  Map<String, Object> objects();",
             "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(module, componentFile))
-        .withCompilerOptions(compilerMode.javacopts())
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining("The same map key is bound more than once")
-        .and()
-        .withErrorContaining("provideObjectForAKey()")
-        .and()
-        .withErrorContaining("provideObjectForAKeyAgain()")
-        .and()
-        .withErrorCount(1);
+    Compilation compilation =
+        daggerCompiler().withOptions(compilerMode.javacopts()).compile(module, componentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining("The same map key is bound more than once");
+    assertThat(compilation).hadErrorContaining("provideObjectForAKey()");
+    assertThat(compilation).hadErrorContaining("provideObjectForAKeyAgain()");
+    assertThat(compilation).hadErrorCount(1);
   }
 
   @Test
@@ -1186,17 +1178,14 @@ public class MapBindingComponentProcessorTest {
             "interface TestComponent {",
             "  Map<String, Object> objects();",
             "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(module, stringKeyTwoFile, componentFile))
-        .withCompilerOptions(compilerMode.javacopts())
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining("uses more than one @MapKey annotation type")
-        .and()
-        .withErrorContaining("provideObjectForAKey()")
-        .and()
-        .withErrorContaining("provideObjectForBKey()")
-        .and()
-        .withErrorCount(1);
+    Compilation compilation =
+        daggerCompiler()
+            .withOptions(compilerMode.javacopts())
+            .compile(module, stringKeyTwoFile, componentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining("uses more than one @MapKey annotation type");
+    assertThat(compilation).hadErrorContaining("provideObjectForAKey()");
+    assertThat(compilation).hadErrorContaining("provideObjectForBKey()");
+    assertThat(compilation).hadErrorCount(1);
   }
 }

--- a/javatests/dagger/internal/codegen/MissingBindingSuggestionsTest.java
+++ b/javatests/dagger/internal/codegen/MissingBindingSuggestionsTest.java
@@ -16,10 +16,10 @@
 
 package dagger.internal.codegen;
 
-import static com.google.common.truth.Truth.assertAbout;
-import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static dagger.internal.codegen.Compilers.daggerCompiler;
 
-import com.google.common.collect.ImmutableList;
+import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
@@ -91,12 +91,11 @@ public class MissingBindingSuggestionsTest {
         "  BarComponent getBar(BarModule barModule);",
         "}");
 
-    assertAbout(javaSources())
-        .that(ImmutableList.of(
-            fooComponent, barComponent, topComponent, foo, bar, barModule))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining("A binding with matching key exists in component: test.BarComponent");
+    Compilation compilation =
+        daggerCompiler().compile(fooComponent, barComponent, topComponent, foo, bar, barModule);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining("A binding with matching key exists in component: test.BarComponent");
   }
 
   @Test public void suggestsBindingInNestedSubcomponent() {
@@ -151,11 +150,11 @@ public class MissingBindingSuggestionsTest {
         "  BarComponent getBar();",
         "}");
 
-    assertAbout(javaSources())
-        .that(ImmutableList.of(
-            fooComponent, barComponent, bazComponent, topComponent, foo, baz, bazModule))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining("A binding with matching key exists in component: test.BazComponent");
+    Compilation compilation =
+        daggerCompiler()
+            .compile(fooComponent, barComponent, bazComponent, topComponent, foo, baz, bazModule);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining("A binding with matching key exists in component: test.BazComponent");
   }
 }

--- a/javatests/dagger/internal/codegen/ModuleValidatorTest.java
+++ b/javatests/dagger/internal/codegen/ModuleValidatorTest.java
@@ -17,7 +17,6 @@
 package dagger.internal.codegen;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
-import static com.google.testing.compile.JavaSourcesSubject.assertThat;
 import static dagger.internal.codegen.Compilers.daggerCompiler;
 import static dagger.internal.codegen.DaggerModuleMethodSubject.Factory.assertThatModuleMethod;
 
@@ -85,12 +84,12 @@ public final class ModuleValidatorTest {
     JavaFileObject notASubcomponent =
         JavaFileObjects.forSourceLines(
             "test.NotASubcomponent", "package test;", "", "class NotASubcomponent {}");
-    assertThat(module, notASubcomponent)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
+    Compilation compilation = daggerCompiler().compile(module, notASubcomponent);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
             "test.NotASubcomponent is not a @Subcomponent or @ProductionSubcomponent")
-        .in(module)
+        .inFile(module)
         .onLine(5);
   }
 
@@ -119,12 +118,12 @@ public final class ModuleValidatorTest {
             "    Sub build();",
             "  }",
             "}");
-    assertThat(module, subcomponent)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
+    Compilation compilation = daggerCompiler().compile(module, subcomponent);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
             "test.Sub.Builder is a @Subcomponent.Builder. Did you mean to use test.Sub?")
-        .in(module)
+        .inFile(module)
         .onLine(5);
   }
 
@@ -153,12 +152,12 @@ public final class ModuleValidatorTest {
             "    Sub build();",
             "  }",
             "}");
-    assertThat(module, subcomponent)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
+    Compilation compilation = daggerCompiler().compile(module, subcomponent);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
             "test.Sub.Builder is a @ProductionSubcomponent.Builder. Did you mean to use test.Sub?")
-        .in(module)
+        .inFile(module)
         .onLine(5);
   }
 
@@ -182,15 +181,15 @@ public final class ModuleValidatorTest {
             "",
             "@Subcomponent",
             "interface NoBuilder {}");
-    assertThat(module, subcomponent)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
+    Compilation compilation = daggerCompiler().compile(module, subcomponent);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
             "test.NoBuilder doesn't have a @Subcomponent.Builder, which is required when used "
                 + "with @"
                 + moduleType.simpleName()
                 + ".subcomponents")
-        .in(module)
+        .inFile(module)
         .onLine(5);
   }
 
@@ -214,15 +213,15 @@ public final class ModuleValidatorTest {
             "",
             "@ProductionSubcomponent",
             "interface NoBuilder {}");
-    assertThat(module, subcomponent)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
+    Compilation compilation = daggerCompiler().compile(module, subcomponent);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
             "test.NoBuilder doesn't have a @ProductionSubcomponent.Builder, which is required "
                 + "when used with @"
                 + moduleType.simpleName()
                 + ".subcomponents")
-        .in(module)
+        .inFile(module)
         .onLine(5);
   }
 
@@ -237,11 +236,11 @@ public final class ModuleValidatorTest {
             "",
             "@Module(subcomponents = int.class)",
             "class TestModule {}");
-    assertThat(module)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining("int is not a valid subcomponent type")
-        .in(module)
+    Compilation compilation = daggerCompiler().compile(module);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining("int is not a valid subcomponent type")
+        .inFile(module)
         .onLine(5);
   }
 

--- a/javatests/dagger/internal/codegen/MultibindingTest.java
+++ b/javatests/dagger/internal/codegen/MultibindingTest.java
@@ -17,7 +17,6 @@
 package dagger.internal.codegen;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
-import static com.google.testing.compile.JavaSourcesSubject.assertThat;
 import static dagger.internal.codegen.Compilers.daggerCompiler;
 
 import com.google.testing.compile.Compilation;
@@ -49,12 +48,12 @@ public class MultibindingTest {
             "  }",
             "}");
 
-    assertThat(module)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
+    Compilation compilation = daggerCompiler().compile(module);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
             "Multiple multibinding annotations cannot be placed on the same Provides method")
-        .in(module)
+        .inFile(module)
         .onLine(10);
   }
 
@@ -78,22 +77,22 @@ public class MultibindingTest {
             "  @IntoMap Map<Integer, Double> map();",
             "}");
 
-    assertThat(component)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
+    Compilation compilation = daggerCompiler().compile(component);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
             "Multibinding annotations may only be on @Provides, @Produces, or @Binds methods")
-        .in(component)
-        .onLine(11)
-        .and()
-        .withErrorContaining(
+        .inFile(component)
+        .onLine(11);
+    assertThat(compilation)
+        .hadErrorContaining(
             "Multibinding annotations may only be on @Provides, @Produces, or @Binds methods")
-        .in(component)
-        .onLine(12)
-        .and()
-        .withErrorContaining(
+        .inFile(component)
+        .onLine(12);
+    assertThat(compilation)
+        .hadErrorContaining(
             "Multibinding annotations may only be on @Provides, @Produces, or @Binds methods")
-        .in(component)
+        .inFile(component)
         .onLine(13);
   }
 

--- a/javatests/dagger/internal/codegen/MultipleRequestTest.java
+++ b/javatests/dagger/internal/codegen/MultipleRequestTest.java
@@ -16,10 +16,10 @@
 
 package dagger.internal.codegen;
 
-import static com.google.common.truth.Truth.assertAbout;
-import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static dagger.internal.codegen.Compilers.daggerCompiler;
 
-import com.google.common.collect.ImmutableList;
+import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
@@ -38,9 +38,9 @@ public class MultipleRequestTest {
       "}");
 
   @Test public void multipleRequests_constructor() {
-    assertAbout(javaSources())
-        .that(
-            ImmutableList.of(
+    Compilation compilation =
+        daggerCompiler()
+            .compile(
                 DEP_FILE,
                 JavaFileObjects.forSourceLines(
                     "test.ConstructorInjectsMultiple",
@@ -60,15 +60,14 @@ public class MultipleRequestTest {
                     "@Component",
                     "interface SimpleComponent {",
                     "  ConstructorInjectsMultiple get();",
-                    "}")))
-        .processedWith(new ComponentProcessor())
-        .compilesWithoutError();
+                    "}"));
+    assertThat(compilation).succeeded();
   }
 
   @Test public void multipleRequests_field() {
-    assertAbout(javaSources())
-        .that(
-            ImmutableList.of(
+    Compilation compilation =
+        daggerCompiler()
+            .compile(
                 DEP_FILE,
                 JavaFileObjects.forSourceLines(
                     "test.FieldInjectsMultiple",
@@ -90,15 +89,14 @@ public class MultipleRequestTest {
                     "@Component",
                     "interface SimpleComponent {",
                     "  FieldInjectsMultiple get();",
-                    "}")))
-        .processedWith(new ComponentProcessor())
-        .compilesWithoutError();
+                    "}"));
+    assertThat(compilation).succeeded();
   }
 
   @Test public void multipleRequests_providesMethod() {
-    assertAbout(javaSources())
-        .that(
-            ImmutableList.of(
+    Compilation compilation =
+        daggerCompiler()
+            .compile(
                 DEP_FILE,
                 JavaFileObjects.forSourceLines(
                     "test.FieldInjectsMultiple",
@@ -122,8 +120,7 @@ public class MultipleRequestTest {
                     "@Component(modules = SimpleModule.class)",
                     "interface SimpleComponent {",
                     "  Object get();",
-                    "}")))
-        .processedWith(new ComponentProcessor())
-        .compilesWithoutError();
+                    "}"));
+    assertThat(compilation).succeeded();
   }
 }

--- a/javatests/dagger/internal/codegen/ProductionGraphValidationTest.java
+++ b/javatests/dagger/internal/codegen/ProductionGraphValidationTest.java
@@ -16,12 +16,9 @@
 
 package dagger.internal.codegen;
 
-import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.CompilationSubject.assertThat;
-import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 import static dagger.internal.codegen.Compilers.daggerCompiler;
 
-import com.google.common.collect.ImmutableList;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import javax.tools.JavaFileObject;
@@ -78,14 +75,13 @@ public class ProductionGraphValidationTest {
         "    return null;",
         "  }",
         "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(EXECUTOR_MODULE, module, component))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
+    Compilation compilation = daggerCompiler().compile(EXECUTOR_MODULE, module, component);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
             "test.Bar cannot be provided without an @Inject constructor or an @Provides- or "
                 + "@Produces-annotated method.")
-        .in(component)
+        .inFile(component)
         .onLine(8);
   }
 
@@ -106,10 +102,9 @@ public class ProductionGraphValidationTest {
         "}");
     String expectedError =
         "test.TestClass.A cannot be provided without an @Provides- or @Produces-annotated method.";
-    assertAbout(javaSources()).that(ImmutableList.of(EXECUTOR_MODULE, component))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(expectedError).in(component).onLine(11);
+    Compilation compilation = daggerCompiler().compile(EXECUTOR_MODULE, component);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(expectedError).inFile(component).onLine(11);
   }
 
   @Test public void provisionDependsOnProduction() {
@@ -148,10 +143,9 @@ public class ProductionGraphValidationTest {
         "}");
     String expectedError =
         "test.TestClass.A is a provision, which cannot depend on a production.";
-    assertAbout(javaSources()).that(ImmutableList.of(EXECUTOR_MODULE, component))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(expectedError).in(component).onLine(30);
+    Compilation compilation = daggerCompiler().compile(EXECUTOR_MODULE, component);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(expectedError).inFile(component).onLine(30);
   }
 
   @Test public void provisionEntryPointDependsOnProduction() {
@@ -182,10 +176,9 @@ public class ProductionGraphValidationTest {
             "}");
     String expectedError =
         "test.TestClass.A is a provision entry-point, which cannot depend on a production.";
-    assertAbout(javaSources()).that(ImmutableList.of(EXECUTOR_MODULE, component))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(expectedError).in(component).onLine(20);
+    Compilation compilation = daggerCompiler().compile(EXECUTOR_MODULE, component);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(expectedError).inFile(component).onLine(20);
   }
 
   @Test
@@ -238,12 +231,11 @@ public class ProductionGraphValidationTest {
             "    ListenableFuture<B> b();",
             "  }",
             "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(EXECUTOR_MODULE, component))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining("test.TestClass.A is a provision, which cannot depend on a production")
-        .in(component)
+    Compilation compilation = daggerCompiler().compile(EXECUTOR_MODULE, component);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining("test.TestClass.A is a provision, which cannot depend on a production")
+        .inFile(component)
         .onLine(43);
   }
 
@@ -290,12 +282,9 @@ public class ProductionGraphValidationTest {
             "}");
     String expectedError =
         "test.TestClass.A cannot be provided without an @Provides-annotated method.";
-    assertAbout(javaSources()).that(ImmutableList.of(EXECUTOR_MODULE, component))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(expectedError)
-        .in(component)
-        .onLine(34);
+    Compilation compilation = daggerCompiler().compile(EXECUTOR_MODULE, component);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(expectedError).inFile(component).onLine(34);
   }
 
   @Test
@@ -346,12 +335,9 @@ public class ProductionGraphValidationTest {
         "java.util.Set<dagger.producers.monitoring.ProductionComponentMonitor.Factory>"
             + " test.TestClass.MonitoringModule#monitorFactory is a provision,"
             + " which cannot depend on a production.";
-    assertAbout(javaSources()).that(ImmutableList.of(EXECUTOR_MODULE, component))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(expectedError)
-        .in(component)
-        .onLine(37);
+    Compilation compilation = daggerCompiler().compile(EXECUTOR_MODULE, component);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(expectedError).inFile(component).onLine(37);
   }
 
   @Test
@@ -390,13 +376,9 @@ public class ProductionGraphValidationTest {
             "    return string;",
             "  }",
             "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(EXECUTOR_MODULE, component, module))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining("cycle")
-        .in(component)
-        .onLine(8);
+    Compilation compilation = daggerCompiler().compile(EXECUTOR_MODULE, component, module);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining("cycle").inFile(component).onLine(8);
   }
 
   @Test
@@ -436,13 +418,9 @@ public class ProductionGraphValidationTest {
             "    return string;",
             "  }",
             "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(EXECUTOR_MODULE, component, module))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining("cycle")
-        .in(component)
-        .onLine(8);
+    Compilation compilation = daggerCompiler().compile(EXECUTOR_MODULE, component, module);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining("cycle").inFile(component).onLine(8);
   }
   
   @Test

--- a/javatests/dagger/internal/codegen/RepeatedModuleValidationTest.java
+++ b/javatests/dagger/internal/codegen/RepeatedModuleValidationTest.java
@@ -16,10 +16,10 @@
 
 package dagger.internal.codegen;
 
-import static com.google.common.truth.Truth.assertAbout;
-import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static dagger.internal.codegen.Compilers.daggerCompiler;
 
-import com.google.common.collect.ImmutableList;
+import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
@@ -61,12 +61,12 @@ public class RepeatedModuleValidationTest {
             "interface TestComponent {",
             "  TestSubcomponent newTestSubcomponent(TestModule module);",
             "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(MODULE_FILE, subcomponentFile, componentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining("TestModule is present in test.TestComponent.")
-        .in(componentFile)
+    Compilation compilation =
+        daggerCompiler().compile(MODULE_FILE, subcomponentFile, componentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining("TestModule is present in test.TestComponent.")
+        .inFile(componentFile)
         .onLine(7)
         .atColumn(51);
   }
@@ -99,10 +99,9 @@ public class RepeatedModuleValidationTest {
             "interface TestComponent {",
             "  TestSubcomponent.Builder newTestSubcomponentBuilder();",
             "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(MODULE_FILE, subcomponentFile, componentFile))
-        .processedWith(new ComponentProcessor())
-        .compilesWithoutError();
+    Compilation compilation =
+        daggerCompiler().compile(MODULE_FILE, subcomponentFile, componentFile);
+    assertThat(compilation).succeeded();
     // TODO(gak): assert about the warning when we have that ability
   }
 
@@ -129,9 +128,8 @@ public class RepeatedModuleValidationTest {
             "interface TestComponent {",
             "  TestSubcomponent newTestSubcomponent();",
             "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(MODULE_FILE, subcomponentFile, componentFile))
-        .processedWith(new ComponentProcessor())
-        .compilesWithoutError();
+    Compilation compilation =
+        daggerCompiler().compile(MODULE_FILE, subcomponentFile, componentFile);
+    assertThat(compilation).succeeded();
   }
 }

--- a/javatests/dagger/internal/codegen/SubcomponentBuilderValidationTest.java
+++ b/javatests/dagger/internal/codegen/SubcomponentBuilderValidationTest.java
@@ -16,14 +16,10 @@
 
 package dagger.internal.codegen;
 
-import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.CompilationSubject.assertThat;
-import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
-import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 import static dagger.internal.codegen.Compilers.daggerCompiler;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import javax.tools.JavaFileObject;
@@ -63,12 +59,13 @@ public class SubcomponentBuilderValidationTest {
         "    ChildComponent build();",
         "  }",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(componentFile, childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(String.format(MSGS.moreThanOneRefToSubcomponent(),
-            "test.ChildComponent", "[child(), builder()]"))
-        .in(componentFile);
+    Compilation compilation = daggerCompiler().compile(componentFile, childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
+            String.format(
+                MSGS.moreThanOneRefToSubcomponent(), "test.ChildComponent", "[child(), builder()]"))
+        .inFile(componentFile);
   }
 
   @Test
@@ -96,12 +93,15 @@ public class SubcomponentBuilderValidationTest {
         "    ChildComponent build();",
         "  }",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(componentFile, childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(String.format(MSGS.moreThanOneRefToSubcomponent(),
-            "test.ChildComponent", "[builder1(), builder2()]"))
-        .in(componentFile);
+    Compilation compilation = daggerCompiler().compile(componentFile, childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
+            String.format(
+                MSGS.moreThanOneRefToSubcomponent(),
+                "test.ChildComponent",
+                "[builder1(), builder2()]"))
+        .inFile(componentFile);
   }
 
   @Test
@@ -133,12 +133,13 @@ public class SubcomponentBuilderValidationTest {
         "    ChildComponent build();",
         "  }",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(componentFile, childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(String.format(MSGS.moreThanOne(),
-            "[test.ChildComponent.Builder1, test.ChildComponent.Builder2]"))
-        .in(childComponentFile);
+    Compilation compilation = daggerCompiler().compile(componentFile, childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
+            String.format(
+                MSGS.moreThanOne(), "[test.ChildComponent.Builder1, test.ChildComponent.Builder2]"))
+        .inFile(childComponentFile);
   }
 
   @Test
@@ -165,11 +166,9 @@ public class SubcomponentBuilderValidationTest {
         "     ChildComponent build();",
         "  }",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(componentFile, childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(MSGS.generics())
-        .in(childComponentFile);
+    Compilation compilation = daggerCompiler().compile(componentFile, childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(MSGS.generics()).inFile(childComponentFile);
   }
 
   @Test
@@ -181,11 +180,9 @@ public class SubcomponentBuilderValidationTest {
         "",
         "@Subcomponent.Builder",
         "interface Builder {}");
-    assertAbout(javaSource()).that(builder)
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(MSGS.mustBeInComponent())
-        .in(builder);
+    Compilation compilation = daggerCompiler().compile(builder);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(MSGS.mustBeInComponent()).inFile(builder);
   }
 
   @Test
@@ -210,11 +207,11 @@ public class SubcomponentBuilderValidationTest {
         "  @Subcomponent.Builder",
         "  interface Builder {}",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(componentFile, childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(MSGS.missingBuildMethod())
-        .in(childComponentFile);
+    Compilation compilation = daggerCompiler().compile(componentFile, childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(MSGS.missingBuildMethod())
+        .inFile(childComponentFile);
   }
 
   @Test
@@ -229,11 +226,9 @@ public class SubcomponentBuilderValidationTest {
         "  @Subcomponent.Builder",
         "  private interface Builder {}",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(MSGS.isPrivate())
-        .in(childComponentFile);
+    Compilation compilation = daggerCompiler().compile(childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(MSGS.isPrivate()).inFile(childComponentFile);
   }
 
   @Test
@@ -248,11 +243,9 @@ public class SubcomponentBuilderValidationTest {
         "  @Subcomponent.Builder",
         "  abstract class Builder {}",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(MSGS.mustBeStatic())
-        .in(childComponentFile);
+    Compilation compilation = daggerCompiler().compile(childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(MSGS.mustBeStatic()).inFile(childComponentFile);
   }
 
   @Test
@@ -267,11 +260,9 @@ public class SubcomponentBuilderValidationTest {
         "  @Subcomponent.Builder",
         "  static class Builder {}",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(MSGS.mustBeAbstract())
-        .in(childComponentFile);
+    Compilation compilation = daggerCompiler().compile(childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining(MSGS.mustBeAbstract()).inFile(childComponentFile);
   }
 
   @Test
@@ -288,11 +279,11 @@ public class SubcomponentBuilderValidationTest {
         "    Builder(String unused) {}",
         "  }",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(MSGS.cxtorOnlyOneAndNoArgs())
-        .in(childComponentFile);
+    Compilation compilation = daggerCompiler().compile(childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(MSGS.cxtorOnlyOneAndNoArgs())
+        .inFile(childComponentFile);
   }
 
   @Test
@@ -310,11 +301,11 @@ public class SubcomponentBuilderValidationTest {
         "    Builder(String unused) {}",
         "  }",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(MSGS.cxtorOnlyOneAndNoArgs())
-        .in(childComponentFile);
+    Compilation compilation = daggerCompiler().compile(childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(MSGS.cxtorOnlyOneAndNoArgs())
+        .inFile(childComponentFile);
   }
 
   @Test
@@ -329,11 +320,11 @@ public class SubcomponentBuilderValidationTest {
         "  @Subcomponent.Builder",
         "  enum Builder {}",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(MSGS.mustBeClassOrInterface())
-        .in(childComponentFile);
+    Compilation compilation = daggerCompiler().compile(childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(MSGS.mustBeClassOrInterface())
+        .inFile(childComponentFile);
   }
 
   @Test
@@ -350,11 +341,12 @@ public class SubcomponentBuilderValidationTest {
         "    String build();",
         "  }",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(MSGS.buildMustReturnComponentType())
-            .in(childComponentFile).onLine(9);
+    Compilation compilation = daggerCompiler().compile(childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(MSGS.buildMustReturnComponentType())
+        .inFile(childComponentFile)
+        .onLine(9);
   }
 
   @Test
@@ -373,12 +365,12 @@ public class SubcomponentBuilderValidationTest {
         "  @Subcomponent.Builder",
         "  interface Builder extends Parent {}",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
-            String.format(MSGS.inheritedBuildMustReturnComponentType(), "build"))
-            .in(childComponentFile).onLine(12);
+    Compilation compilation = daggerCompiler().compile(childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(String.format(MSGS.inheritedBuildMustReturnComponentType(), "build"))
+        .inFile(childComponentFile)
+        .onLine(12);
   }
 
   @Test
@@ -396,11 +388,12 @@ public class SubcomponentBuilderValidationTest {
         "    ChildComponent create();",
         "  }",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(String.format(MSGS.twoBuildMethods(), "build()"))
-            .in(childComponentFile).onLine(10);
+    Compilation compilation = daggerCompiler().compile(childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(String.format(MSGS.twoBuildMethods(), "build()"))
+        .inFile(childComponentFile)
+        .onLine(10);
   }
 
   @Test
@@ -420,12 +413,12 @@ public class SubcomponentBuilderValidationTest {
         "  @Subcomponent.Builder",
         "  interface Builder extends Parent {}",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
-            String.format(MSGS.inheritedTwoBuildMethods(), "build()", "create()"))
-            .in(childComponentFile).onLine(13);
+    Compilation compilation = daggerCompiler().compile(childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(String.format(MSGS.inheritedTwoBuildMethods(), "build()", "create()"))
+        .inFile(childComponentFile)
+        .onLine(13);
   }
 
   @Test
@@ -444,13 +437,16 @@ public class SubcomponentBuilderValidationTest {
         "    Builder set(Number n, Double d);",
         "  }",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(MSGS.methodsMustTakeOneArg())
-            .in(childComponentFile).onLine(10)
-        .and().withErrorContaining(MSGS.methodsMustTakeOneArg())
-            .in(childComponentFile).onLine(11);
+    Compilation compilation = daggerCompiler().compile(childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(MSGS.methodsMustTakeOneArg())
+        .inFile(childComponentFile)
+        .onLine(10);
+    assertThat(compilation)
+        .hadErrorContaining(MSGS.methodsMustTakeOneArg())
+        .inFile(childComponentFile)
+        .onLine(11);
   }
 
   @Test
@@ -470,13 +466,14 @@ public class SubcomponentBuilderValidationTest {
         "  @Subcomponent.Builder",
         "  interface Builder extends Parent {}",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
-            String.format(MSGS.inheritedMethodsMustTakeOneArg(),
-                "set1(java.lang.String,java.lang.Integer)"))
-            .in(childComponentFile).onLine(13);
+    Compilation compilation = daggerCompiler().compile(childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
+            String.format(
+                MSGS.inheritedMethodsMustTakeOneArg(), "set1(java.lang.String,java.lang.Integer)"))
+        .inFile(childComponentFile)
+        .onLine(13);
   }
 
   @Test
@@ -494,11 +491,12 @@ public class SubcomponentBuilderValidationTest {
         "    String set(Integer i);",
         "  }",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(MSGS.methodsMustReturnVoidOrBuilder())
-            .in(childComponentFile).onLine(10);
+    Compilation compilation = daggerCompiler().compile(childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(MSGS.methodsMustReturnVoidOrBuilder())
+        .inFile(childComponentFile)
+        .onLine(10);
   }
 
   @Test
@@ -518,13 +516,13 @@ public class SubcomponentBuilderValidationTest {
         "  @Subcomponent.Builder",
         "  interface Builder extends Parent {}",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
-            String.format(MSGS.inheritedMethodsMustReturnVoidOrBuilder(),
-                "set(java.lang.Integer)"))
-            .in(childComponentFile).onLine(13);
+    Compilation compilation = daggerCompiler().compile(childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
+            String.format(MSGS.inheritedMethodsMustReturnVoidOrBuilder(), "set(java.lang.Integer)"))
+        .inFile(childComponentFile)
+        .onLine(13);
   }
 
   @Test
@@ -542,11 +540,12 @@ public class SubcomponentBuilderValidationTest {
         "    <T> Builder set(T t);",
         "  }",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(MSGS.methodsMayNotHaveTypeParameters())
-            .in(childComponentFile).onLine(10);
+    Compilation compilation = daggerCompiler().compile(childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(MSGS.methodsMayNotHaveTypeParameters())
+        .inFile(childComponentFile)
+        .onLine(10);
   }
 
   @Test
@@ -566,12 +565,13 @@ public class SubcomponentBuilderValidationTest {
         "  @Subcomponent.Builder",
         "  interface Builder extends Parent {}",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
+    Compilation compilation = daggerCompiler().compile(childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
             String.format(MSGS.inheritedMethodsMayNotHaveTypeParameters(), "<T>set(T)"))
-            .in(childComponentFile).onLine(13);
+        .inFile(childComponentFile)
+        .onLine(13);
   }
 
   @Test
@@ -617,16 +617,16 @@ public class SubcomponentBuilderValidationTest {
             "    void set2(TestModule s);",
             "  }",
             "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(moduleFile, componentFile, childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
+    Compilation compilation =
+        daggerCompiler().compile(moduleFile, componentFile, childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
             String.format(
                 MSGS.manyMethodsForType(),
                 "test.TestModule",
                 "[set1(test.TestModule), set2(test.TestModule)]"))
-        .in(childComponentFile)
+        .inFile(childComponentFile)
         .onLine(10);
   }
 
@@ -676,14 +676,14 @@ public class SubcomponentBuilderValidationTest {
             "    void set2(TestModule s);",
             "  }",
             "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(moduleFile, componentFile, childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
+    Compilation compilation =
+        daggerCompiler().compile(moduleFile, componentFile, childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
             String.format(
                 MSGS.manyMethodsForType(), "test.TestModule", "[set1(T), set2(test.TestModule)]"))
-        .in(childComponentFile)
+        .inFile(childComponentFile)
         .onLine(14);
   }
 
@@ -758,14 +758,16 @@ public class SubcomponentBuilderValidationTest {
         "    void set2(Integer s);",
         "  }",
         "}");
-    assertAbout(javaSources()).that(ImmutableList.of(componentFile, childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
-            String.format(MSGS.extraSetters(),
-                  "[void test.ChildComponent.Builder.set1(String),"
-                  + " void test.ChildComponent.Builder.set2(Integer)]"))
-            .in(childComponentFile).onLine(8);
+    Compilation compilation = daggerCompiler().compile(componentFile, childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
+            String.format(
+                MSGS.extraSetters(),
+                "[void test.ChildComponent.Builder.set1(String),"
+                    + " void test.ChildComponent.Builder.set2(Integer)]"))
+        .inFile(childComponentFile)
+        .onLine(8);
   }
 
   @Test
@@ -827,19 +829,17 @@ public class SubcomponentBuilderValidationTest {
         "    ChildComponent create();",
         "  }",
         "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(moduleFile,
-            module2File,
-            module3File,
-            componentFile,
-            childComponentFile))
-        .processedWith(new ComponentProcessor())
-        .failsToCompile()
-        .withErrorContaining(
+    Compilation compilation =
+        daggerCompiler()
+            .compile(moduleFile, module2File, module3File, componentFile, childComponentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
             // Ignores Test2Module because we can construct it ourselves.
             // TODO(sameb): Ignore Test3Module because it's not used within transitive dependencies.
             String.format(MSGS.missingSetters(), "[test.TestModule, test.Test3Module]"))
-            .in(childComponentFile).onLine(11);
+        .inFile(childComponentFile)
+        .onLine(11);
   }
 
   @Test

--- a/util/deploy-to-maven-central.sh
+++ b/util/deploy-to-maven-central.sh
@@ -20,16 +20,6 @@ if [[ "$version_name" =~ " " ]]; then
   exit 3
 fi
 
-#validate key
-keystatus=$(gpg --list-keys | grep ${key} | awk '{print $1}')
-if [ "${keystatus}" != "pub" ]; then
-  echo "Could not find public key with label ${key}"
-  echo -n "Available keys from: "
-  gpg --list-keys | grep --invert-match '^sub'
-
-  exit 64
-fi
-
 bazel test //...
 
 bash $(dirname $0)/execute-deploy.sh \
@@ -60,4 +50,5 @@ for generated_pom_file in dagger*pom.xml; do
   rm "${generated_pom_file}.asc"
 done
 
-
+git tag dagger-"${version_name}"
+git push --tags origin master


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Some release script updates:

- don't validate the gpg key. We were relying on text formats in a way that was explicitly unsupported by gpg, and in fact did change :)
- add a tag at the end of the release

069ed2e30275b42417b4cc9304ef5637a9e6c310

-------

<p> Use CompilationSubject instead of JavaSourcesSubject.

A few related cleanups: merge the two static daggerCompiler() methods into one, and use it throughout.

Cleanup change automatically generated by error-prone refactoring third_party/java_src/compile_testing/java/com/google/testing/compile/refactor:JavaSourcesSubjectToCompilationSubject on targets third_party/java_src/dagger/project/javatests/dagger/internal/codegen:all

a1ee6ffd09c417fb83eae288aefa79d43e89795d

-------

<p> Use scope annotation values in error messages

Even though JSR 330 says that scopes shouldn't have annotation values, there isn't a clear reason for Dagger to enforce this. We support scopes with members already - our error messages should reflect that.

Fixes https://github.com/google/dagger/issues/1160

RELNOTES=Fixes a bug where scope annotations in error messages were missing annotation attributes

0e1fb959e373f6a05fbf58e89a0d275775140857

-------

<p> Mark dagger.android map keys as @Documented

a0b3dcda9dc3e7b93248bf0b90a8d7a40c358884