### PR TITLE
Moe Sync

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+import %workspace%/tools/bazel.rc

--- a/java/dagger/android/AndroidInjectionModule.java
+++ b/java/dagger/android/AndroidInjectionModule.java
@@ -35,6 +35,12 @@ import java.util.Map;
 @Module
 public abstract class AndroidInjectionModule {
   @Multibinds
+  abstract Map<Class<?>, AndroidInjector.Factory<?>> allInjectorFactories();
+
+  @Multibinds
+  abstract Map<String, AndroidInjector.Factory<?>> allInjectorFactoriesWithStringKeys();
+
+  @Multibinds
   abstract Map<Class<? extends Activity>, AndroidInjector.Factory<? extends Activity>>
       activityInjectorFactories();
 

--- a/java/dagger/android/processor/AndroidInjectorDescriptor.java
+++ b/java/dagger/android/processor/AndroidInjectorDescriptor.java
@@ -20,7 +20,7 @@ import static com.google.auto.common.AnnotationMirrors.getAnnotatedAnnotations;
 import static com.google.auto.common.AnnotationMirrors.getAnnotationValue;
 import static com.google.auto.common.MoreElements.getAnnotationMirror;
 import static com.google.auto.common.MoreElements.isAnnotationPresent;
-import static dagger.android.processor.AndroidMapKeys.annotationsAndFrameworkTypes;
+import static dagger.android.processor.AndroidMapKeys.frameworkTypesByMapKey;
 import static java.util.stream.Collectors.toList;
 import static javax.lang.model.element.Modifier.ABSTRACT;
 
@@ -60,15 +60,6 @@ abstract class AndroidInjectorDescriptor {
   /** The type to be injected; the return type of the {@link ContributesAndroidInjector} method. */
   abstract ClassName injectedType();
 
-  /**
-   * The base framework type of {@link #injectedType()}, e.g. {@code Activity}, {@code Fragment},
-   * etc.
-   */
-  abstract ClassName frameworkType();
-
-  /** The {@link dagger.MapKey} type for the associated {@link #frameworkType()}. */
-  abstract ClassName mapKeyType();
-
   /** Scopes to apply to the generated {@link dagger.Subcomponent}. */
   abstract ImmutableSet<AnnotationSpec> scopes();
 
@@ -88,10 +79,6 @@ abstract class AndroidInjectorDescriptor {
     abstract ImmutableSet.Builder<AnnotationSpec> scopesBuilder();
 
     abstract ImmutableSet.Builder<ClassName> modulesBuilder();
-
-    abstract Builder frameworkType(ClassName frameworkType);
-
-    abstract Builder mapKeyType(ClassName mapKeyType);
 
     abstract Builder enclosingModule(ClassName enclosingModule);
 
@@ -136,18 +123,13 @@ abstract class AndroidInjectorDescriptor {
 
       TypeMirror injectedType = method.getReturnType();
       Optional<? extends Class<? extends Annotation>> maybeMapKeyAnnotation =
-          annotationsAndFrameworkTypes(elements)
+          frameworkTypesByMapKey(elements)
               .entrySet()
               .stream()
               .filter(entry -> types.isAssignable(injectedType, entry.getValue()))
               .map(Map.Entry::getKey)
               .findFirst();
       if (maybeMapKeyAnnotation.isPresent()) {
-        Class<? extends Annotation> mapKeyAnnotation = maybeMapKeyAnnotation.get();
-        TypeMirror frameworkType = annotationsAndFrameworkTypes(elements).get(mapKeyAnnotation);
-        builder
-            .mapKeyType(ClassName.get(mapKeyAnnotation))
-            .frameworkType((ClassName) TypeName.get(frameworkType));
         if (MoreTypes.asDeclared(injectedType).getTypeArguments().isEmpty()) {
           builder.injectedType(ClassName.get(MoreTypes.asTypeElement(injectedType)));
         } else {

--- a/java/dagger/android/processor/AndroidMapKeyValidator.java
+++ b/java/dagger/android/processor/AndroidMapKeyValidator.java
@@ -20,7 +20,7 @@ import static com.google.auto.common.AnnotationMirrors.getAnnotatedAnnotations;
 import static com.google.auto.common.MoreElements.getAnnotationMirror;
 import static com.google.auto.common.MoreElements.isAnnotationPresent;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static dagger.android.processor.AndroidMapKeys.annotationsAndFrameworkTypes;
+import static dagger.android.processor.AndroidMapKeys.frameworkTypesByMapKey;
 import static dagger.android.processor.AndroidMapKeys.injectedTypeFromMapKey;
 
 import com.google.auto.common.BasicAnnotationProcessor.ProcessingStep;
@@ -29,8 +29,10 @@ import com.google.auto.common.MoreTypes;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
 import dagger.Binds;
+import dagger.MapKey;
 import dagger.android.AndroidInjectionKey;
 import dagger.android.AndroidInjector;
+import dagger.multibindings.ClassKey;
 import java.lang.annotation.Annotation;
 import java.util.Set;
 import javax.annotation.processing.Messager;
@@ -64,8 +66,9 @@ final class AndroidMapKeyValidator implements ProcessingStep {
   @Override
   public Set<? extends Class<? extends Annotation>> annotations() {
     return ImmutableSet.<Class<? extends Annotation>>builder()
-        .addAll(annotationsAndFrameworkTypes(elements).keySet())
+        .addAll(frameworkTypesByMapKey(elements).keySet())
         .add(AndroidInjectionKey.class)
+        .add(ClassKey.class)
         .build();
   }
 
@@ -88,8 +91,6 @@ final class AndroidMapKeyValidator implements ProcessingStep {
       return;
     }
 
-    TypeMirror frameworkType = frameworkTypeForMapKey(method, annotation);
-
     if (!getAnnotatedAnnotations(method, Scope.class).isEmpty()) {
       SuppressWarnings suppressedWarnings = method.getAnnotation(SuppressWarnings.class);
       if (suppressedWarnings == null
@@ -99,30 +100,67 @@ final class AndroidMapKeyValidator implements ProcessingStep {
             Kind.ERROR,
             String.format(
                 "%s bindings should not be scoped. Scoping this method may leak instances of %s. ",
-                AndroidInjector.Factory.class.getCanonicalName(), frameworkType),
+                AndroidInjector.Factory.class.getCanonicalName(), frameworkTypeForMapKey(method)),
             method);
       }
     }
 
-    DeclaredType intendedReturnType = injectorFactoryOf(types.getWildcardType(frameworkType, null));
-    if (!MoreTypes.equivalence().equivalent(returnType, intendedReturnType)) {
-      String subject =
-          annotation.equals(AndroidInjectionKey.class)
-              ? method.toString()
-              : String.format("@%s methods", annotation.getCanonicalName());
-
-      messager.printMessage(
-          Kind.ERROR,
-          String.format(
-              "%s should bind %s, not %s. See https://google.github.io/dagger/android",
-              subject, intendedReturnType, returnType),
-          method);
-    }
+    validateReturnTypeMatchesMapKey(method, annotation);
 
     // @Binds methods should only have one parameter, but we can't guarantee the order of Processors
     // in javac, so do a basic check for valid form
     if (isAnnotationPresent(method, Binds.class) && method.getParameters().size() == 1) {
       validateMapKeyMatchesBindsParameter(annotation, method);
+    }
+  }
+
+  /**
+   * Report an error if the method's return type doesn't match the expectations for the map key
+   * annotation.
+   *
+   * <ul>
+   *   <li>Methods annotated with {@code @ClassKey} must return {@code AndroidInjector.Factory<?>}.
+   *   <li>Methods annotated with {@code @AndroidInjectionKey} must return either {@code
+   *       AndroidInjector.Factory<?>} or {@code AndroidInjector.Factory<? extends AndroidType>},
+   *       where {@code AndroidType} is the Android component type extended by the map key class.
+   *   <li>Methods annotated with {@code @ActivityKey}, {@code FragmentKey}, etc., must return
+   *       {@code AndroidInjector.Factory<? extends Activity>}, {@code AndroidInjector.Factory<?
+   *       extends Fragment>}, etc.
+   * </ul>
+   */
+  private void validateReturnTypeMatchesMapKey(
+      ExecutableElement method, Class<? extends Annotation> mapKeyType) {
+    TypeMirror returnType = method.getReturnType();
+    DeclaredType boundedInjectorFactoryType =
+        injectorFactoryOf(types.getWildcardType(frameworkTypeForMapKey(method), null));
+    DeclaredType unboundedInjectorFactoryType =
+        injectorFactoryOf(types.getWildcardType(null, null));
+
+    // first check the original return type format, AndroidInjector.Factory<? extends FRAMEWORK>.
+    // This should match all map keys besides ClassKey.
+    boolean isValidReturnType =
+        mapKeyType != ClassKey.class
+            && MoreTypes.equivalence().equivalent(returnType, boundedInjectorFactoryType);
+
+    // if the first check fails, check if the return type matches the new, all-encompassing
+    // multibindings: AndroidInjector.Factory<?>. This is only supported for ClassKey (which has an
+    // unbounded Class<?> return type) or AndroidInjectionKey
+    isValidReturnType |=
+        ((mapKeyType == ClassKey.class || mapKeyType == AndroidInjectionKey.class)
+            && MoreTypes.equivalence().equivalent(returnType, unboundedInjectorFactoryType));
+
+    if (!isValidReturnType) {
+      String subject =
+          mapKeyType.equals(AndroidInjectionKey.class)
+              ? method.toString()
+              : String.format("@%s methods", mapKeyType.getCanonicalName());
+
+      messager.printMessage(
+          Kind.ERROR,
+          String.format(
+              "%s should bind %s, not %s. See https://google.github.io/dagger/android",
+              subject, boundedInjectorFactoryType, returnType),
+          method);
     }
   }
 
@@ -155,12 +193,13 @@ final class AndroidMapKeyValidator implements ProcessingStep {
     }
   }
 
-  private TypeMirror frameworkTypeForMapKey(
-      ExecutableElement method, Class<? extends Annotation> annotation) {
-    AnnotationMirror annotationMirror = getAnnotationMirror(method, annotation).get();
+  /** Returns the framework type that {@code method}'s map key annotation represents. */
+  private TypeMirror frameworkTypeForMapKey(ExecutableElement method) {
+    AnnotationMirror mapKeyAnnotation =
+        getOnlyElement(getAnnotatedAnnotations(method, MapKey.class));
     TypeMirror mapKeyType =
-        elements.getTypeElement(injectedTypeFromMapKey(annotationMirror).get()).asType();
-    return annotationsAndFrameworkTypes(elements)
+        elements.getTypeElement(injectedTypeFromMapKey(mapKeyAnnotation).get()).asType();
+    return frameworkTypesByMapKey(elements)
         .values()
         .stream()
         .filter(frameworkType -> types.isAssignable(mapKeyType, frameworkType))

--- a/java/dagger/android/processor/AndroidMapKeys.java
+++ b/java/dagger/android/processor/AndroidMapKeys.java
@@ -46,7 +46,7 @@ final class AndroidMapKeys {
    * framework, and only contain the support library types if they are on the classpath of the
    * current compilation.
    */
-  static ImmutableMap<Class<? extends Annotation>, TypeMirror> annotationsAndFrameworkTypes(
+  static ImmutableMap<Class<? extends Annotation>, TypeMirror> frameworkTypesByMapKey(
       Elements elements) {
     return ImmutableMap.copyOf(
         Stream.of(

--- a/java/dagger/android/processor/ContributesAndroidInjectorGenerator.java
+++ b/java/dagger/android/processor/ContributesAndroidInjectorGenerator.java
@@ -50,6 +50,7 @@ import dagger.android.AndroidInjectionKey;
 import dagger.android.AndroidInjector;
 import dagger.android.ContributesAndroidInjector;
 import dagger.android.processor.AndroidInjectorDescriptor.Validator;
+import dagger.multibindings.ClassKey;
 import dagger.multibindings.IntoMap;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -144,7 +145,7 @@ final class ContributesAndroidInjectorGenerator implements ProcessingStep {
         .returns(
             parameterizedTypeName(
                 AndroidInjector.Factory.class,
-                WildcardTypeName.subtypeOf(descriptor.frameworkType())))
+                WildcardTypeName.subtypeOf(TypeName.OBJECT)))
         .addParameter(subcomponentBuilderName, "builder")
         .build();
   }
@@ -155,7 +156,7 @@ final class ContributesAndroidInjectorGenerator implements ProcessingStep {
           .addMember("value", "$S", descriptor.injectedType().toString())
           .build();
     }
-    return AnnotationSpec.builder(descriptor.mapKeyType())
+    return AnnotationSpec.builder(ClassKey.class)
         .addMember("value", "$T.class", descriptor.injectedType())
         .build();
   }

--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -18,7 +18,7 @@
 package(default_visibility = ["//:src"])
 
 load("//:build_defs.bzl", "DOCLINT_HTML_AND_SYNTAX", "DOCLINT_REFERENCES")
-load("//tools:maven.bzl", "pom_file", "POM_VERSION")
+load("//tools:maven.bzl", "POM_VERSION", "pom_file")
 load("//tools:simple_jar.bzl", "simple_jar")
 
 EXPERIMENTAL_VISUALIZER_SRCS = ["BindingNetworkVisualizer.java"]
@@ -257,6 +257,7 @@ java_library(
         "GeneratedComponentModel.java",
         "GeneratedInstanceBindingExpression.java",
         "GwtCompatibility.java",
+        "HjarSourceFileGenerator.java",
         "ImmediateFutureBindingExpression.java",
         "InaccessibleMapKeyProxyGenerator.java",
         "InjectionMethods.java",
@@ -342,6 +343,7 @@ java_library(
         "ProcessingEnvironmentModule.java",
         "ProcessingOptions.java",
         "ProductionExecutorModuleProcessingStep.java",
+        "SourceFileGeneratorsModule.java",
         "SystemComponentsModule.java",
     ],
     plugins = CODEGEN_PLUGINS,

--- a/java/dagger/internal/codegen/CodeBlocks.java
+++ b/java/dagger/internal/codegen/CodeBlocks.java
@@ -25,62 +25,42 @@ import static javax.lang.model.element.Modifier.PUBLIC;
 
 import com.google.auto.common.MoreElements;
 import com.google.auto.common.MoreTypes;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
-import com.squareup.javapoet.CodeBlock.Builder;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeName;
 import java.util.stream.Collector;
 import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
 
 final class CodeBlocks {
   /**
-   * A {@link Collector} implementation that joins {@link CodeBlock} instances together into one
-   * separated by {@code delimiter}. For example, joining {@code String s}, {@code Object o} and
-   * {@code int i} using {@code ", "} would produce {@code String s, Object o, int i}.
-   */
-  static Collector<CodeBlock, ?, CodeBlock> joiningCodeBlocks(String delimiter) {
-    return Collector.of(
-        () -> new CodeBlockJoiner(delimiter, CodeBlock.builder()),
-        CodeBlockJoiner::add,
-        CodeBlockJoiner::merge,
-        CodeBlockJoiner::join);
-  }
-
-  /**
    * Joins {@link CodeBlock} instances in a manner suitable for use as method parameters (or
-   * arguments). This is equivalent to {@code joiningCodeBlocks(", ")}.
+   * arguments).
    */
   static Collector<CodeBlock, ?, CodeBlock> toParametersCodeBlock() {
-    return joiningCodeBlocks(", ");
+    // TODO(ronshapiro,jakew): consider adding zero-width spaces to help line breaking when the
+    // formatter is off. If not, inline this
+    return CodeBlock.joining(", ");
   }
 
-  /**
-   * Joins {@link TypeName} instances into a {@link CodeBlock} that is a comma-separated list for
-   * use as type parameters or javadoc method arguments.
-   */
-  static Collector<TypeName, ?, CodeBlock> toTypeNamesCodeBlock() {
-    return Collector.of(
-        () -> new CodeBlockJoiner(", ", CodeBlock.builder()),
-        CodeBlockJoiner::addTypeName,
-        CodeBlockJoiner::merge,
-        CodeBlockJoiner::join);
-  }
-
-  /**
-   * Concatenates {@link CodeBlock} instances separated by newlines for readability. This is
-   * equivalent to {@code joiningCodeBlocks("\n")}.
-   */
+  /** Concatenates {@link CodeBlock} instances separated by newlines for readability. */
   static Collector<CodeBlock, ?, CodeBlock> toConcatenatedCodeBlock() {
-    return joiningCodeBlocks("\n");
+    return CodeBlock.joining("\n", "", "\n");
   }
 
   /** Returns a comma-separated version of {@code codeBlocks} as one unified {@link CodeBlock}. */
   static CodeBlock makeParametersCodeBlock(Iterable<CodeBlock> codeBlocks) {
     return stream(codeBlocks.spliterator(), false).collect(toParametersCodeBlock());
+  }
+
+  /**
+   * Returns one unified {@link CodeBlock} which joins each item in {@code codeBlocks} with a
+   * newline.
+   */
+  static CodeBlock concat(Iterable<CodeBlock> codeBlocks) {
+    return stream(codeBlocks.spliterator(), false).collect(toConcatenatedCodeBlock());
   }
 
   /** Adds an annotation to a method. */
@@ -111,57 +91,8 @@ final class CodeBlocks {
     return CodeBlock.of("($T) $L", castTo, expression);
   }
 
-  private static final class CodeBlockJoiner {
-    private final String delimiter;
-    private final CodeBlock.Builder builder;
-    private boolean first = true;
-
-    CodeBlockJoiner(String delimiter, Builder builder) {
-      this.delimiter = delimiter;
-      this.builder = builder;
-    }
-
-    @CanIgnoreReturnValue
-    CodeBlockJoiner add(CodeBlock codeBlock) {
-      maybeAddDelimiter();
-      builder.add(codeBlock);
-      return this;
-    }
-
-    @CanIgnoreReturnValue
-    CodeBlockJoiner addTypeName(TypeName typeName) {
-      maybeAddDelimiter();
-      builder.add("$T", typeName);
-      return this;
-    }
-
-    private void maybeAddDelimiter() {
-      if (!first) {
-        builder.add(delimiter);
-      }
-      first = false;
-    }
-
-    @CanIgnoreReturnValue
-    CodeBlockJoiner merge(CodeBlockJoiner other) {
-      CodeBlock otherBlock = other.builder.build();
-      if (!otherBlock.isEmpty()) {
-        add(otherBlock);
-      }
-      return this;
-    }
-
-    CodeBlock join() {
-      return builder.build();
-    }
-  }
-
-  /**
-   * Returns one unified {@link CodeBlock} which joins each item in {@code codeBlocks} with a
-   * newline.
-   */
-  static CodeBlock concat(Iterable<CodeBlock> codeBlocks) {
-    return stream(codeBlocks.spliterator(), false).collect(toConcatenatedCodeBlock());
+  static CodeBlock type(TypeMirror type) {
+    return CodeBlock.of("$T", type);
   }
 
   static CodeBlock stringLiteral(String toWrap) {
@@ -195,10 +126,8 @@ final class CodeBlocks {
         executableElement
             .getParameters()
             .stream()
-            .map(VariableElement::asType)
-            .map(TypeName::get)
-            .map(TypeNames::rawTypeName)
-            .collect(toTypeNamesCodeBlock()));
+            .map(parameter -> CodeBlock.of("$T", rawTypeName(TypeName.get(parameter.asType()))))
+            .collect(toParametersCodeBlock()));
     return builder.add(")}").build();
   }
 

--- a/java/dagger/internal/codegen/ComponentProcessingStep.java
+++ b/java/dagger/internal/codegen/ComponentProcessingStep.java
@@ -49,7 +49,7 @@ final class ComponentProcessingStep implements ProcessingStep {
   private final ComponentDescriptorValidator componentDescriptorValidator;
   private final ComponentDescriptor.Factory componentDescriptorFactory;
   private final BindingGraphFactory bindingGraphFactory;
-  private final ComponentGenerator componentGenerator;
+  private final SourceFileGenerator<BindingGraph> componentGenerator;
   private final BindingGraphConverter bindingGraphConverter;
   private final BindingGraphPlugins validationPlugins;
   private final BindingGraphPlugins spiPlugins;
@@ -63,7 +63,7 @@ final class ComponentProcessingStep implements ProcessingStep {
       ComponentDescriptorValidator componentDescriptorValidator,
       ComponentDescriptor.Factory componentDescriptorFactory,
       BindingGraphFactory bindingGraphFactory,
-      ComponentGenerator componentGenerator,
+      SourceFileGenerator<BindingGraph> componentGenerator,
       BindingGraphConverter bindingGraphConverter,
       @Validation BindingGraphPlugins validationPlugins,
       BindingGraphPlugins spiPlugins,

--- a/java/dagger/internal/codegen/ComponentProcessor.java
+++ b/java/dagger/internal/codegen/ComponentProcessor.java
@@ -50,8 +50,8 @@ public class ComponentProcessor extends BasicAnnotationProcessor {
   private final Optional<ImmutableSet<BindingGraphPlugin>> testingPlugins;
 
   @Inject InjectBindingRegistry injectBindingRegistry;
-  @Inject FactoryGenerator factoryGenerator;
-  @Inject MembersInjectorGenerator membersInjectorGenerator;
+  @Inject SourceFileGenerator<ProvisionBinding> factoryGenerator;
+  @Inject SourceFileGenerator<MembersInjectionBinding> membersInjectorGenerator;
   @Inject ImmutableList<ProcessingStep> processingSteps;
   @Inject BindingGraphPlugins spiPlugins;
   @Inject CompilerOptions compilerOptions;
@@ -124,6 +124,7 @@ public class ComponentProcessor extends BasicAnnotationProcessor {
         BindingMethodValidatorsModule.class,
         IncorrectlyInstalledBindsMethodsValidator.Module.class,
         ProcessingStepsModule.class,
+        SourceFileGeneratorsModule.class,
         SystemComponentsModule.class
       })
   interface ProcessorComponent {
@@ -174,7 +175,9 @@ public class ComponentProcessor extends BasicAnnotationProcessor {
           bindsInstanceProcessingStep,
           moduleProcessingStep,
           compilerOptions.headerCompilation()
-                  // TODO(b/72748365): Support hjars for ahead-of-time subcomponents.
+                  // Ahead Of Time subcomponents use the regular hjar filtering in
+                  // HjarSourceFileGenerator since they must retain protected implementation methods
+                  // between subcomponents
                   && !compilerOptions.aheadOfTimeSubcomponents()
               ? componentHjarProcessingStep
               : componentProcessingStep,

--- a/java/dagger/internal/codegen/GeneratedComponentBuilderModel.java
+++ b/java/dagger/internal/codegen/GeneratedComponentBuilderModel.java
@@ -186,19 +186,23 @@ final class GeneratedComponentBuilderModel {
       buildMethod.returns(ClassName.get(graph.componentType())).addModifiers(PUBLIC);
 
       builderFields.forEach(
-          (requirement, builderField) -> {
+          (requirement, field) -> {
             switch (requirement.nullPolicy(elements, types)) {
               case NEW:
-                buildMethod.addCode(
-                    "if ($1N == null) { this.$1N = new $2T(); }", builderField, builderField.type);
+                buildMethod
+                    .beginControlFlow("if ($N == null)", field)
+                    .addStatement("this.$N = new $T()", field, field.type)
+                    .endControlFlow();
                 break;
               case THROW:
-                buildMethod.addCode(
-                    "if ($N == null) { throw new $T($T.class.getCanonicalName() + $S); }",
-                    builderField,
-                    IllegalStateException.class,
-                    TypeNames.rawTypeName(builderField.type),
-                    " must be set");
+                buildMethod
+                    .beginControlFlow("if ($N == null)", field)
+                    .addStatement(
+                        "throw new $T($T.class.getCanonicalName() + $S)",
+                        IllegalStateException.class,
+                        TypeNames.rawTypeName(field.type),
+                        " must be set")
+                    .endControlFlow();
                 break;
               case ALLOW:
                 break;

--- a/java/dagger/internal/codegen/HjarSourceFileGenerator.java
+++ b/java/dagger/internal/codegen/HjarSourceFileGenerator.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2017 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen;
+
+import static com.squareup.javapoet.MethodSpec.constructorBuilder;
+import static com.squareup.javapoet.MethodSpec.methodBuilder;
+import static com.squareup.javapoet.TypeSpec.classBuilder;
+import static javax.lang.model.element.Modifier.PRIVATE;
+
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeSpec;
+import java.util.Optional;
+import javax.lang.model.element.Element;
+
+/**
+ * A source file generator that only writes the relevant code necessary for Bazel to create a
+ * correct header (ABI) jar.
+ */
+final class HjarSourceFileGenerator<T> extends SourceFileGenerator<T> {
+  private final SourceFileGenerator<T> delegate;
+
+  private HjarSourceFileGenerator(SourceFileGenerator<T> delegate) {
+    super(delegate);
+    this.delegate = delegate;
+  }
+
+  static <T> SourceFileGenerator<T> wrap(SourceFileGenerator<T> delegate) {
+    return new HjarSourceFileGenerator<>(delegate);
+  }
+
+  @Override
+  ClassName nameGeneratedType(T input) {
+    return delegate.nameGeneratedType(input);
+  }
+
+  @Override
+  Element originatingElement(T input) {
+    return delegate.originatingElement(input);
+  }
+
+  @Override
+  Optional<TypeSpec.Builder> write(ClassName generatedTypeName, T input) {
+    return delegate
+        .write(generatedTypeName, input)
+        .map(completeType -> skeletonType(completeType.build()));
+  }
+
+  private TypeSpec.Builder skeletonType(TypeSpec completeType) {
+    TypeSpec.Builder skeleton =
+        classBuilder(completeType.name)
+            .addSuperinterfaces(completeType.superinterfaces)
+            .addTypeVariables(completeType.typeVariables);
+
+    if (!completeType.superclass.equals(ClassName.OBJECT)) {
+      skeleton.superclass(completeType.superclass);
+    }
+
+    completeType.modifiers.forEach(skeleton::addModifiers);
+
+    completeType.methodSpecs.stream()
+        .filter(method -> !method.modifiers.contains(PRIVATE) || method.isConstructor())
+        .map(this::skeletonMethod)
+        .forEach(skeleton::addMethod);
+
+    completeType.typeSpecs.stream()
+        .map(type -> skeletonType(type).build())
+        .forEach(skeleton::addType);
+
+    // Dagger has no fields that are exposed in its APIs, but if we add some, we need to implement
+    // skeleton fields here.
+
+    return skeleton;
+  }
+
+  private MethodSpec skeletonMethod(MethodSpec completeMethod) {
+    MethodSpec.Builder skeleton =
+        completeMethod.isConstructor()
+            ? constructorBuilder()
+            : methodBuilder(completeMethod.name).returns(completeMethod.returnType);
+
+    if (completeMethod.isConstructor()) {
+      // Code in Turbine must (for technical reasons in javac) have a valid super() call for
+      // constructors, otherwise javac will bark, and Turbine has no way to avoid this. So we retain
+      // constructor method bodies if they do exist
+      skeleton.addCode(completeMethod.code);
+    }
+
+    return skeleton
+        .addModifiers(completeMethod.modifiers)
+        .addTypeVariables(completeMethod.typeVariables)
+        .addParameters(completeMethod.parameters)
+        .addExceptions(completeMethod.exceptions)
+        .varargs(completeMethod.varargs)
+        .build();
+  }
+}

--- a/java/dagger/internal/codegen/MemberSelect.java
+++ b/java/dagger/internal/codegen/MemberSelect.java
@@ -18,7 +18,7 @@ package dagger.internal.codegen;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static dagger.internal.codegen.Accessibility.isTypeAccessibleFrom;
-import static dagger.internal.codegen.CodeBlocks.toTypeNamesCodeBlock;
+import static dagger.internal.codegen.CodeBlocks.toParametersCodeBlock;
 import static dagger.internal.codegen.ContributionBinding.FactoryCreationStrategy.SINGLETON_INSTANCE;
 import static dagger.internal.codegen.SourceFiles.bindingTypeElementTypeVariableNames;
 import static dagger.internal.codegen.SourceFiles.generatedClassNameForBinding;
@@ -34,7 +34,6 @@ import com.google.auto.common.MoreTypes;
 import com.google.common.collect.ImmutableList;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
-import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeVariableName;
 import java.util.List;
 import java.util.Optional;
@@ -210,7 +209,7 @@ abstract class MemberSelect {
         return CodeBlock.of(
             "$T.<$L>$L",
             owningClass(),
-            typeParameters.stream().map(TypeName::get).collect(toTypeNamesCodeBlock()),
+            typeParameters.stream().map(CodeBlocks::type).collect(toParametersCodeBlock()),
             methodCodeBlock);
       } else {
         return CodeBlock.of("(($T) $T.$L)", rawReturnType, owningClass(), methodCodeBlock);

--- a/java/dagger/internal/codegen/ModuleProcessingStep.java
+++ b/java/dagger/internal/codegen/ModuleProcessingStep.java
@@ -47,8 +47,8 @@ final class ModuleProcessingStep implements ProcessingStep {
   private final Messager messager;
   private final ModuleValidator moduleValidator;
   private final BindingFactory bindingFactory;
-  private final FactoryGenerator factoryGenerator;
-  private final ProducerFactoryGenerator producerFactoryGenerator;
+  private final SourceFileGenerator<ProvisionBinding> factoryGenerator;
+  private final SourceFileGenerator<ProductionBinding> producerFactoryGenerator;
   private final InaccessibleMapKeyProxyGenerator inaccessibleMapKeyProxyGenerator;
   private final DelegateDeclaration.Factory delegateDeclarationFactory;
   private final Set<TypeElement> processedModuleElements = Sets.newLinkedHashSet();
@@ -58,8 +58,8 @@ final class ModuleProcessingStep implements ProcessingStep {
       Messager messager,
       ModuleValidator moduleValidator,
       BindingFactory bindingFactory,
-      FactoryGenerator factoryGenerator,
-      ProducerFactoryGenerator producerFactoryGenerator,
+      SourceFileGenerator<ProvisionBinding> factoryGenerator,
+      SourceFileGenerator<ProductionBinding> producerFactoryGenerator,
       InaccessibleMapKeyProxyGenerator inaccessibleMapKeyProxyGenerator,
       Factory delegateDeclarationFactory) {
     this.messager = messager;

--- a/java/dagger/internal/codegen/SourceFileGenerator.java
+++ b/java/dagger/internal/codegen/SourceFileGenerator.java
@@ -51,6 +51,10 @@ abstract class SourceFileGenerator<T> {
     this.sourceVersion = checkNotNull(sourceVersion);
   }
 
+  SourceFileGenerator(SourceFileGenerator<T> delegate) {
+    this(delegate.filer, delegate.elements, delegate.sourceVersion);
+  }
+
   /**
    * Generates a source file to be compiled for {@code T}. Writes any generation exception to {@code
    * messager} and does not throw.

--- a/java/dagger/internal/codegen/SourceFileGeneratorsModule.java
+++ b/java/dagger/internal/codegen/SourceFileGeneratorsModule.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2018 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen;
+
+import dagger.Module;
+import dagger.Provides;
+import dagger.internal.codegen.SourceFileGeneratorsModule.ComponentModule;
+import dagger.internal.codegen.SourceFileGeneratorsModule.MembersInjectionModule;
+import dagger.internal.codegen.SourceFileGeneratorsModule.ProductionModule;
+import dagger.internal.codegen.SourceFileGeneratorsModule.ProvisionModule;
+
+@Module(
+    includes = {
+      ProvisionModule.class,
+      ProductionModule.class,
+      MembersInjectionModule.class,
+      ComponentModule.class
+    })
+interface SourceFileGeneratorsModule {
+  @Module
+  abstract class GeneratorModule<T, G extends SourceFileGenerator<T>> {
+    @Provides
+    SourceFileGenerator<T> generator(G generator, CompilerOptions compilerOptions) {
+      return compilerOptions.headerCompilation()
+          ? HjarSourceFileGenerator.wrap(generator)
+          : generator;
+    }
+  }
+
+  @Module
+  class ProvisionModule extends GeneratorModule<ProvisionBinding, FactoryGenerator> {}
+
+  @Module
+  class ProductionModule extends GeneratorModule<ProductionBinding, ProducerFactoryGenerator> {}
+
+  @Module
+  class MembersInjectionModule
+      extends GeneratorModule<MembersInjectionBinding, MembersInjectorGenerator> {}
+
+  @Module
+  class ComponentModule extends GeneratorModule<BindingGraph, ComponentGenerator> {}
+}

--- a/javatests/dagger/android/DispatchingAndroidInjectorTest.java
+++ b/javatests/dagger/android/DispatchingAndroidInjectorTest.java
@@ -35,7 +35,10 @@ public final class DispatchingAndroidInjectorTest {
   public void withClassKeys() {
     DispatchingAndroidInjector<Activity> dispatchingAndroidInjector =
         new DispatchingAndroidInjector<>(
-            ImmutableMap.of(FooActivity.class, FooInjector.Factory::new), ImmutableMap.of());
+            ImmutableMap.of(FooActivity.class, FooInjector.Factory::new),
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            ImmutableMap.of());
 
     FooActivity activity = Robolectric.setupActivity(FooActivity.class);
     assertThat(dispatchingAndroidInjector.maybeInject(activity)).isTrue();
@@ -46,7 +49,9 @@ public final class DispatchingAndroidInjectorTest {
     DispatchingAndroidInjector<Activity> dispatchingAndroidInjector =
         new DispatchingAndroidInjector<>(
             ImmutableMap.of(),
-            ImmutableMap.of(FooActivity.class.getName(), FooInjector.Factory::new));
+            ImmutableMap.of(FooActivity.class.getName(), FooInjector.Factory::new),
+            ImmutableMap.of(),
+            ImmutableMap.of());
 
     FooActivity activity = Robolectric.setupActivity(FooActivity.class);
     assertThat(dispatchingAndroidInjector.maybeInject(activity)).isTrue();
@@ -57,7 +62,9 @@ public final class DispatchingAndroidInjectorTest {
     DispatchingAndroidInjector<Activity> dispatchingAndroidInjector =
         new DispatchingAndroidInjector<>(
             ImmutableMap.of(FooActivity.class, FooInjector.Factory::new),
-            ImmutableMap.of(BarActivity.class.getName(), BarInjector.Factory::new));
+            ImmutableMap.of(BarActivity.class.getName(), BarInjector.Factory::new),
+            ImmutableMap.of(),
+            ImmutableMap.of());
 
     FooActivity fooActivity = Robolectric.setupActivity(FooActivity.class);
     assertThat(dispatchingAndroidInjector.maybeInject(fooActivity)).isTrue();
@@ -68,8 +75,9 @@ public final class DispatchingAndroidInjectorTest {
   @Test
   public void maybeInject_returnsFalse_ifNoMatchingInjectorExists() {
     DispatchingAndroidInjector<Activity> dispatchingAndroidInjector =
-        new DispatchingAndroidInjector<>(ImmutableMap.of(), ImmutableMap.of());
-    
+        new DispatchingAndroidInjector<>(
+            ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());
+
     BarActivity activity = Robolectric.setupActivity(BarActivity.class);
     assertThat(dispatchingAndroidInjector.maybeInject(activity)).isFalse();
   }
@@ -79,6 +87,8 @@ public final class DispatchingAndroidInjectorTest {
     DispatchingAndroidInjector<Activity> dispatchingAndroidInjector =
         new DispatchingAndroidInjector<>(
             ImmutableMap.of(FooActivity.class, () -> null),
+            ImmutableMap.of(),
+            ImmutableMap.of(),
             ImmutableMap.of());
     FooActivity activity = Robolectric.setupActivity(FooActivity.class);
 
@@ -93,7 +103,10 @@ public final class DispatchingAndroidInjectorTest {
   public void throwsIfClassMismatched() {
     DispatchingAndroidInjector<Activity> dispatchingAndroidInjector =
         new DispatchingAndroidInjector<>(
-            ImmutableMap.of(FooActivity.class, BarInjector.Factory::new), ImmutableMap.of());
+            ImmutableMap.of(FooActivity.class, BarInjector.Factory::new),
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            ImmutableMap.of());
     FooActivity activity = Robolectric.setupActivity(FooActivity.class);
 
     try {

--- a/javatests/dagger/android/processor/AndroidMapKeyValidatorTest.java
+++ b/javatests/dagger/android/processor/AndroidMapKeyValidatorTest.java
@@ -69,7 +69,7 @@ public class AndroidMapKeyValidatorTest {
         "import dagger.Module;",
         "import dagger.*;",
         "import dagger.android.*;",
-        "import dagger.multibindings.IntoMap;",
+        "import dagger.multibindings.*;",
         "import javax.inject.*;",
         "",
         "@Module",
@@ -277,6 +277,18 @@ public class AndroidMapKeyValidatorTest {
             "@ActivityKey(FooActivity.class)",
             "abstract AndroidInjector.Factory<? extends Activity> bindCorrectType(",
             "    FooActivity.Builder builder);");
+    Compilation compilation = compile(module, FOO_ACTIVITY);
+    assertThat(compilation).succeededWithoutWarnings();
+  }
+
+  @Test
+  public void bindsCorrectType_unbounded() {
+    JavaFileObject module =
+        moduleWithMethod(
+            "@Binds",
+            "@IntoMap",
+            "@ClassKey(FooActivity.class)",
+            "abstract AndroidInjector.Factory<?> bindCorrectType(FooActivity.Builder builder);");
     Compilation compilation = compile(module, FOO_ACTIVITY);
     assertThat(compilation).succeededWithoutWarnings();
   }

--- a/javatests/dagger/android/processor/DuplicateAndroidInjectorsCheckerTest.java
+++ b/javatests/dagger/android/processor/DuplicateAndroidInjectorsCheckerTest.java
@@ -68,13 +68,25 @@ public final class DuplicateAndroidInjectorsCheckerTest {
             "interface TestModule {",
             "  @Binds",
             "  @IntoMap",
-            "  @ActivityKey(TestActivity.class)",
-            "  AndroidInjector.Factory<? extends Activity> classKey(TestInjectorFactory factory);",
+            "  @ClassKey(TestActivity.class)",
+            "  AndroidInjector.Factory<?> classKey(TestInjectorFactory factory);",
             "",
             "  @Binds",
             "  @IntoMap",
             "  @AndroidInjectionKey(\"test.TestActivity\")",
-            "  AndroidInjector.Factory<? extends Activity> stringKey(TestInjectorFactory factory);",
+            "  AndroidInjector.Factory<?> stringKey(TestInjectorFactory factory);",
+            "",
+            "  @Binds",
+            "  @IntoMap",
+            "  @ActivityKey(TestActivity.class)",
+            "  AndroidInjector.Factory<? extends Activity> boundedClassKey(",
+            "      TestInjectorFactory factory);",
+            "",
+            "  @Binds",
+            "  @IntoMap",
+            "  @AndroidInjectionKey(\"test.TestActivity\")",
+            "  AndroidInjector.Factory<? extends Activity> boundedStringKey(",
+            "      TestInjectorFactory factory);",
             "}");
     JavaFileObject component =
         JavaFileObjects.forSourceLines(
@@ -101,6 +113,8 @@ public final class DuplicateAndroidInjectorsCheckerTest {
         .onLineContaining("interface TestComponent");
     assertThat(compilation).hadErrorContaining("classKey(test.TestInjectorFactory)");
     assertThat(compilation).hadErrorContaining("stringKey(test.TestInjectorFactory)");
+    assertThat(compilation).hadErrorContaining("boundedClassKey(test.TestInjectorFactory)");
+    assertThat(compilation).hadErrorContaining("boundedStringKey(test.TestInjectorFactory)");
     assertThat(compilation).hadErrorCount(1);
   }
 }

--- a/javatests/dagger/internal/codegen/CodeBlocksTest.java
+++ b/javatests/dagger/internal/codegen/CodeBlocksTest.java
@@ -18,7 +18,6 @@ package dagger.internal.codegen;
 
 import static com.google.common.truth.Truth.assertThat;
 import static dagger.internal.codegen.CodeBlocks.javadocLinkTo;
-import static dagger.internal.codegen.CodeBlocks.joiningCodeBlocks;
 import static dagger.internal.codegen.CodeBlocks.toParametersCodeBlock;
 import static javax.lang.model.element.ElementKind.METHOD;
 
@@ -62,12 +61,6 @@ public final class CodeBlocksTest {
   @Test
   public void testToParametersCodeBlock_oneElement() {
     assertThat(Stream.of(objectO).collect(toParametersCodeBlock())).isEqualTo(objectO);
-  }
-
-  @Test
-  public void testJoiningCodeBlocks() {
-    assertThat(Stream.of(objectO, stringS, intI).collect(joiningCodeBlocks("!")))
-        .isEqualTo(CodeBlock.of("$T o!$T s!$T i", Object.class, String.class, int.class));
   }
 
   @Test


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add support for binding AndroidInjector.Factory with an unbounded wildcard type.

This is the first step in adding support for binding any Android framework type, such as WorkManager, within dagger.android.

02a46c9760a1213bf0a4774989bf423779de000e

-------

<p> Use begin/end control flow in build() method to ensure proper formatting.

127bea3de718bf1d95b6eb878622ff7434723e8b

-------

<p> Use the new bazelrc file location as per https://github.com/bazelbuild/bazel/issues/6319

We can just move the old file to the new location once we're building exclusively with 0.19, but that's not yet released and we don't support it yet.

fd6bbf6016a59b9dd1466fddafed6783b02c3d80

-------

<p> Create general purpose Hjar support for any SourceFileGenerator

This is a rollforward of a previous attempt that completely removed private classes. Because those classes may appear in signatures of methods that are protected in AOT mode, javac/Turbine would get confused

551ff9718a31bcc76baf870c0aad9745cc567c68

-------

<p> Remove JavaPoet features that were upstreamed in 1.10

Addresses some (all?) of the issues in https://github.com/google/dagger/issues/1307

e17ea091e8a564346b25295f99abc75678309f8d