### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/android/DaggerFragment.java
+++ b/java/dagger/android/DaggerFragment.java
@@ -25,8 +25,13 @@ import javax.inject.Inject;
  * A {@link Fragment} that injects its members in {@link #onAttach(Context)} and can be used to
  * inject child {@link Fragment}s attached to it. Note that when this fragment gets reattached, its
  * members will be injected again.
+ *
+ * @deprecated Framework fragments are deprecated in Android P; prefer {@code
+ *     dagger.android.support.DaggerFragment} to use a support-library-friendly {@code
+ *     dagger.android} fragment implementation.
  */
 @Beta
+@Deprecated
 public abstract class DaggerFragment extends Fragment implements HasFragmentInjector {
 
   @Inject DispatchingAndroidInjector<Fragment> childFragmentInjector;


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Deprecate framework DaggerFragments

https://github.com/google/dagger/issues/1194

RELNOTES=Deprecated `dagger.android.DaggerFragment` in favor of `dagger.android.support.DaggerFragment` to match Android P's deprecation of framework fragments.

710fea211de2eef25b073d067403b01a10442200