### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/ProducesMethodValidator.java
+++ b/java/dagger/internal/codegen/ProducesMethodValidator.java
@@ -56,7 +56,6 @@ final class ProducesMethodValidator extends BindingMethodValidator {
   protected void checkMethod(ValidationReport.Builder<ExecutableElement> builder) {
     super.checkMethod(builder);
     checkNullable(builder);
-    checkScope(builder);
   }
 
   /** Adds a warning if a {@link Produces @Produces} method is declared nullable. */
@@ -68,7 +67,8 @@ final class ProducesMethodValidator extends BindingMethodValidator {
   }
 
   /** Adds an error if a {@link Produces @Produces} method has a scope annotation. */
-  private void checkScope(ValidationReport.Builder<ExecutableElement> builder) {
+  @Override
+  protected void checkScopes(ValidationReport.Builder<ExecutableElement> builder) {
     if (!scopesOf(builder.getSubject()).isEmpty()) {
       builder.addError("@Produces methods may not have scope annotations");
     }

--- a/javatests/dagger/functional/BasicTest.java
+++ b/javatests/dagger/functional/BasicTest.java
@@ -56,8 +56,8 @@ public class BasicTest {
     assertThat(basicComponent.getInt()).isEqualTo(BOUND_INT);
     assertThat(basicComponent.getLong()).isEqualTo(BOUND_LONG);
     assertThat(basicComponent.getBoolean()).isEqualTo(BOUND_BOOLEAN);
-    assertThat(basicComponent.getFloat()).isWithin(0).of(BOUND_FLOAT);
-    assertThat(basicComponent.getDouble()).isWithin(0).of(BOUND_DOUBLE);
+    assertThat(basicComponent.getFloat()).isEqualTo(BOUND_FLOAT);
+    assertThat(basicComponent.getDouble()).isEqualTo(BOUND_DOUBLE);
   }
 
   @Theory public void boxedPrimitives(BasicComponent basicComponent) {
@@ -67,8 +67,8 @@ public class BasicTest {
     assertThat(basicComponent.getBoxedInt()).isEqualTo(new Integer(BOUND_INT));
     assertThat(basicComponent.getBoxedLong()).isEqualTo(new Long(BOUND_LONG));
     assertThat(basicComponent.getBoxedBoolean()).isEqualTo(new Boolean(BOUND_BOOLEAN));
-    assertThat(basicComponent.getBoxedFloat()).isWithin(0).of(BOUND_FLOAT);
-    assertThat(basicComponent.getBoxedDouble()).isWithin(0).of(BOUND_DOUBLE);
+    assertThat(basicComponent.getBoxedFloat()).isEqualTo(BOUND_FLOAT);
+    assertThat(basicComponent.getBoxedDouble()).isEqualTo(BOUND_DOUBLE);
   }
 
   @Theory public void boxedPrimitiveProviders(BasicComponent basicComponent) {
@@ -78,8 +78,8 @@ public class BasicTest {
     assertThat(basicComponent.getIntProvider().get()).isEqualTo(new Integer(BOUND_INT));
     assertThat(basicComponent.getLongProvider().get()).isEqualTo(new Long(BOUND_LONG));
     assertThat(basicComponent.getBooleanProvider().get()).isEqualTo(new Boolean(BOUND_BOOLEAN));
-    assertThat(basicComponent.getFloatProvider().get()).isWithin(0).of(BOUND_FLOAT);
-    assertThat(basicComponent.getDoubleProvider().get()).isWithin(0).of(BOUND_DOUBLE);
+    assertThat(basicComponent.getFloatProvider().get()).isEqualTo(BOUND_FLOAT);
+    assertThat(basicComponent.getDoubleProvider().get()).isEqualTo(BOUND_DOUBLE);
   }
 
   @Theory public void primitiveArrays(BasicComponent basicComponent) {

--- a/javatests/dagger/functional/builder/BuilderTest.java
+++ b/javatests/dagger/functional/builder/BuilderTest.java
@@ -45,8 +45,8 @@ public class BuilderTest {
     TestComponentWithBuilderInterface component = builder.build();
     assertThat(component.s()).isEqualTo("sam");
     assertThat(component.i()).isEqualTo(1);
-    assertThat(component.d()).isWithin(0).of(4.2d);
-    assertThat(component.f()).isWithin(0).of(5.5f);
+    assertThat(component.d()).isEqualTo(4.2d);
+    assertThat(component.f()).isEqualTo(5.5f);
     assertThat(component.l()).isEqualTo(6L);
   }
 
@@ -69,8 +69,8 @@ public class BuilderTest {
     TestComponentWithBuilderAbstractClass component = builder.build();
     assertThat(component.s()).isEqualTo("sam");
     assertThat(component.i()).isEqualTo(1);
-    assertThat(component.d()).isWithin(0).of(4.2d);
-    assertThat(component.f()).isWithin(0).of(5.5f);
+    assertThat(component.d()).isEqualTo(4.2d);
+    assertThat(component.f()).isEqualTo(5.5f);
     assertThat(component.l()).isEqualTo(6L);
   }
 
@@ -93,8 +93,8 @@ public class BuilderTest {
     TestComponentWithGenericBuilderInterface component = builder.build();
     assertThat(component.s()).isEqualTo("sam");
     assertThat(component.i()).isEqualTo(1);
-    assertThat(component.d()).isWithin(0).of(4.2d);
-    assertThat(component.f()).isWithin(0).of(5.5f);
+    assertThat(component.d()).isEqualTo(4.2d);
+    assertThat(component.f()).isEqualTo(5.5f);
     assertThat(component.l()).isEqualTo(6L);
   }
 
@@ -117,8 +117,8 @@ public class BuilderTest {
     TestComponentWithGenericBuilderAbstractClass component = builder.build();
     assertThat(component.s()).isEqualTo("sam");
     assertThat(component.i()).isEqualTo(1);
-    assertThat(component.d()).isWithin(0).of(4.2d);
-    assertThat(component.f()).isWithin(0).of(5.5f);
+    assertThat(component.d()).isEqualTo(4.2d);
+    assertThat(component.f()).isEqualTo(5.5f);
     assertThat(component.l()).isEqualTo(6L);
   }
   
@@ -137,8 +137,8 @@ public class BuilderTest {
     TestChildComponentWithBuilderInterface child1 = builder1.build();
     assertThat(child1.s()).isEqualTo("sam");
     assertThat(child1.i()).isEqualTo(1);
-    assertThat(child1.d()).isWithin(0).of(4.2d);
-    assertThat(child1.f()).isWithin(0).of(5.5f);
+    assertThat(child1.d()).isEqualTo(4.2d);
+    assertThat(child1.f()).isEqualTo(5.5f);
     assertThat(child1.l()).isEqualTo(6L);
     assertThat(child1.b()).isEqualTo((byte)7);
   }
@@ -159,8 +159,8 @@ public class BuilderTest {
     TestChildComponentWithBuilderAbstractClass child2 = builder2.build();
     assertThat(child2.s()).isEqualTo("tara");
     assertThat(child2.i()).isEqualTo(10);
-    assertThat(child2.d()).isWithin(0).of(4.2d);
-    assertThat(child2.f()).isWithin(0).of(5.5f);
+    assertThat(child2.d()).isEqualTo(4.2d);
+    assertThat(child2.f()).isEqualTo(5.5f);
     assertThat(child2.l()).isEqualTo(6L);
     assertThat(child2.b()).isEqualTo((byte)70);
   }

--- a/javatests/dagger/functional/producers/badexecutor/BadExecutorTest.java
+++ b/javatests/dagger/functional/producers/badexecutor/BadExecutorTest.java
@@ -86,6 +86,6 @@ public final class BadExecutorTest {
 
   @Test
   public void doNotRejectComponentDepMethod() throws Exception {
-    assertThat(component.doubleDep().get()).isWithin(0).of(42.0);
+    assertThat(component.doubleDep().get()).isEqualTo(42.0);
   }
 }

--- a/javatests/dagger/functional/producers/builder/ProductionComponentBuilderTest.java
+++ b/javatests/dagger/functional/producers/builder/ProductionComponentBuilderTest.java
@@ -36,7 +36,7 @@ public final class ProductionComponentBuilderTest {
             .strModule(new StringModule())
             .build();
     assertThat(component.s().get()).isEqualTo("arg: 42");
-    assertThat(component.d().get()).isWithin(0).of(15.3);
+    assertThat(component.d().get()).isEqualTo(15.3);
   }
 
   @Test
@@ -46,7 +46,7 @@ public final class ProductionComponentBuilderTest {
             .depComponent(depComponent(15.3))
             .build();
     assertThat(component.s().get()).isEqualTo("arg: 42");
-    assertThat(component.d().get()).isWithin(0).of(15.3);
+    assertThat(component.d().get()).isEqualTo(15.3);
   }
 
   @Test(expected = IllegalStateException.class)

--- a/javatests/dagger/internal/codegen/ModuleFactoryGeneratorTest.java
+++ b/javatests/dagger/internal/codegen/ModuleFactoryGeneratorTest.java
@@ -380,21 +380,6 @@ public class ModuleFactoryGeneratorTest {
         .and().generatesSources(factoryFile);
   }
 
-  private static final JavaFileObject QUALIFIER_A =
-      JavaFileObjects.forSourceLines("test.QualifierA",
-          "package test;",
-          "",
-          "import javax.inject.Qualifier;",
-          "",
-          "@Qualifier @interface QualifierA {}");
-  private static final JavaFileObject QUALIFIER_B =
-      JavaFileObjects.forSourceLines("test.QualifierB",
-          "package test;",
-          "",
-          "import javax.inject.Qualifier;",
-          "",
-          "@Qualifier @interface QualifierB {}");
-
   @Test public void multipleProvidesMethods() {
     JavaFileObject classXFile = JavaFileObjects.forSourceLines("test.X",
         "package test;",
@@ -1298,6 +1283,24 @@ public class ModuleFactoryGeneratorTest {
             provideNonGenericTypeWithDepsFactory);
   }
 
+  private static final JavaFileObject QUALIFIER_A =
+      JavaFileObjects.forSourceLines(
+          "test.QualifierA",
+          "package test;",
+          "",
+          "import javax.inject.Qualifier;",
+          "",
+          "@Qualifier @interface QualifierA {}");
+
+  private static final JavaFileObject QUALIFIER_B =
+      JavaFileObjects.forSourceLines(
+          "test.QualifierB",
+          "package test;",
+          "",
+          "import javax.inject.Qualifier;",
+          "",
+          "@Qualifier @interface QualifierB {}");
+
   @Test public void providesMethodMultipleQualifiers() {
     JavaFileObject moduleFile = JavaFileObjects.forSourceLines("test.TestModule",
         "package test;",
@@ -1316,6 +1319,55 @@ public class ModuleFactoryGeneratorTest {
     Compilation compilation = daggerCompiler().compile(moduleFile, QUALIFIER_A, QUALIFIER_B);
     assertThat(compilation).failed();
     assertThat(compilation).hadErrorContaining("Cannot use more than one @Qualifier");
+  }
+
+  private static final JavaFileObject SCOPE_A =
+      JavaFileObjects.forSourceLines(
+          "test.ScopeA",
+          "package test;",
+          "",
+          "import javax.inject.Scope;",
+          "",
+          "@Scope @interface ScopeA {}");
+
+  private static final JavaFileObject SCOPE_B =
+      JavaFileObjects.forSourceLines(
+          "test.ScopeB",
+          "package test;",
+          "",
+          "import javax.inject.Scope;",
+          "",
+          "@Scope @interface ScopeB {}");
+
+  @Test
+  public void providesMethodMultipleScopes() {
+    JavaFileObject moduleFile =
+        JavaFileObjects.forSourceLines(
+            "test.TestModule",
+            "package test;",
+            "",
+            "import dagger.Module;",
+            "import dagger.Provides;",
+            "",
+            "@Module",
+            "final class TestModule {",
+            "  @Provides",
+            "  @ScopeA",
+            "  @ScopeB",
+            "  String provideString() {",
+            "    return \"foo\";",
+            "  }",
+            "}");
+    Compilation compilation = daggerCompiler().compile(moduleFile, SCOPE_A, SCOPE_B);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining("Cannot use more than one @Scope")
+        .inFile(moduleFile)
+        .onLineContaining("@ScopeA");
+    assertThat(compilation)
+        .hadErrorContaining("Cannot use more than one @Scope")
+        .inFile(moduleFile)
+        .onLineContaining("@ScopeB");
   }
 
   @Test public void providerDependsOnProduced() {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Replace isWithin(0).of(..) with isEqualTo(..) or isZero().

And likewise for isNotWithin. isEqualTo is no longer deprecated for floating point types, and is a more readable way to assert equality.

c660ec6a12e7077cf44a6baeee503bd09b460f8b

-------

<p> Report an error for binding methods that have more than one scope annotation, instead of throwing an exception.

RELNOTES=Report an error for binding methods that have more than one scope annotation, instead of throwing an exception.

708b415ba3a24e1b6bed8ee97d57deef43cd9f12