### PR TITLE
Add DaggerFragmentActivity

### DIFF
--- a/java/dagger/android/support/DaggerFragmentActivity.java
+++ b/java/dagger/android/support/DaggerFragmentActivity.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2017 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.android.support;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+import dagger.android.AndroidInjection;
+import dagger.android.AndroidInjector;
+import dagger.android.DispatchingAndroidInjector;
+import dagger.android.HasFragmentInjector;
+import dagger.internal.Beta;
+import javax.inject.Inject;
+
+/**
+ * An {@link FragmentActivity} that injects its members in {@link #onCreate(Bundle)} and can be
+ * used to inject {@code Fragment}s attached to it.
+ */
+@Beta
+public abstract class DaggerFragmentActivity extends FragmentActivity
+    implements HasFragmentInjector, HasSupportFragmentInjector {
+
+  @Inject DispatchingAndroidInjector<Fragment> supportFragmentInjector;
+  @Inject DispatchingAndroidInjector<android.app.Fragment> frameworkFragmentInjector;
+
+  @Override
+  protected void onCreate(@Nullable Bundle savedInstanceState) {
+    AndroidInjection.inject(this);
+    super.onCreate(savedInstanceState);
+  }
+
+  @Override
+  public AndroidInjector<Fragment> supportFragmentInjector() {
+    return supportFragmentInjector;
+  }
+
+  @Override
+  public AndroidInjector<android.app.Fragment> fragmentInjector() {
+    return frameworkFragmentInjector;
+  }
+}


### PR DESCRIPTION
There are some cases, mostly for AndroidTV, where you don't want `AppCompatActivity` but do need to use support fragments. Partially because the framework fragments are now deprecated in P.

This class is just a copy of `DaggerAppCompatActivity`, but extends `FragmentActivity` instead 