### PR TITLE
java/dagger/internal/codegen/BUILD: rm tools.jar dep.

### DIFF
--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -36,13 +36,13 @@ CODEGEN_SRCS = glob(
 CODEGEN_PLUGINS = [":bootstrap_compiler_plugin"]
 
 CODEGEN_SHARED_DEPS = [
+    "@bazel_tools//third_party/java/jdk/langtools:javac",
     "@google_bazel_common//third_party/java/auto:service",
     "@google_bazel_common//third_party/java/auto:value",
     "@google_bazel_common//third_party/java/auto:common",
     "@google_bazel_common//third_party/java/error_prone:annotations",
     "@google_bazel_common//third_party/java/google_java_format",
     "@google_bazel_common//third_party/java/javapoet",
-    "@local_jdk//:lib/tools.jar",
     "@google_bazel_common//third_party/java/jsr250_annotations",
     "@google_bazel_common//third_party/java/jsr330_inject",
     "//java/dagger:core",


### PR DESCRIPTION
When building Dagger with Bazel, a dependency on the local JDK's tools.jar is used to resolve two javadoc references to classes in `com.sun` (one each in [Accessibility.java](https://github.com/google/dagger/blob/29db569ff349acd7b102be045f404db6bc771167/java/dagger/internal/codegen/Accessibility.java#L58) and [MemberSelect.java](https://github.com/google/dagger/blob/29db569ff349acd7b102be045f404db6bc771167/java/dagger/internal/codegen/MemberSelect.java#L45)).

tools.jar [no longer exists](https://docs.oracle.com/javase/9/migrate/toc.htm#JSMIG-GUID-A78CC891-701D-4549-AA4E-B8DD90228B4B) in JDK9+, so building Dagger with Bazel with local JDK9+ is broken. This commit removes the tools.jar dependency, using instead a dependency on Bazel's embedded javac jar that also provides the `com.sun` references. This dependency is already being used by Dagger to compile its Kythe plugin.

This is a partial fix for #1286.