### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/BindsOptionalOfMethodValidator.java
+++ b/java/dagger/internal/codegen/BindsOptionalOfMethodValidator.java
@@ -22,12 +22,14 @@ import static dagger.internal.codegen.BindingMethodValidator.ExceptionSuperclass
 import static dagger.internal.codegen.InjectionAnnotations.getQualifiers;
 import static dagger.internal.codegen.InjectionAnnotations.injectedConstructors;
 import static dagger.internal.codegen.Keys.isValidImplicitProvisionKey;
+import static dagger.internal.codegen.Scopes.scopesOf;
 
 import com.google.auto.common.MoreElements;
 import com.google.auto.common.MoreTypes;
 import com.google.common.collect.ImmutableSet;
 import dagger.BindsOptionalOf;
 import dagger.Module;
+import dagger.model.Scope;
 import dagger.producers.ProducerModule;
 import javax.inject.Inject;
 import javax.lang.model.element.ExecutableElement;
@@ -75,6 +77,16 @@ final class BindsOptionalOfMethodValidator extends BindingMethodValidator {
   private void checkParameters(ValidationReport.Builder<ExecutableElement> builder) {
     if (!builder.getSubject().getParameters().isEmpty()) {
       builder.addError("@BindsOptionalOf methods cannot have parameters");
+    }
+  }
+
+  @Override
+  protected void checkScopes(ValidationReport.Builder<ExecutableElement> builder) {
+    for (Scope scope : scopesOf(builder.getSubject())) {
+      builder.addError(
+          "@BindsOptionalOf methods cannot be scoped",
+          builder.getSubject(),
+          scope.scopeAnnotation());
     }
   }
 }

--- a/javatests/dagger/internal/codegen/BindsOptionalOfMethodValidatorTest.java
+++ b/javatests/dagger/internal/codegen/BindsOptionalOfMethodValidatorTest.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Annotation;
 import java.util.Collection;
 import javax.inject.Inject;
 import javax.inject.Qualifier;
+import javax.inject.Singleton;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -122,6 +123,13 @@ public class BindsOptionalOfMethodValidatorTest {
     assertThatMethod("@BindsOptionalOf abstract Thing thing();")
         .importing(Thing.class)
         .hasError("return unqualified types that have an @Inject-annotated constructor");
+  }
+
+  @Test
+  public void hasScope() {
+    assertThatMethod("@BindsOptionalOf @Singleton abstract String scoped();")
+        .importing(Singleton.class)
+        .hasError("cannot be scoped");
   }
 
   private DaggerModuleMethodSubject assertThatMethod(String method) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Scope annotations have no meaning on @BindsOptionalOf methods. Dagger now reports an error for them. Instead of applying a scope to the @BindsOptionalOf method, apply it to the non-optional binding that satisfies the optional binding.

RELNOTES=Scope annotations have no meaning on `@BindsOptionalOf` methods. Dagger now reports an error for them. Instead of applying a scope to the `@BindsOptionalOf` method, apply it to the non-optional binding that satisfies the optional binding.

57f860c2958f21316f0c47886a35ccfa84935261