### PR TITLE
Moe Sync

### DIFF
--- a/android.md
+++ b/android.md
@@ -336,7 +336,7 @@ method.
 [`DaggerApplication`]: https://google.github.io/dagger/api/latest/dagger/android/DaggerApplication.html
 [`DaggerBroadcastReceiver`]: https://google.github.io/dagger/api/latest/dagger/android/DaggerBroadcastReceiver.html
 [`DaggerContentProvider`]: https://google.github.io/dagger/api/latest/dagger/android/DaggerContentProvider.html
-[`DaggerFragment`]: https://google.github.io/dagger/api/latest/dagger/android/DaggerFragment.html
+[`DaggerFragment`]: https://google.github.io/dagger/api/latest/dagger/android/support/DaggerFragment.html
 [`DaggerIntentService`]: https://google.github.io/dagger/api/latest/dagger/android/DaggerIntentService.html
 [`DaggerService`]: https://google.github.io/dagger/api/latest/dagger/android/DaggerService.html
 [DispatchingAndroidInjector]: https://google.github.io/dagger/api/latest/dagger/android/DispatchingAndroidInjector.html


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Deprecate framework DaggerFragments

https://github.com/google/dagger/issues/1194

RELNOTES=Deprecated `dagger.android.DaggerFragment` in favor of `dagger.android.support.DaggerFragment` to match Android P's deprecation of framework fragments.

6424e43664a574b9bfda79b1b3c935cdd2fb65d4