### PR TITLE
Moe Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Given the following `WORKSPACE` definition, you can reference dagger via
 
 ```python
 http_archive(
-    name = "com_google_dagger"
+    name = "com_google_dagger",
     urls = ["https://github.com/google/dagger/archive/dagger-<version>.zip"],
 )
 ```

--- a/java/dagger/internal/SetFactory.java
+++ b/java/dagger/internal/SetFactory.java
@@ -101,8 +101,7 @@ public final class SetFactory<T> implements Factory<Set<T>> {
   }
 
   /**
-   * Returns a {@link Set} whose iteration order is that of the elements given by each of the
-   * providers, which are invoked in the order given at creation.
+   * Returns a {@link Set} that contains the elements given by each of the providers.
    *
    * @throws NullPointerException if any of the delegate {@link Set} instances or elements therein
    *     are {@code null}

--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -176,6 +176,7 @@ java_library(
         "ComponentHierarchyValidator.java",
         "ComponentValidator.java",
         "DependencyRequestFormatter.java",
+        "DependencyRequestValidator.java",
         "ForReleasableReferencesValidator.java",
         "InjectValidator.java",
         "MapKeyValidator.java",

--- a/java/dagger/internal/codegen/BindsOptionalOfMethodValidator.java
+++ b/java/dagger/internal/codegen/BindsOptionalOfMethodValidator.java
@@ -42,12 +42,14 @@ final class BindsOptionalOfMethodValidator extends BindingMethodValidator {
   private final Types types;
 
   @Inject
-  BindsOptionalOfMethodValidator(DaggerElements elements, Types types) {
+  BindsOptionalOfMethodValidator(
+      DaggerElements elements, Types types, DependencyRequestValidator dependencyRequestValidator) {
     super(
         elements,
         types,
         BindsOptionalOf.class,
         ImmutableSet.of(Module.class, ProducerModule.class),
+        dependencyRequestValidator,
         MUST_BE_ABSTRACT,
         NO_EXCEPTIONS,
         NO_MULTIBINDINGS);
@@ -74,7 +76,8 @@ final class BindsOptionalOfMethodValidator extends BindingMethodValidator {
     }
   }
 
-  private void checkParameters(ValidationReport.Builder<ExecutableElement> builder) {
+  @Override
+  protected void checkParameters(ValidationReport.Builder<ExecutableElement> builder) {
     if (!builder.getSubject().getParameters().isEmpty()) {
       builder.addError("@BindsOptionalOf methods cannot have parameters");
     }

--- a/java/dagger/internal/codegen/ComponentValidator.java
+++ b/java/dagger/internal/codegen/ComponentValidator.java
@@ -82,6 +82,7 @@ final class ComponentValidator {
   private final Types types;
   private final ModuleValidator moduleValidator;
   private final BuilderValidator builderValidator;
+  private final DependencyRequestValidator dependencyRequestValidator;
   private final MethodSignatureFormatter methodSignatureFormatter;
   private final DependencyRequestFactory dependencyRequestFactory;
 
@@ -91,12 +92,14 @@ final class ComponentValidator {
       Types types,
       ModuleValidator moduleValidator,
       BuilderValidator builderValidator,
+      DependencyRequestValidator dependencyRequestValidator,
       MethodSignatureFormatter methodSignatureFormatter,
       DependencyRequestFactory dependencyRequestFactory) {
     this.elements = elements;
     this.types = types;
     this.moduleValidator = moduleValidator;
     this.builderValidator = builderValidator;
+    this.dependencyRequestValidator = dependencyRequestValidator;
     this.methodSignatureFormatter = methodSignatureFormatter;
     this.dependencyRequestFactory = dependencyRequestFactory;
   }
@@ -199,7 +202,8 @@ final class ComponentValidator {
                 switch (parameters.size()) {
                   case 0:
                     // no parameters means that it is a provision method
-                    // basically, there are no restrictions here.  \o/
+                    dependencyRequestValidator.validateDependencyRequest(
+                        report, method, returnType);
                     break;
                   case 1:
                     // one parameter means that it's a members injection method

--- a/java/dagger/internal/codegen/DependencyRequestValidator.java
+++ b/java/dagger/internal/codegen/DependencyRequestValidator.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2018 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen;
+
+import static dagger.internal.codegen.InjectionAnnotations.getQualifiers;
+import static dagger.internal.codegen.RequestKinds.extractKeyType;
+import static dagger.internal.codegen.RequestKinds.getRequestKind;
+import static javax.lang.model.type.TypeKind.WILDCARD;
+
+import com.google.auto.common.MoreTypes;
+import com.google.common.collect.ImmutableSet;
+import javax.inject.Inject;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
+
+/** Validation for dependency requests. */
+final class DependencyRequestValidator {
+  @Inject
+  DependencyRequestValidator() {}
+
+  /**
+   * Adds an error if the given dependency request has more than one qualifier annotation or is a
+   * non-instance request with a wildcard type.
+   */
+  void validateDependencyRequest(
+      ValidationReport.Builder<?> report, Element requestElement, TypeMirror requestType) {
+    ImmutableSet<? extends AnnotationMirror> qualifiers = getQualifiers(requestElement);
+    if (qualifiers.size() > 1) {
+      for (AnnotationMirror qualifier : qualifiers) {
+        report.addError(
+            "A single dependency request may not use more than one @Qualifier",
+            requestElement,
+            qualifier);
+      }
+    }
+
+    TypeMirror keyType = extractKeyType(getRequestKind(requestType), requestType);
+    if (keyType.getKind().equals(WILDCARD)) {
+      // TODO(ronshapiro): Explore creating this message using RequestKinds.
+      report.addError(
+          "Dagger does not support injecting Provider<T>, Lazy<T>, Producer<T>, "
+              + "or Produced<T> when T is a wildcard type such as "
+              + keyType,
+          requestElement);
+    }
+  }
+
+  /**
+   * Adds an error if the given dependency request is for a {@link dagger.producers.Producer} or
+   * {@link dagger.producers.Produced}.
+   *
+   * <p>Only call this when processing a provision binding.
+   */
+  // TODO(dpb): Should we disallow Producer entry points in non-production components?
+  void checkNotProducer(ValidationReport.Builder<?> report, VariableElement requestElement) {
+    TypeMirror requestType = requestElement.asType();
+    if (FrameworkTypes.isProducerType(requestType)) {
+      report.addError(
+          String.format(
+              "%s may only be injected in @Produces methods",
+              MoreTypes.asTypeElement(requestType).getSimpleName()),
+          requestElement);
+    }
+  }
+}

--- a/java/dagger/internal/codegen/ErrorMessages.java
+++ b/java/dagger/internal/codegen/ErrorMessages.java
@@ -16,7 +16,6 @@
 
 package dagger.internal.codegen;
 
-import com.google.auto.common.MoreTypes;
 import com.google.common.base.Joiner;
 import java.util.Set;
 import javax.lang.model.element.ExecutableElement;
@@ -27,12 +26,6 @@ import javax.lang.model.type.TypeMirror;
  * The collection of error messages to be reported back to users.
  */
 final class ErrorMessages {
-
-  static String provisionMayNotDependOnProducerType(TypeMirror type) {
-    return String.format(
-        "%s may only be injected in @Produces methods",
-        MoreTypes.asTypeElement(type).getSimpleName());
-  }
 
   static ComponentBuilderMessages builderMsgsFor(ComponentDescriptor.Kind kind) {
     switch(kind) {

--- a/java/dagger/internal/codegen/KytheBindingGraphFactory.java
+++ b/java/dagger/internal/codegen/KytheBindingGraphFactory.java
@@ -111,21 +111,17 @@ final class KytheBindingGraphFactory {
   private static BindingGraphFactory createBindingGraphFactory(
       DaggerTypes types, DaggerElements elements, CompilerOptions compilerOptions) {
     KeyFactory keyFactory = new KeyFactory(types, elements);
-    DependencyRequestFactory dependencyRequestFactory =
-        new DependencyRequestFactory(keyFactory, types);
-    Messager messager = new NullMessager();
 
     BindingFactory bindingFactory =
-        new BindingFactory(types, elements, keyFactory, dependencyRequestFactory);
-
-    InjectValidator injectMethodValidator = new InjectValidator(types, elements, compilerOptions);
+        new BindingFactory(
+            types, elements, keyFactory, new DependencyRequestFactory(keyFactory, types));
 
     InjectBindingRegistry injectBindingRegistry =
         new InjectBindingRegistryImpl(
             elements,
             types,
-            messager,
-            injectMethodValidator,
+            new NullMessager(),
+            new InjectValidator(types, elements, new DependencyRequestValidator(), compilerOptions),
             keyFactory,
             bindingFactory,
             compilerOptions);

--- a/java/dagger/internal/codegen/MultibindsMethodValidator.java
+++ b/java/dagger/internal/codegen/MultibindsMethodValidator.java
@@ -36,12 +36,14 @@ class MultibindsMethodValidator extends BindingMethodValidator {
 
   /** Creates a validator for {@link Multibinds @Multibinds} methods. */
   @Inject
-  MultibindsMethodValidator(DaggerElements elements, Types types) {
+  MultibindsMethodValidator(
+      DaggerElements elements, Types types, DependencyRequestValidator dependencyRequestValidator) {
     super(
         elements,
         types,
         Multibinds.class,
         ImmutableSet.of(Module.class, ProducerModule.class),
+        dependencyRequestValidator,
         MUST_BE_ABSTRACT,
         NO_EXCEPTIONS,
         NO_MULTIBINDINGS);
@@ -54,7 +56,8 @@ class MultibindsMethodValidator extends BindingMethodValidator {
     checkParameters(builder);
   }
 
-  private void checkParameters(ValidationReport.Builder<ExecutableElement> builder) {
+  @Override
+  protected void checkParameters(ValidationReport.Builder<ExecutableElement> builder) {
     if (!builder.getSubject().getParameters().isEmpty()) {
       builder.addError(bindingMethods("cannot have parameters"));
     }

--- a/java/dagger/internal/codegen/ProducesMethodValidator.java
+++ b/java/dagger/internal/codegen/ProducesMethodValidator.java
@@ -41,10 +41,12 @@ import javax.lang.model.util.Types;
 final class ProducesMethodValidator extends BindingMethodValidator {
 
   @Inject
-  ProducesMethodValidator(DaggerElements elements, Types types) {
+  ProducesMethodValidator(
+      DaggerElements elements, Types types, DependencyRequestValidator dependencyRequestValidator) {
     super(
         elements,
         types,
+        dependencyRequestValidator,
         Produces.class,
         ProducerModule.class,
         MUST_BE_CONCRETE,

--- a/java/dagger/producers/internal/SetOfProducedProducer.java
+++ b/java/dagger/producers/internal/SetOfProducedProducer.java
@@ -101,15 +101,14 @@ public final class SetOfProducedProducer<T> extends AbstractProducer<Set<Produce
   }
 
   /**
-   * Returns a future {@link Set} of {@link Produced} values whose iteration order is that of the
-   * elements given by each of the producers, which are invoked in the order given at creation.
+   * Returns a future {@link Set} of {@link Produced} elements given by each of the producers.
    *
    * <p>If any of the delegate collections, or any elements therein, are null, then that
    * corresponding {@code Produced} element will fail with a NullPointerException.
    *
    * <p>Canceling this future will attempt to cancel all of the component futures; but if any of the
-   * delegate futures fail or are canceled, this future succeeds, with the appropriate failed
-   * {@link Produced}.
+   * delegate futures fail or are canceled, this future succeeds, with the appropriate failed {@link
+   * Produced}.
    *
    * @throws NullPointerException if any of the delegate producers return null
    */

--- a/java/dagger/producers/internal/SetProducer.java
+++ b/java/dagger/producers/internal/SetProducer.java
@@ -109,8 +109,7 @@ public final class SetProducer<T> extends AbstractProducer<Set<T>> {
   }
 
   /**
-   * Returns a future {@link Set} whose iteration order is that of the elements given by each of the
-   * producers, which are invoked in the order given at creation.
+   * Returns a future {@link Set} that contains the elements given by each of the producers.
    *
    * <p>If any of the delegate collections, or any elements therein, are null, then this future will
    * fail with a NullPointerException.

--- a/javatests/dagger/internal/codegen/BindsMethodValidatorTest.java
+++ b/javatests/dagger/internal/codegen/BindsMethodValidatorTest.java
@@ -92,9 +92,17 @@ public class BindsMethodValidatorTest {
   }
 
   @Test
-  public void tooManyQualifiers() {
+  public void tooManyQualifiersOnMethod() {
     assertThatMethod(
             "@Binds @Qualifier1 @Qualifier2 abstract String tooManyQualifiers(String impl);")
+        .importing(Qualifier1.class, Qualifier2.class)
+        .hasError("more than one @Qualifier");
+  }
+
+  @Test
+  public void tooManyQualifiersOnParameter() {
+    assertThatMethod(
+            "@Binds abstract String tooManyQualifiers(@Qualifier1 @Qualifier2 String impl);")
         .importing(Qualifier1.class, Qualifier2.class)
         .hasError("more than one @Qualifier");
   }

--- a/javatests/dagger/internal/codegen/GraphValidationTest.java
+++ b/javatests/dagger/internal/codegen/GraphValidationTest.java
@@ -983,6 +983,37 @@ public class GraphValidationTest {
         .onLineContaining("void inject(Self target);");
   }
 
+  @Test
+  public void genericInjectClassWithWildcardDependencies() {
+    JavaFileObject component =
+        JavaFileObjects.forSourceLines(
+            "test.TestComponent",
+            "package test;",
+            "",
+            "import dagger.Component;",
+            "",
+            "@Component",
+            "interface TestComponent {",
+            "  Foo<? extends Number> foo();",
+            "}");
+    JavaFileObject foo =
+        JavaFileObjects.forSourceLines(
+            "test.Foo",
+            "package test;",
+            "",
+            "import javax.inject.Inject;",
+            "",
+            "final class Foo<T> {",
+            "  @Inject Foo(T t) {}",
+            "}");
+    Compilation compilation = daggerCompiler().compile(component, foo);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
+            "test.Foo<? extends java.lang.Number> cannot be provided "
+                + "without an @Provides-annotated method");
+  }
+
   @Test public void duplicateExplicitBindings_ProvidesAndComponentProvision() {
     JavaFileObject component = JavaFileObjects.forSourceLines("test.Outer",
         "package test;",

--- a/javatests/dagger/internal/codegen/InjectConstructorFactoryGeneratorTest.java
+++ b/javatests/dagger/internal/codegen/InjectConstructorFactoryGeneratorTest.java
@@ -564,7 +564,7 @@ public final class InjectConstructorFactoryGeneratorTest {
     assertThat(compilation).failed();
     // for whatever reason, javac only reports the error once on the constructor
     assertThat(compilation)
-        .hadErrorContaining("A single injection site may not use more than one @Qualifier")
+        .hadErrorContaining("A single dependency request may not use more than one @Qualifier")
         .inFile(file)
         .onLine(6);
   }
@@ -824,12 +824,12 @@ public final class InjectConstructorFactoryGeneratorTest {
     Compilation compilation = daggerCompiler().compile(file, QUALIFIER_A, QUALIFIER_B);
     assertThat(compilation).failed();
     assertThat(compilation)
-        .hadErrorContaining("A single injection site may not use more than one @Qualifier")
+        .hadErrorContaining("A single dependency request may not use more than one @Qualifier")
         .inFile(file)
         .onLine(6)
         .atColumn(11);
     assertThat(compilation)
-        .hadErrorContaining("A single injection site may not use more than one @Qualifier")
+        .hadErrorContaining("A single dependency request may not use more than one @Qualifier")
         .inFile(file)
         .onLine(6)
         .atColumn(23);
@@ -943,7 +943,7 @@ public final class InjectConstructorFactoryGeneratorTest {
     Compilation compilation = daggerCompiler().compile(file, QUALIFIER_A, QUALIFIER_B);
     assertThat(compilation).failed();
     assertThat(compilation)
-        .hadErrorContaining("A single injection site may not use more than one @Qualifier")
+        .hadErrorContaining("A single dependency request may not use more than one @Qualifier")
         .inFile(file)
         .onLine(6);
   }

--- a/javatests/dagger/internal/codegen/MultibindsValidatorTest.java
+++ b/javatests/dagger/internal/codegen/MultibindsValidatorTest.java
@@ -141,7 +141,7 @@ public class MultibindsValidatorTest {
                 + "abstract Set<Object> tooManyQualifiersSet();")
         .withDeclaration(moduleDeclaration)
         .importing(SomeQualifier.class, OtherQualifier.class)
-        .hasError("Cannot use more than one @Qualifier");
+        .hasError("may not use more than one @Qualifier");
   }
 
   @Test
@@ -151,7 +151,7 @@ public class MultibindsValidatorTest {
                 + "abstract Map<String, Object> tooManyQualifiersMap();")
         .withDeclaration(moduleDeclaration)
         .importing(SomeQualifier.class, OtherQualifier.class)
-        .hasError("Cannot use more than one @Qualifier");
+        .hasError("may not use more than one @Qualifier");
   }
 
   @Test

--- a/javatests/dagger/internal/codegen/ProducerModuleFactoryGeneratorTest.java
+++ b/javatests/dagger/internal/codegen/ProducerModuleFactoryGeneratorTest.java
@@ -466,11 +466,32 @@ public class ProducerModuleFactoryGeneratorTest {
         .generatesSources(factoryFile);
   }
 
-  @Test public void producesMethodMultipleQualifiers() {
+  @Test
+  public void producesMethodMultipleQualifiersOnMethod() {
     assertThatProductionModuleMethod(
-            "@Produces @QualifierA @QualifierB abstract String produceString() { return null; }")
+            "@Produces @QualifierA @QualifierB static String produceString() { return null; }")
         .importing(ListenableFuture.class, QualifierA.class, QualifierB.class)
-        .hasError("Cannot use more than one @Qualifier");
+        .hasError("may not use more than one @Qualifier");
+  }
+
+  @Test
+  public void producesMethodMultipleQualifiersOnParameter() {
+    assertThatProductionModuleMethod(
+            "@Produces static String produceString(@QualifierA @QualifierB Object input) "
+                + "{ return null; }")
+        .importing(ListenableFuture.class, QualifierA.class, QualifierB.class)
+        .hasError("may not use more than one @Qualifier");
+  }
+
+  @Test
+  public void producesMethodWildcardDependency() {
+    assertThatProductionModuleMethod(
+            "@Produces static String produceString(Provider<? extends Number> numberProvider) "
+                + "{ return null; }")
+        .importing(ListenableFuture.class, QualifierA.class, QualifierB.class)
+        .hasError(
+            "Dagger does not support injecting Provider<T>, Lazy<T>, Producer<T>, or Produced<T> "
+                + "when T is a wildcard type such as ? extends java.lang.Number");
   }
 
   @Qualifier


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Check dependency requests for multiple qualifiers, wildcard types, and provider-depending-on-producer errors during initial validation instead of after building the binding graph.

Check those errors on entry points as well as binding methods; before, they were checked only on @Inject parameters.

RELNOTES=Report errors for dependency requests with multiple qualifiers in `@Provides` and `@Produces` methods and component entry points instead of throwing `IllegalArgumentException`.

9e99bdb2a37f72dbaa0b6601e4abb19728fbfbb5

-------

<p> Don't specify iteration order of SetFactory/SetProducer/SetOfProducedProducer, even though they're internal classes

Fixes https://github.com/google/dagger/issues/1219

0cee97f5a4d574f5a0d291377d130e07a8056d61

-------

<p> Add a missing comma from a bazel config snippet.

7e66dd7690d4c62e6da8950f93599288a0594ca1