### PR TITLE
fix //j/d/internal/codegen:processor_manifest_files.

### DIFF
--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -19,7 +19,6 @@ package(default_visibility = ["//:src"])
 
 load("//:build_defs.bzl", "DOCLINT_HTML_AND_SYNTAX", "DOCLINT_REFERENCES")
 load("//tools:maven.bzl", "pom_file", "POM_VERSION")
-load("//tools:simple_jar.bzl", "simple_jar")
 
 EXPERIMENTAL_VISUALIZER_SRCS = ["BindingNetworkVisualizer.java"]
 
@@ -308,9 +307,20 @@ java_library(
     ],
 )
 
-simple_jar(
+genrule(
     name = "processor_manifest_files",
-    srcs = glob(["META-INF/**"]),
+    srcs = [
+        "META-INF/gradle/incremental.annotation.processors",
+    ],
+    outs = [
+        "processor_manifest_files.jar",
+    ],
+    cmd = """
+OUT="$$(pwd)/$@"
+mkdir -p $(@D)/META-INF/gradle
+cp $(<) $(@D)/META-INF/gradle
+cd $(@D)
+zip "$$OUT" -r * &> /dev/null"""
 )
 
 # The processor's "main", if you will


### PR DESCRIPTION
the [simple_jar macro](https://github.com/google/dagger/blob/beefa94d8eda8cd74a01346a4eeeaf16744348a5/tools/simple_jar.bzl#L17) is used in two places in Dagger BUILD files to create an archive of metadata that can be used by Gradle.

simple_jar makes an unwarranted assumption about the layout of the working directory associated with its genrule's action. it `cd`'s directly from the genrule's execroot to the calling package's path (e.g. `java/dagger/internal/codegen`). however, when the simple_jar is built from a downstream bazel repo (`bazel build @dagger//java/dagger/internal/codegen:processor_manifest_files`), the action's execroot will have a top-level `external` directory ([docs](https://docs.bazel.build/versions/master/output_directories.html)). `cd`'ing directly into `java/dagger/internal/codegen` will fail.

since processor_manifest_files.jar is [included as a resource_jar](https://github.com/google/dagger/blob/c0efd334476a1b13f2361af3172f20299ba6a23f/java/dagger/internal/codegen/BUILD#L341) to the main processor java_library, this means that using Dagger as an external Bazel repo has been broken since that resource_jar was added (cd83b30).

this commit inlines :processor_manifest_files into a genrule that sets up the desired archive layout manually. (the root of the generated jar is still `META-INF`.) it does not change the [one remaining simple_jar use](https://github.com/google/dagger/blob/beefa94d8eda8cd74a01346a4eeeaf16744348a5/java/dagger/android/processor/BUILD#L74), as that is not required to build :processor from a downstream Bazel repo.

This is a partial fix for #1286.