### PR TITLE
Moe Sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,9 @@ before_install:
   - ln -s $(which g++-4.8) travis_bin/g++
   - export PATH="${PWD}/travis_bin:${PATH}"
 
-script: bazel test --test_output errors //...
+script:
+  - bazel test --test_output errors //...
+  - pushd examples && mvn compile && popd
 
 env:
   global:

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -18,15 +18,16 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.google.dagger</groupId>
-    <artifactId>dagger-parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>9</version>
   </parent>
 
   <groupId>com.google.dagger.example</groupId>
   <artifactId>dagger-example-parent</artifactId>
   <packaging>pom</packaging>
   <name>Examples</name>
+  <version>2.17</version>
 
   <modules>
     <module>simple</module>
@@ -44,6 +45,11 @@
         <groupId>com.google.dagger</groupId>
         <artifactId>dagger-compiler</artifactId>
         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>26.0-jre</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/examples/simple/pom.xml
+++ b/examples/simple/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.google.dagger.example</groupId>
     <artifactId>dagger-example-parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>2.17</version>
   </parent>
 
   <artifactId>simple</artifactId>
@@ -36,10 +36,24 @@
       <groupId>com.google.dagger</groupId>
       <artifactId>dagger</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.google.dagger</groupId>
-      <artifactId>dagger-compiler</artifactId>
-      <optional>true</optional>
-    </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.1</version>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.dagger</groupId>
+              <artifactId>dagger-compiler</artifactId>
+              <version>${project.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/java/dagger/android/processor/DuplicateAndroidInjectorsChecker.java
+++ b/java/dagger/android/processor/DuplicateAndroidInjectorsChecker.java
@@ -66,7 +66,7 @@ public final class DuplicateAndroidInjectorsChecker implements BindingGraphPlugi
   }
 
   private boolean isDispatchingAndroidInjector(BindingNode node) {
-    Key key = node.binding().key();
+    Key key = node.key();
     return MoreTypes.isTypeOf(DispatchingAndroidInjector.class, key.type())
         && !key.qualifier().isPresent();
   }
@@ -129,7 +129,7 @@ public final class DuplicateAndroidInjectorsChecker implements BindingGraphPlugi
         .filter(
             node -> {
               TypeMirror valueType =
-                  MoreTypes.asDeclared(node.binding().key().type()).getTypeArguments().get(1);
+                  MoreTypes.asDeclared(node.key().type()).getTypeArguments().get(1);
               if (!MoreTypes.isTypeOf(Provider.class, valueType)
                   || !valueType.getKind().equals(TypeKind.DECLARED)) {
                 return false;

--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -124,7 +124,6 @@ java_library(
         "BindingGraph.java",
         "BindingNodeImpl.java",
         "BindingType.java",
-        "BindingTypeMapper.java",
         "BindingVariableNamer.java",  # needed by FrameworkField
         "BindsTypeChecker.java",
         "ComponentDescriptor.java",
@@ -140,6 +139,7 @@ java_library(
         "FrameworkDependency.java",
         "FrameworkField.java",  # Used by SourceFiles
         "FrameworkType.java",
+        "FrameworkTypeMapper.java",
         "InjectBindingRegistry.java",
         "KeyFactory.java",
         "MapKeys.java",

--- a/java/dagger/internal/codegen/BindingGraphConverter.java
+++ b/java/dagger/internal/codegen/BindingGraphConverter.java
@@ -118,7 +118,7 @@ final class BindingGraphConverter {
               && node.componentPath().equals(currentComponent.componentPath())) {
             network.addEdge(
                 node,
-                subcomponentNode(node.binding().key().type(), graph),
+                subcomponentNode(node.key().type(), graph),
                 subcomponentBuilderBindingEdge(subcomponentDeclaringModules(resolvedBindings)));
           }
         }

--- a/java/dagger/internal/codegen/BindingType.java
+++ b/java/dagger/internal/codegen/BindingType.java
@@ -16,43 +16,16 @@
 
 package dagger.internal.codegen;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
-import com.squareup.javapoet.ClassName;
-import com.squareup.javapoet.ParameterizedTypeName;
-import com.squareup.javapoet.TypeName;
 import dagger.MembersInjector;
-import dagger.producers.Producer;
-import javax.inject.Provider;
 
 /** Whether a binding or declaration is for provision, production, or a {@link MembersInjector}. */
 enum BindingType {
   /** A binding with this type is a {@link ProvisionBinding}. */
-  PROVISION(Provider.class),
+  PROVISION,
 
   /** A binding with this type is a {@link MembersInjectionBinding}. */
-  MEMBERS_INJECTION(MembersInjector.class),
+  MEMBERS_INJECTION,
 
   /** A binding with this type is a {@link ProductionBinding}. */
-  PRODUCTION(Producer.class),
-  ;
-
-  static final ImmutableSet<BindingType> CONTRIBUTION_TYPES =
-      Sets.immutableEnumSet(PROVISION, PRODUCTION);
-
-  private final Class<?> frameworkClass;
-
-  BindingType(Class<?> frameworkClass) {
-    this.frameworkClass = frameworkClass;
-  }
-
-  /** The framework class associated with bindings of this type. */
-  Class<?> frameworkClass() {
-    return frameworkClass;
-  }
-
-  /** Returns the {@link #frameworkClass()} parameterized with a type. */
-  ParameterizedTypeName frameworkClassOf(TypeName valueType) {
-    return ParameterizedTypeName.get(ClassName.get(frameworkClass()), valueType);
-  }
+  PRODUCTION,
 }

--- a/java/dagger/internal/codegen/BindingType.java
+++ b/java/dagger/internal/codegen/BindingType.java
@@ -26,37 +26,29 @@ import dagger.producers.Producer;
 import javax.inject.Provider;
 
 /** Whether a binding or declaration is for provision, production, or a {@link MembersInjector}. */
-// TODO(dpb): Merge with FrameworkType?
 enum BindingType {
   /** A binding with this type is a {@link ProvisionBinding}. */
-  PROVISION(Provider.class, FrameworkType.PROVIDER),
+  PROVISION(Provider.class),
 
   /** A binding with this type is a {@link MembersInjectionBinding}. */
-  MEMBERS_INJECTION(MembersInjector.class, FrameworkType.MEMBERS_INJECTOR),
+  MEMBERS_INJECTION(MembersInjector.class),
 
   /** A binding with this type is a {@link ProductionBinding}. */
-  PRODUCTION(Producer.class, FrameworkType.PRODUCER),
+  PRODUCTION(Producer.class),
   ;
 
   static final ImmutableSet<BindingType> CONTRIBUTION_TYPES =
       Sets.immutableEnumSet(PROVISION, PRODUCTION);
 
   private final Class<?> frameworkClass;
-  private final FrameworkType frameworkType;
 
-  private BindingType(Class<?> frameworkClass, FrameworkType frameworkType) {
+  BindingType(Class<?> frameworkClass) {
     this.frameworkClass = frameworkClass;
-    this.frameworkType = frameworkType;
   }
 
   /** The framework class associated with bindings of this type. */
   Class<?> frameworkClass() {
     return frameworkClass;
-  }
-
-  /** The framework type used to represent bindings of this type. */
-  FrameworkType frameworkType() {
-    return frameworkType;
   }
 
   /** Returns the {@link #frameworkClass()} parameterized with a type. */

--- a/java/dagger/internal/codegen/CompilerOptions.java
+++ b/java/dagger/internal/codegen/CompilerOptions.java
@@ -309,24 +309,30 @@ abstract class CompilerOptions {
       ProcessingEnvironment processingEnv, String key, T defaultValue, Set<T> validValues) {
     Map<String, String> options = processingEnv.getOptions();
     if (options.containsKey(key)) {
-      try {
-        T type =
-            Enum.valueOf(defaultValue.getDeclaringClass(), Ascii.toUpperCase(options.get(key)));
-        if (!validValues.contains(type)) {
-          throw new IllegalArgumentException(); // let handler below print out good msg.
-        }
-        return type;
-      } catch (IllegalArgumentException e) {
+      String optionValue = options.get(key);
+      if (optionValue == null) {
         processingEnv
             .getMessager()
-            .printMessage(
-                Diagnostic.Kind.ERROR,
-                "Processor option -A"
-                    + key
-                    + " may only have the values "
-                    + validValues
-                    + " (case insensitive), found: "
-                    + options.get(key));
+            .printMessage(Diagnostic.Kind.ERROR, "Processor option -A" + key + " needs a value");
+      } else {
+        try {
+          T type = Enum.valueOf(defaultValue.getDeclaringClass(), Ascii.toUpperCase(optionValue));
+          if (!validValues.contains(type)) {
+            throw new IllegalArgumentException(); // let handler below print out good msg.
+          }
+          return type;
+        } catch (IllegalArgumentException e) {
+          processingEnv
+              .getMessager()
+              .printMessage(
+                  Diagnostic.Kind.ERROR,
+                  "Processor option -A"
+                      + key
+                      + " may only have the values "
+                      + validValues
+                      + " (case insensitive), found: "
+                      + options.get(key));
+        }
       }
     }
     return defaultValue;

--- a/java/dagger/internal/codegen/ComponentBindingExpressions.java
+++ b/java/dagger/internal/codegen/ComponentBindingExpressions.java
@@ -336,7 +336,7 @@ final class ComponentBindingExpressions {
           return frameworkInstanceBindingExpression(resolvedBindings);
         } else {
           return new DerivedFromFrameworkInstanceBindingExpression(
-              resolvedBindings, requestKind, this, types);
+              resolvedBindings, FrameworkType.PRODUCER, requestKind, this, types);
         }
 
       default:
@@ -464,16 +464,15 @@ final class ComponentBindingExpressions {
             : new FrameworkFieldInitializer(
                 generatedComponentModel, resolvedBindings, frameworkInstanceCreationExpression);
 
-    FrameworkType frameworkType = resolvedBindings.bindingType().frameworkType();
-    switch (frameworkType) {
-      case PROVIDER:
+    switch (resolvedBindings.bindingType()) {
+      case PROVISION:
         return new ProviderInstanceBindingExpression(
             resolvedBindings, frameworkInstanceSupplier, types, elements);
-      case PRODUCER:
+      case PRODUCTION:
         return new ProducerInstanceBindingExpression(
             resolvedBindings, frameworkInstanceSupplier, types, elements);
       default:
-        throw new AssertionError("invalid framework type: " + frameworkType);
+        throw new AssertionError("invalid binding type: " + resolvedBindings.bindingType());
     }
   }
 
@@ -593,7 +592,7 @@ final class ComponentBindingExpressions {
       case PRODUCED:
       case PROVIDER_OF_LAZY:
         return new DerivedFromFrameworkInstanceBindingExpression(
-            resolvedBindings, requestKind, this, types);
+            resolvedBindings, FrameworkType.PROVIDER, requestKind, this, types);
 
       case PRODUCER:
         return producerFromProviderBindingExpression(resolvedBindings);
@@ -643,7 +642,7 @@ final class ComponentBindingExpressions {
    */
   private FrameworkInstanceBindingExpression producerFromProviderBindingExpression(
       ResolvedBindings resolvedBindings) {
-    checkArgument(resolvedBindings.bindingType().frameworkType().equals(FrameworkType.PROVIDER));
+    checkArgument(resolvedBindings.bindingType().equals(BindingType.PROVISION));
     return new ProducerInstanceBindingExpression(
         resolvedBindings,
         new FrameworkFieldInitializer(
@@ -679,7 +678,7 @@ final class ComponentBindingExpressions {
           : directInstanceExpression;
     }
     return new DerivedFromFrameworkInstanceBindingExpression(
-        resolvedBindings, RequestKind.INSTANCE, this, types);
+        resolvedBindings, FrameworkType.PROVIDER, RequestKind.INSTANCE, this, types);
   }
 
   /**

--- a/java/dagger/internal/codegen/ComponentBindingExpressions.java
+++ b/java/dagger/internal/codegen/ComponentBindingExpressions.java
@@ -180,7 +180,9 @@ final class ComponentBindingExpressions {
   Expression getDependencyExpression(
       FrameworkDependency frameworkDependency, ClassName requestingClass) {
     return getDependencyExpression(
-        frameworkDependency.key(), frameworkDependency.dependencyRequestKind(), requestingClass);
+        frameworkDependency.key(),
+        frameworkDependency.frameworkType().requestKind(),
+        requestingClass);
   }
 
   /**

--- a/java/dagger/internal/codegen/ContributionBinding.java
+++ b/java/dagger/internal/codegen/ContributionBinding.java
@@ -143,7 +143,7 @@ abstract class ContributionBinding extends Binding implements HasContributionTyp
   final TypeMirror contributedType() {
     switch (contributionType()) {
       case MAP:
-        return MapType.from(key()).unwrappedValueType(bindingType().frameworkClass());
+        return MapType.from(key()).unwrappedFrameworkValueType();
       case SET:
         return SetType.from(key()).elementType();
       case SET_VALUES:

--- a/java/dagger/internal/codegen/DelegatingFrameworkInstanceCreationExpression.java
+++ b/java/dagger/internal/codegen/DelegatingFrameworkInstanceCreationExpression.java
@@ -46,6 +46,6 @@ final class DelegatingFrameworkInstanceCreationExpression
         componentBindingExpressions
             .getDependencyExpression(frameworkDependency, generatedComponentModel.name())
             .codeBlock(),
-        binding.bindingType().frameworkClass());
+        frameworkDependency.frameworkClass());
   }
 }

--- a/java/dagger/internal/codegen/DependsOnProductionExecutorValidator.java
+++ b/java/dagger/internal/codegen/DependsOnProductionExecutorValidator.java
@@ -54,22 +54,17 @@ final class DependsOnProductionExecutorValidator implements BindingGraphPlugin {
     Key productionImplementationExecutorKey = keyFactory.forProductionImplementationExecutor();
     Key productionExecutorKey = keyFactory.forProductionExecutor();
 
-    bindingGraph
-        .bindingNodes(productionExecutorKey)
-        .stream()
+    bindingGraph.bindingNodes(productionExecutorKey).stream()
         .flatMap(
             productionExecutorBinding ->
                 bindingGraph.predecessors(productionExecutorBinding).stream())
         .flatMap(instancesOf(BindingNode.class))
-        .filter(binding -> !binding.binding().key().equals(productionImplementationExecutorKey))
+        .filter(binding -> !binding.key().equals(productionImplementationExecutorKey))
         .forEach(binding -> reportError(diagnosticReporter, binding));
   }
 
   private void reportError(DiagnosticReporter diagnosticReporter, BindingNode bindingNode) {
     diagnosticReporter.reportBinding(
-        ERROR,
-        bindingNode,
-        "%s may not depend on the production executor",
-        bindingNode.binding().key());
+        ERROR, bindingNode, "%s may not depend on the production executor", bindingNode.key());
   }
 }

--- a/java/dagger/internal/codegen/DerivedFromFrameworkInstanceBindingExpression.java
+++ b/java/dagger/internal/codegen/DerivedFromFrameworkInstanceBindingExpression.java
@@ -33,12 +33,13 @@ final class DerivedFromFrameworkInstanceBindingExpression extends BindingExpress
 
   DerivedFromFrameworkInstanceBindingExpression(
       ResolvedBindings resolvedBindings,
+      FrameworkType frameworkType,
       RequestKind requestKind,
       ComponentBindingExpressions componentBindingExpressions,
       DaggerTypes types) {
     this.key = resolvedBindings.key();
     this.requestKind = checkNotNull(requestKind);
-    this.frameworkType = resolvedBindings.bindingType().frameworkType();
+    this.frameworkType = checkNotNull(frameworkType);
     this.componentBindingExpressions = checkNotNull(componentBindingExpressions);
     this.types = checkNotNull(types);
   }

--- a/java/dagger/internal/codegen/FrameworkDependency.java
+++ b/java/dagger/internal/codegen/FrameworkDependency.java
@@ -18,8 +18,6 @@ package dagger.internal.codegen;
 
 import com.google.auto.value.AutoValue;
 import dagger.model.Key;
-import dagger.model.RequestKind;
-import javax.inject.Provider;
 
 /**
  * The framework class and binding key for a resolved dependency of a binding. If a binding has
@@ -34,7 +32,7 @@ import javax.inject.Provider;
  *
  * But they both can be satisfied with the same instance of {@code Provider<Bar>}. So one instance
  * of {@code FrameworkDependency} will be used for both. Its {@link #key()} will be for {@code Bar},
- * and its {@link #frameworkClass()} will be {@link Provider}.
+ * and its {@link #frameworkType()} will be {@link FrameworkType#PROVIDER}.
  *
  * <pre><code>
  *   {@literal @Provides} static Foo provideFoo(Bar bar, {@literal Provider<Bar>} barProvider) {
@@ -48,30 +46,16 @@ abstract class FrameworkDependency {
   /** The fully-resolved key shared by all the dependency requests. */
   abstract Key key();
 
-  /** The binding type of the framework dependency. */
-  abstract BindingType bindingType();
+  /** The type of the framework dependency. */
+  abstract FrameworkType frameworkType();
 
-  /** The dependency request kind that is equivalent to requesting the framework dependency. */
-  RequestKind dependencyRequestKind() {
-    switch (bindingType()) {
-      case PROVISION:
-        return RequestKind.PROVIDER;
-
-      case PRODUCTION:
-        return RequestKind.PRODUCER;
-
-      default:
-        throw new AssertionError(bindingType());
-    }
-  }
-
-  /** The framework class to use for these requests. */
+  /** The framework class to use for this dependency. */
   final Class<?> frameworkClass() {
-    return bindingType().frameworkClass();
+    return frameworkType().frameworkClass();
   }
 
   /** Returns a new instance with the given key and type. */
-  static FrameworkDependency create(Key key, BindingType bindingType) {
-    return new AutoValue_FrameworkDependency(key, bindingType);
+  static FrameworkDependency create(Key key, FrameworkType frameworkType) {
+    return new AutoValue_FrameworkDependency(key, frameworkType);
   }
 }

--- a/java/dagger/internal/codegen/FrameworkField.java
+++ b/java/dagger/internal/codegen/FrameworkField.java
@@ -69,24 +69,17 @@ abstract class FrameworkField {
   static FrameworkField forResolvedBindings(
       ResolvedBindings resolvedBindings, Optional<ClassName> frameworkClass) {
     return create(
-        frameworkClass.orElse(ClassName.get(resolvedBindings.frameworkClass())),
+        frameworkClass.orElse(
+            ClassName.get(
+                FrameworkType.forBindingType(resolvedBindings.bindingType()).frameworkClass())),
         TypeName.get(fieldValueType(resolvedBindings)),
         frameworkFieldName(resolvedBindings));
   }
 
   private static TypeMirror fieldValueType(ResolvedBindings resolvedBindings) {
-    if (resolvedBindings.isMultibindingContribution()) {
-      switch (resolvedBindings.contributionType()) {
-        case MAP:
-          return MapType.from(resolvedBindings.key())
-              .unwrappedValueType(resolvedBindings.frameworkClass());
-        case SET:
-          return SetType.from(resolvedBindings.key()).elementType();
-        default:
-          // do nothing
-      }
-    }
-    return resolvedBindings.key().type();
+    return resolvedBindings.isMultibindingContribution()
+        ? resolvedBindings.contributionBinding().contributedType()
+        : resolvedBindings.key().type();
   }
 
   private static String frameworkFieldName(ResolvedBindings resolvedBindings) {

--- a/java/dagger/internal/codegen/FrameworkInstanceBindingExpression.java
+++ b/java/dagger/internal/codegen/FrameworkInstanceBindingExpression.java
@@ -24,20 +24,19 @@ import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.FieldSpec;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.Elements;
 
 /** A binding expression that uses a {@link FrameworkType} field. */
 abstract class FrameworkInstanceBindingExpression extends BindingExpression {
   private final ResolvedBindings resolvedBindings;
   private final FrameworkInstanceSupplier frameworkInstanceSupplier;
   private final DaggerTypes types;
-  private final Elements elements;
+  private final DaggerElements elements;
 
   FrameworkInstanceBindingExpression(
       ResolvedBindings resolvedBindings,
       FrameworkInstanceSupplier frameworkInstanceSupplier,
       DaggerTypes types,
-      Elements elements) {
+      DaggerElements elements) {
     this.resolvedBindings = checkNotNull(resolvedBindings);
     this.frameworkInstanceSupplier = checkNotNull(frameworkInstanceSupplier);
     this.types = checkNotNull(types);
@@ -58,7 +57,7 @@ abstract class FrameworkInstanceBindingExpression extends BindingExpression {
         frameworkInstanceSupplier.specificType().isPresent()
                 || isTypeAccessibleFrom(contributedType, requestingClass.packageName())
                 || isInlinedFactoryCreation(memberSelect)
-            ? types.wrapType(contributedType, resolvedBindings.frameworkClass())
+            ? types.wrapType(contributedType, frameworkType().frameworkClass())
             : rawFrameworkType();
     return Expression.create(expressionType, memberSelect.getExpressionFor(requestingClass));
   }
@@ -82,7 +81,6 @@ abstract class FrameworkInstanceBindingExpression extends BindingExpression {
   }
 
   private DeclaredType rawFrameworkType() {
-    return types.getDeclaredType(
-        elements.getTypeElement(resolvedBindings.frameworkClass().getCanonicalName()));
+    return types.getDeclaredType(elements.getTypeElement(frameworkType().frameworkClass()));
   }
 }

--- a/java/dagger/internal/codegen/FrameworkType.java
+++ b/java/dagger/internal/codegen/FrameworkType.java
@@ -25,7 +25,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.squareup.javapoet.CodeBlock;
 import dagger.Lazy;
-import dagger.MembersInjector;
 import dagger.internal.DoubleCheck;
 import dagger.internal.ProviderOfLazy;
 import dagger.model.DependencyRequest;
@@ -137,25 +136,6 @@ enum FrameworkType {
           throw new IllegalArgumentException(
               String.format("Cannot request a %s from a %s", requestKind, this));
       }
-    }
-  },
-
-  // TODO(ronshapiro): Remove this once MembersInjectionBinding no longer extends Binding
-  /** A {@link MembersInjector}. */
-  MEMBERS_INJECTOR {
-    @Override
-    RequestKind requestKind() {
-      return RequestKind.MEMBERS_INJECTION;
-    }
-
-    @Override
-    CodeBlock to(RequestKind requestKind, CodeBlock from) {
-      throw new UnsupportedOperationException(requestKind.toString());
-    }
-
-    @Override
-    Expression to(RequestKind requestKind, Expression from, DaggerTypes types) {
-      throw new UnsupportedOperationException(requestKind.toString());
     }
   },
   ;

--- a/java/dagger/internal/codegen/InjectBindingValidation.java
+++ b/java/dagger/internal/codegen/InjectBindingValidation.java
@@ -53,7 +53,7 @@ final class InjectBindingValidation implements BindingGraphPlugin {
 
   private void validateInjectionBinding(BindingNode node, DiagnosticReporter diagnosticReporter) {
     ValidationReport<TypeElement> typeReport =
-        injectValidator.validateType(MoreTypes.asTypeElement(node.binding().key().type()));
+        injectValidator.validateType(MoreTypes.asTypeElement(node.key().type()));
     for (Item item : typeReport.allItems()) {
       diagnosticReporter.reportBinding(item.kind(), node, item.message());
     }

--- a/java/dagger/internal/codegen/InjectionOrProvisionProviderCreationExpression.java
+++ b/java/dagger/internal/codegen/InjectionOrProvisionProviderCreationExpression.java
@@ -24,11 +24,11 @@ import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.TypeName;
 import dagger.internal.codegen.FrameworkFieldInitializer.FrameworkInstanceCreationExpression;
 import java.util.Optional;
+import javax.inject.Provider;
 
 /**
- * A {@link javax.inject.Provider} creation expression for an {@link
- * javax.inject.Inject @Inject}-constructed class or a {@link dagger.Provides @Provides}-annotated
- * module method.
+ * A {@link Provider} creation expression for an {@link javax.inject.Inject @Inject}-constructed
+ * class or a {@link dagger.Provides @Provides}-annotated module method.
  */
 // TODO(dpb): Resolve with ProducerCreationExpression.
 final class InjectionOrProvisionProviderCreationExpression
@@ -56,7 +56,7 @@ final class InjectionOrProvisionProviderCreationExpression
     if (binding.kind().equals(INJECTION)
         && binding.unresolved().isPresent()
         && binding.scope().isPresent()) {
-      return CodeBlocks.cast(createFactory, binding.bindingType().frameworkClass());
+      return CodeBlocks.cast(createFactory, Provider.class);
     } else {
       return createFactory;
     }

--- a/java/dagger/internal/codegen/MapMultibindingValidation.java
+++ b/java/dagger/internal/codegen/MapMultibindingValidation.java
@@ -91,8 +91,7 @@ final class MapMultibindingValidation implements BindingGraphPlugin {
         diagnosticReporter.reportBinding(
             ERROR,
             multiboundMapBindingNode,
-            duplicateMapKeyErrorMessage(
-                contributionsForOneMapKey, multiboundMapBindingNode.binding().key()));
+            duplicateMapKeyErrorMessage(contributionsForOneMapKey, multiboundMapBindingNode.key()));
       }
     }
   }
@@ -109,7 +108,7 @@ final class MapMultibindingValidation implements BindingGraphPlugin {
           ERROR,
           multiboundMapBindingNode,
           inconsistentMapKeyAnnotationTypesErrorMessage(
-              contributionsByMapKeyAnnotationType, multiboundMapBindingNode.binding().key()));
+              contributionsByMapKeyAnnotationType, multiboundMapBindingNode.key()));
     }
   }
 

--- a/java/dagger/internal/codegen/MapType.java
+++ b/java/dagger/internal/codegen/MapType.java
@@ -88,7 +88,20 @@ abstract class MapType {
   boolean valuesAreFrameworkType() {
     return FrameworkTypes.isFrameworkType(valueType());
   }
-  
+
+  /**
+   * {@code V} if {@link #valueType()} is a framework type like {@code Provider<V>} or {@code
+   * Producer<V>}.
+   *
+   * @throws IllegalStateException if {@link #isRawType()} is true or {@link #valueType()} is not a
+   *     framework type
+   */
+  TypeMirror unwrappedFrameworkValueType() {
+    checkState(
+        valuesAreFrameworkType(), "called unwrappedFrameworkValueType() on %s", declaredMapType());
+    return uncheckedUnwrappedValueType();
+  }
+
   /**
    * {@code V} if {@link #valueType()} is a {@code WrappingClass<V>}.
    *
@@ -103,6 +116,10 @@ abstract class MapType {
         "%s must have exactly one type parameter",
         wrappingClass);
     checkState(valuesAreTypeOf(wrappingClass), "expected values to be %s: %s", wrappingClass, this);
+    return uncheckedUnwrappedValueType();
+  }
+
+  private TypeMirror uncheckedUnwrappedValueType() {
     return MoreTypes.asDeclared(valueType()).getTypeArguments().get(0);
   }
 

--- a/java/dagger/internal/codegen/MembersInjectionBindingValidation.java
+++ b/java/dagger/internal/codegen/MembersInjectionBindingValidation.java
@@ -66,10 +66,10 @@ final class MembersInjectionBindingValidation implements BindingGraphPlugin {
   private Optional<TypeMirror> membersInjectedType(BindingNode bindingNode) {
     switch (bindingNode.binding().kind()) {
       case MEMBERS_INJECTION:
-        return Optional.of(bindingNode.binding().key().type());
+        return Optional.of(bindingNode.key().type());
 
       case MEMBERS_INJECTOR:
-        return Optional.of(types.unwrapType(bindingNode.binding().key().type()));
+        return Optional.of(types.unwrapType(bindingNode.key().type()));
 
       default:
         return Optional.empty();

--- a/java/dagger/internal/codegen/NullableBindingValidation.java
+++ b/java/dagger/internal/codegen/NullableBindingValidation.java
@@ -49,7 +49,7 @@ final class NullableBindingValidation implements BindingGraphPlugin {
             compilerOptions.nullableValidationKind(),
             dependencyEdge,
             nullableToNonNullable(
-                bindingNode.binding().key().toString(),
+                bindingNode.key().toString(),
                 bindingNode.toString())); // will include the @Nullable
       }
     }

--- a/java/dagger/internal/codegen/ProducerFromProviderCreationExpression.java
+++ b/java/dagger/internal/codegen/ProducerFromProviderCreationExpression.java
@@ -17,7 +17,6 @@
 package dagger.internal.codegen;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static dagger.internal.codegen.BindingType.PROVISION;
 
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
@@ -47,7 +46,7 @@ final class ProducerFromProviderCreationExpression implements FrameworkInstanceC
         RequestKind.PRODUCER,
         componentBindingExpressions
             .getDependencyExpression(
-                FrameworkDependency.create(binding.key(), PROVISION),
+                FrameworkDependency.create(binding.key(), FrameworkType.PROVIDER),
                 generatedComponentModel.name())
             .codeBlock());
   }

--- a/java/dagger/internal/codegen/ProducerInstanceBindingExpression.java
+++ b/java/dagger/internal/codegen/ProducerInstanceBindingExpression.java
@@ -16,8 +16,6 @@
 
 package dagger.internal.codegen;
 
-import javax.lang.model.util.Elements;
-
 /** Binding expression for producer instances. */
 final class ProducerInstanceBindingExpression extends FrameworkInstanceBindingExpression {
 
@@ -25,7 +23,7 @@ final class ProducerInstanceBindingExpression extends FrameworkInstanceBindingEx
       ResolvedBindings resolvedBindings,
       FrameworkInstanceSupplier frameworkInstanceSupplier,
       DaggerTypes types,
-      Elements elements) {
+      DaggerElements elements) {
     super(
         resolvedBindings,
         frameworkInstanceSupplier,

--- a/java/dagger/internal/codegen/ProviderInstanceBindingExpression.java
+++ b/java/dagger/internal/codegen/ProviderInstanceBindingExpression.java
@@ -16,8 +16,6 @@
 
 package dagger.internal.codegen;
 
-import javax.lang.model.util.Elements;
-
 /** Binding expression for provider instances. */
 final class ProviderInstanceBindingExpression extends FrameworkInstanceBindingExpression {
 
@@ -25,7 +23,7 @@ final class ProviderInstanceBindingExpression extends FrameworkInstanceBindingEx
       ResolvedBindings resolvedBindings,
       FrameworkInstanceSupplier frameworkInstanceSupplier,
       DaggerTypes types,
-      Elements elements) {
+      DaggerElements elements) {
     super(
         resolvedBindings,
         frameworkInstanceSupplier,

--- a/java/dagger/internal/codegen/ProvisionDependencyOnProducerBindingValidation.java
+++ b/java/dagger/internal/codegen/ProvisionDependencyOnProducerBindingValidation.java
@@ -111,6 +111,6 @@ final class ProvisionDependencyOnProducerBindingValidation implements BindingGra
       DependencyEdge dependencyOnProduction, BindingGraph bindingGraph) {
     return String.format(
         "%s is a provision, which cannot depend on a production.",
-        bindingRequestingDependency(dependencyOnProduction, bindingGraph).binding().key());
+        bindingRequestingDependency(dependencyOnProduction, bindingGraph).key());
   }
 }

--- a/java/dagger/internal/codegen/ResolvedBindings.java
+++ b/java/dagger/internal/codegen/ResolvedBindings.java
@@ -274,13 +274,6 @@ abstract class ResolvedBindings implements HasContributionType {
   }
 
   /**
-   * The framework class associated with these bindings.
-   */
-  Class<?> frameworkClass() {
-    return bindingType().frameworkClass();
-  }
-
-  /**
    * The scope associated with the single binding.
    *
    * @throws IllegalStateException if {@link #bindings()} does not have exactly one element

--- a/java/dagger/model/testing/BindingGraphSubject.java
+++ b/java/dagger/model/testing/BindingGraphSubject.java
@@ -96,10 +96,8 @@ public final class BindingGraphSubject extends Subject<BindingGraphSubject, Bind
   }
 
   private ImmutableSet<BindingNode> getBindingNodes(String keyString) {
-    return actual()
-        .bindingNodes()
-        .stream()
-        .filter(node -> node.binding().key().toString().equals(keyString))
+    return actual().bindingNodes().stream()
+        .filter(node -> node.key().toString().equals(keyString))
         .collect(toImmutableSet());
   }
 
@@ -139,12 +137,10 @@ public final class BindingGraphSubject extends Subject<BindingGraphSubject, Bind
     }
 
     private void dependsOnBindingWithKeyString(String keyString) {
-      if (actualBindingGraph()
-          .successors(actual())
-          .stream()
+      if (actualBindingGraph().successors(actual()).stream()
           .filter(node -> node instanceof BindingNode)
           .map(node -> (BindingNode) node)
-          .noneMatch(node -> node.binding().key().toString().equals(keyString))) {
+          .noneMatch(node -> node.key().toString().equals(keyString))) {
         fail("has successor with key", keyString);
       }
     }

--- a/java/dagger/spi/DiagnosticReporter.java
+++ b/java/dagger/spi/DiagnosticReporter.java
@@ -18,15 +18,17 @@ package dagger.spi;
 
 import com.google.errorprone.annotations.FormatMethod;
 import dagger.model.BindingGraph;
-import dagger.model.BindingGraph.BindingNode;
 import dagger.model.BindingGraph.ChildFactoryMethodEdge;
 import dagger.model.BindingGraph.ComponentNode;
 import dagger.model.BindingGraph.DependencyEdge;
+import dagger.model.BindingGraph.MaybeBindingNode;
 import javax.tools.Diagnostic;
 
 /**
  * An object that {@link BindingGraphPlugin}s can use to report diagnostics while visiting a {@link
  * BindingGraph}.
+ *
+ * <p>Note: This API is still experimental and will change.
  */
 public interface DiagnosticReporter {
   /**
@@ -48,19 +50,19 @@ public interface DiagnosticReporter {
       Object... moreArgs);
 
   /**
-   * Reports a diagnostic for a binding. Includes information about how the binding is reachable
-   * from entry points.
+   * Reports a diagnostic for a binding or missing binding. Includes information about how the
+   * binding is reachable from entry points.
    */
-  void reportBinding(Diagnostic.Kind diagnosticKind, BindingNode bindingNode, String message);
+  void reportBinding(Diagnostic.Kind diagnosticKind, MaybeBindingNode bindingNode, String message);
 
   /**
-   * Reports a diagnostic for a binding. Includes information about how the binding is reachable
-   * from entry points.
+   * Reports a diagnostic for a binding or missing binding. Includes information about how the
+   * binding is reachable from entry points.
    */
   @FormatMethod
   void reportBinding(
       Diagnostic.Kind diagnosticKind,
-      BindingNode bindingNode,
+      MaybeBindingNode bindingNode,
       String messageFormat,
       Object firstArg,
       Object... moreArgs);

--- a/javatests/dagger/internal/codegen/FrameworkTypeMapperTest.java
+++ b/javatests/dagger/internal/codegen/FrameworkTypeMapperTest.java
@@ -17,8 +17,6 @@
 package dagger.internal.codegen;
 
 import static com.google.common.truth.Truth.assertThat;
-import static dagger.internal.codegen.BindingType.PRODUCTION;
-import static dagger.internal.codegen.BindingType.PROVISION;
 import static dagger.model.RequestKind.INSTANCE;
 import static dagger.model.RequestKind.LAZY;
 import static dagger.model.RequestKind.PRODUCED;
@@ -29,32 +27,22 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Test case for {@link BindingTypeMapper}.
- */
+/** Test case for {@link FrameworkTypeMapper}. */
 @RunWith(JUnit4.class)
-public class BindingTypeMapperTest {
+public class FrameworkTypeMapperTest {
   @Test public void forProvider() {
-    BindingTypeMapper mapper = BindingTypeMapper.FOR_PROVIDER;
-    assertThat(mapper.getBindingType(INSTANCE))
-        .isEqualTo(PROVISION);
-    assertThat(mapper.getBindingType(LAZY))
-        .isEqualTo(PROVISION);
-    assertThat(mapper.getBindingType(PROVIDER))
-        .isEqualTo(PROVISION);
+    FrameworkTypeMapper mapper = FrameworkTypeMapper.FOR_PROVIDER;
+    assertThat(mapper.getFrameworkType(INSTANCE)).isEqualTo(FrameworkType.PROVIDER);
+    assertThat(mapper.getFrameworkType(LAZY)).isEqualTo(FrameworkType.PROVIDER);
+    assertThat(mapper.getFrameworkType(PROVIDER)).isEqualTo(FrameworkType.PROVIDER);
   }
 
   @Test public void forProducer() {
-    BindingTypeMapper mapper = BindingTypeMapper.FOR_PRODUCER;
-    assertThat(mapper.getBindingType(INSTANCE))
-        .isEqualTo(PRODUCTION);
-    assertThat(mapper.getBindingType(LAZY))
-        .isEqualTo(PROVISION);
-    assertThat(mapper.getBindingType(PROVIDER))
-        .isEqualTo(PROVISION);
-    assertThat(mapper.getBindingType(PRODUCER))
-        .isEqualTo(PRODUCTION);
-    assertThat(mapper.getBindingType(PRODUCED))
-        .isEqualTo(PRODUCTION);
+    FrameworkTypeMapper mapper = FrameworkTypeMapper.FOR_PRODUCER;
+    assertThat(mapper.getFrameworkType(INSTANCE)).isEqualTo(FrameworkType.PRODUCER);
+    assertThat(mapper.getFrameworkType(LAZY)).isEqualTo(FrameworkType.PROVIDER);
+    assertThat(mapper.getFrameworkType(PROVIDER)).isEqualTo(FrameworkType.PROVIDER);
+    assertThat(mapper.getFrameworkType(PRODUCER)).isEqualTo(FrameworkType.PRODUCER);
+    assertThat(mapper.getFrameworkType(PRODUCED)).isEqualTo(FrameworkType.PRODUCER);
   }
 }

--- a/javatests/dagger/spi/FailingPlugin.java
+++ b/javatests/dagger/spi/FailingPlugin.java
@@ -45,12 +45,11 @@ public final class FailingPlugin implements BindingGraphPlugin {
       String key = options.get("error_on_binding");
       bindingGraph.bindingNodes().stream()
           .filter(node -> node.key().toString().equals(key))
-          .forEach(node -> diagnosticReporter.reportBinding(ERROR, node, "Bad %s!", "Binding"));
+          .forEach(node -> diagnosticReporter.reportBinding(ERROR, node, "Bad Binding!"));
     }
 
     if (options.containsKey("error_on_component")) {
-      diagnosticReporter.reportComponent(
-          ERROR, bindingGraph.rootComponentNode(), "Bad %s!", "Component");
+      diagnosticReporter.reportComponent(ERROR, bindingGraph.rootComponentNode(), "Bad Component!");
     }
 
     if (options.containsKey("error_on_subcomponents")) {
@@ -63,9 +62,7 @@ public final class FailingPlugin implements BindingGraphPlugin {
 
     if (options.containsKey("error_on_dependency")) {
       String dependency = options.get("error_on_dependency");
-      bindingGraph
-          .dependencyEdges()
-          .stream()
+      bindingGraph.dependencyEdges().stream()
           .filter(
               edge ->
                   edge.dependencyRequest()
@@ -73,8 +70,7 @@ public final class FailingPlugin implements BindingGraphPlugin {
                       .get()
                       .getSimpleName()
                       .contentEquals(dependency))
-          .forEach(
-              edge -> diagnosticReporter.reportDependency(ERROR, edge, "Bad %s!", "Dependency"));
+          .forEach(edge -> diagnosticReporter.reportDependency(ERROR, edge, "Bad Dependency!"));
     }
   }
 

--- a/javatests/dagger/spi/FailingPlugin.java
+++ b/javatests/dagger/spi/FailingPlugin.java
@@ -43,10 +43,8 @@ public final class FailingPlugin implements BindingGraphPlugin {
   public void visitGraph(BindingGraph bindingGraph, DiagnosticReporter diagnosticReporter) {
     if (options.containsKey("error_on_binding")) {
       String key = options.get("error_on_binding");
-      bindingGraph
-          .bindingNodes()
-          .stream()
-          .filter(node -> node.binding().key().toString().equals(key))
+      bindingGraph.bindingNodes().stream()
+          .filter(node -> node.key().toString().equals(key))
           .forEach(node -> diagnosticReporter.reportBinding(ERROR, node, "Bad %s!", "Binding"));
     }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Avoid IncompatibleClassChangeError in DiagnosticReporterImpl when guava_jdk5 is on the processor path.

RELNOTES=Avoid IncompatibleClassChangeError in DiagnosticReporterImpl when guava-android is on the processor path.

f6a6735307c569bba8d97e68d44a653291a7ceb2

-------

<p> Print specific warning when options don't have values

dcc7571a218acd60f98ea25c3e6cb6e8b3285db3

-------

<p> Remove unnecessary BindingType.frameworkType(), and now we can delete FrameworkType.MEMBERS_INJECTOR. We never use a MemberInjector field anymore.

e098076d8feef367e31ef68a3eff5ccc167ee3e0

-------

<p> Moved knowledge of framework classes out of BindingType and consolidated them into FrameworkType.

9eee3fa1b0988a31f20c4ec69eb5d466e2e812f2

-------

<p> Make BindingNode and MissingBindingNode extend a common interface, MaybeBindingNode, so that dependencies on missing bindings can be treated the same way as dependencies on present bindings.

This is required to report missing bindings only once across all their requests.

a0333518ef83bec3e5bdd7e97870a38ca05a042a

-------

<p> Simplify FailingPlugin.

bf62e8ffaaaf92389eda5f3ce1a9a9a880073aaa

-------

<p> Fix and make sure our maven examples always compile

Fixes https://github.com/google/dagger/issues/1224

c6adb1418da7e96b4b512dda4e5da2f9a6f295cd