### PR TITLE
Moe Sync

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -64,6 +64,7 @@ jarjar_library(
         "//java/dagger/internal/codegen:validation",
         "//java/dagger/internal/codegen:writing",
         "//java/dagger/model:internal-proxies",
+        "//java/dagger/errorprone",
         "@com_google_auto_auto_common//jar",
     ],
     rules = SHADE_RULES,
@@ -79,6 +80,7 @@ jarjar_library(
         "//java/dagger/internal/codegen:libshared-with-spi-src.jar",
         "//java/dagger/internal/codegen:libvalidation-src.jar",
         "//java/dagger/internal/codegen:libwriting-src.jar",
+        "//java/dagger/errorprone:liberrorprone-src.jar",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,8 +14,8 @@
 
 http_archive(
     name = "google_bazel_common",
-    strip_prefix = "bazel-common-b3778739a9c67eaefe0725389f03cf821392ac67",
-    urls = ["https://github.com/google/bazel-common/archive/b3778739a9c67eaefe0725389f03cf821392ac67.zip"],
+    strip_prefix = "bazel-common-c0a6655a70fb389dbb6473989450df0c86447ec3",
+    urls = ["https://github.com/google/bazel-common/archive/c0a6655a70fb389dbb6473989450df0c86447ec3.zip"],
 )
 
 load("@google_bazel_common//:workspace_defs.bzl", "google_common_workspace_rules")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,8 +14,8 @@
 
 http_archive(
     name = "google_bazel_common",
-    strip_prefix = "bazel-common-aafb9b64f25f66b5ab6b9b991331160ef4130626",
-    urls = ["https://github.com/google/bazel-common/archive/aafb9b64f25f66b5ab6b9b991331160ef4130626.zip"],
+    strip_prefix = "bazel-common-b3778739a9c67eaefe0725389f03cf821392ac67",
+    urls = ["https://github.com/google/bazel-common/archive/b3778739a9c67eaefe0725389f03cf821392ac67.zip"],
 )
 
 load("@google_bazel_common//:workspace_defs.bzl", "google_common_workspace_rules")

--- a/java/dagger/android/ActivityKey.java
+++ b/java/dagger/android/ActivityKey.java
@@ -24,11 +24,17 @@ import dagger.internal.Beta;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Target;
 
-/** {@link MapKey} annotation to key bindings by a type of an {@link Activity}. */
+/**
+ * {@link MapKey} annotation to key bindings by a type of an {@link Activity}.
+ *
+ * @deprecated Use {@link dagger.multibindings.ClassKey} instead. See <a
+ *     href="https://google.github.io/dagger/android">https://google.github.io/dagger/android</a>.
+ */
 @Beta
 @MapKey
 @Documented
 @Target(METHOD)
+@Deprecated
 public @interface ActivityKey {
   Class<? extends Activity> value();
 }

--- a/java/dagger/android/BUILD
+++ b/java/dagger/android/BUILD
@@ -23,7 +23,7 @@ load(
     "DOCLINT_REFERENCES",
     "SOURCE_7_TARGET_7",
 )
-load("//tools:maven.bzl", "pom_file", "POM_VERSION")
+load("//tools:maven.bzl", "POM_VERSION", "pom_file")
 
 # Work around b/70476182 which prevents Kythe from connecting :producers to the .java files it
 # contains.

--- a/java/dagger/android/BroadcastReceiverKey.java
+++ b/java/dagger/android/BroadcastReceiverKey.java
@@ -24,11 +24,17 @@ import dagger.internal.Beta;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Target;
 
-/** {@link MapKey} annotation to key bindings by a type of a {@link BroadcastReceiver}. */
+/**
+ * {@link MapKey} annotation to key bindings by a type of a {@link BroadcastReceiver}
+ *
+ * @deprecated Use {@link dagger.multibindings.ClassKey} instead. See <a
+ *     href="https://google.github.io/dagger/android">https://google.github.io/dagger/android</a>.
+ */
 @Beta
 @MapKey
 @Documented
 @Target(METHOD)
+@Deprecated
 public @interface BroadcastReceiverKey {
   Class<? extends BroadcastReceiver> value();
 }

--- a/java/dagger/android/ContentProviderKey.java
+++ b/java/dagger/android/ContentProviderKey.java
@@ -24,11 +24,17 @@ import dagger.internal.Beta;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Target;
 
-/** {@link MapKey} annotation to key bindings by a type of a {@link ContentProvider}. */
+/**
+ * {@link MapKey} annotation to key bindings by a type of a {@link ContentProvider}.
+ *
+ * @deprecated Use {@link dagger.multibindings.ClassKey} instead. See <a
+ *     href="https://google.github.io/dagger/android">https://google.github.io/dagger/android</a>.
+ */
 @Beta
 @MapKey
 @Documented
 @Target(METHOD)
+@Deprecated
 public @interface ContentProviderKey {
   Class<? extends ContentProvider> value();
 }

--- a/java/dagger/android/FragmentKey.java
+++ b/java/dagger/android/FragmentKey.java
@@ -24,11 +24,17 @@ import dagger.internal.Beta;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Target;
 
-/** {@link MapKey} annotation to key bindings by a type of a {@link Fragment}. */
+/**
+ * {@link MapKey} annotation to key bindings by a type of a {@link Fragment}.
+ *
+ * @deprecated Use {@link dagger.multibindings.ClassKey} instead. See <a
+ *     href="https://google.github.io/dagger/android">https://google.github.io/dagger/android</a>.
+ */
 @Beta
 @MapKey
 @Documented
 @Target(METHOD)
+@Deprecated
 public @interface FragmentKey {
   Class<? extends Fragment> value();
 }

--- a/java/dagger/android/ServiceKey.java
+++ b/java/dagger/android/ServiceKey.java
@@ -24,11 +24,17 @@ import dagger.internal.Beta;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Target;
 
-/** {@link MapKey} annotation to key bindings by a type of a {@link Service}. */
+/**
+ * {@link MapKey} annotation to key bindings by a type of a {@link Service}.
+ *
+ * @deprecated Use {@link dagger.multibindings.ClassKey} instead. See <a
+ *     href="https://google.github.io/dagger/android">https://google.github.io/dagger/android</a>.
+ */
 @Beta
 @MapKey
 @Documented
 @Target(METHOD)
+@Deprecated
 public @interface ServiceKey {
   Class<? extends Service> value();
 }

--- a/java/dagger/android/support/FragmentKey.java
+++ b/java/dagger/android/support/FragmentKey.java
@@ -24,11 +24,17 @@ import dagger.internal.Beta;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Target;
 
-/** {@link MapKey} annotation to key bindings by a type of a {@link Fragment}. */
+/**
+ * {@link MapKey} annotation to key bindings by a type of a {@link Fragment}.
+ *
+ * @deprecated Use {@link dagger.multibindings.ClassKey} instead. See <a
+ *     href="https://google.github.io/dagger/android">https://google.github.io/dagger/android</a>.
+ */
 @Beta
 @MapKey
 @Documented
 @Target(METHOD)
+@Deprecated
 public @interface FragmentKey {
   Class<? extends Fragment> value();
 }

--- a/java/dagger/errorprone/AndroidInjectorBindingMigrator.java
+++ b/java/dagger/errorprone/AndroidInjectorBindingMigrator.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2018 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.errorprone;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+import static com.google.errorprone.util.ASTHelpers.getType;
+import static com.google.errorprone.util.ASTHelpers.hasAnnotation;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.Type.ClassType;
+import com.sun.tools.javac.code.Type.WildcardType;
+import com.sun.tools.javac.code.Types;
+import dagger.multibindings.ClassKey;
+import dagger.multibindings.IntoMap;
+
+/** A refactoring to update AndroidInjector bindings to their new form. */
+@BugPattern(
+    name = "AndroidInjectorBindingMigrator",
+    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION,
+    summary = "A refactoring to update AndroidInjector bindings to their new form.",
+    explanation =
+        "dagger.android is migrating the mechanism used to bind AndroidInjectors. This refactoring "
+            + "will migrate usages of the `dagger.android` class-based map keys to "
+            + "`@dagger.multibindings.ClassKey` and also modify the return type of those binding "
+            + "methods to AndroidInjector.Factory<?> (from AndroidInjector.Factory<? "
+            + "extends Activity>).",
+    severity = SUGGESTION)
+public final class AndroidInjectorBindingMigrator extends BugChecker implements MethodTreeMatcher {
+  private static final String ANDROID_INJECTOR_FACTORY = "dagger.android.AndroidInjector$Factory";
+  private static final String CLASS_KEY = ClassKey.class.getName();
+  private static final String ANDROID_INJECTION_KEY = "dagger.android.AndroidInjectionKey";
+
+  @Override
+  public Description matchMethod(MethodTree tree, VisitorState state) {
+    if (!hasAnnotation(tree, IntoMap.class, state)) {
+      return Description.NO_MATCH;
+    }
+
+    Symbol androidInjectorFactory = state.getSymbolFromString(ANDROID_INJECTOR_FACTORY);
+
+    if (androidInjectorFactory == null) {
+      return Description.NO_MATCH;
+    }
+
+    SuggestedFix.Builder suggestedFix = SuggestedFix.builder();
+    Types types = state.getTypes();
+
+    if (!androidInjectorFactory.equals(getSymbol(tree.getReturnType()))) {
+      return Description.NO_MATCH;
+    }
+
+    ClassType bindingType = (ClassType) getType(tree.getReturnType());
+    if (bindingType.isParameterized()) {
+      Type typeParameter = getOnlyElement(bindingType.getTypeArguments());
+      if (typeParameter instanceof WildcardType
+          && ((WildcardType) typeParameter).getExtendsBound() != null) {
+        suggestedFix.replace(tree.getReturnType(), "AndroidInjector.Factory<?>");
+      }
+    }
+
+    Type classKey = state.getTypeFromString(CLASS_KEY);
+    Type androidInjectionKey = state.getTypeFromString(ANDROID_INJECTION_KEY);
+    for (AnnotationTree annotationTree : tree.getModifiers().getAnnotations()) {
+      Type annotationType = getType(annotationTree.getAnnotationType());
+
+      if (hasAnnotation(annotationType.tsym, "dagger.MapKey", state)
+          && !types.isSameType(annotationType, classKey)
+          && !types.isSameType(annotationType, androidInjectionKey)) {
+        suggestedFix.replace(annotationTree.getAnnotationType(), "ClassKey").addImport(CLASS_KEY);
+      }
+    }
+
+    if (suggestedFix.isEmpty()) {
+      return Description.NO_MATCH;
+    }
+
+    return buildDescription(tree).addFix(suggestedFix.build()).build();
+  }
+}

--- a/java/dagger/errorprone/BUILD
+++ b/java/dagger/errorprone/BUILD
@@ -1,0 +1,15 @@
+# Description:
+#   ErrorProne refactorings and static analysis for Dagger
+
+package(default_visibility = ["//:src"])
+
+java_library(
+    name = "errorprone",
+    srcs = glob(["*.java"]),
+    deps = [
+        "//java/dagger:core",
+        "@google_bazel_common//third_party/java/error_prone:check_api",
+        "@google_bazel_common//third_party/java/guava",
+        "@local_jdk//:lib/tools.jar",
+    ],
+)

--- a/java/dagger/example/android/simple/MainActivity.java
+++ b/java/dagger/example/android/simple/MainActivity.java
@@ -16,14 +16,13 @@
 
 package dagger.example.android.simple;
 
-import android.app.Activity;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.TextView;
 import dagger.Binds;
-import dagger.android.ActivityKey;
 import dagger.android.AndroidInjector;
 import dagger.android.support.DaggerAppCompatActivity;
+import dagger.multibindings.ClassKey;
 import dagger.multibindings.IntoMap;
 import javax.inject.Inject;
 
@@ -44,8 +43,8 @@ public class MainActivity extends DaggerAppCompatActivity {
 
     @Binds
     @IntoMap
-    @ActivityKey(MainActivity.class)
-    abstract AndroidInjector.Factory<? extends Activity> bind(Component.Builder builder);
+    @ClassKey(MainActivity.class)
+    abstract AndroidInjector.Factory<?> bind(Component.Builder builder);
   }
 
   private static final String TAG = MainActivity.class.getSimpleName();

--- a/java/dagger/internal/codegen/BindingGraphConverter.java
+++ b/java/dagger/internal/codegen/BindingGraphConverter.java
@@ -29,7 +29,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.Network;
 import com.google.common.graph.NetworkBuilder;
-import dagger.internal.codegen.ComponentDescriptor.ComponentMethodDescriptor;
 import dagger.model.BindingGraph.BindingNode;
 import dagger.model.BindingGraph.ComponentNode;
 import dagger.model.BindingGraph.DependencyEdge;
@@ -105,10 +104,6 @@ final class BindingGraphConverter {
 
       network.addNode(currentComponent);
 
-      for (ComponentMethodDescriptor method : graph.componentDescriptor().entryPointMethods()) {
-        addDependencyEdges(currentComponent, method.dependencyRequest().get());
-      }
-
       for (ResolvedBindings resolvedBindings : graph.resolvedBindings()) {
         for (BindingNode node : bindingNodes(resolvedBindings)) {
           addBindingNode(node);
@@ -127,6 +122,12 @@ final class BindingGraphConverter {
 
       currentComponent = parentComponent;
       parentComponent = grandparentComponent;
+    }
+
+    @Override
+    protected void visitEntryPoint(DependencyRequest entryPoint, BindingGraph graph) {
+      addDependencyEdges(currentComponent, entryPoint);
+      super.visitEntryPoint(entryPoint, graph);
     }
 
     @Override

--- a/java/dagger/internal/codegen/BindingRequest.java
+++ b/java/dagger/internal/codegen/BindingRequest.java
@@ -95,7 +95,9 @@ abstract class BindingRequest {
   /** Returns a name that can be used for the kind of request this is. */
   final String kindName() {
     Object requestKindObject =
-        requestKind().isPresent() ? requestKind().get() : frameworkType().get();
+        requestKind().isPresent()
+            ? requestKind().get()
+            : frameworkType().get().frameworkClass().getSimpleName();
     return requestKindObject.toString();
   }
 }

--- a/java/dagger/internal/codegen/ComponentBindingExpressions.java
+++ b/java/dagger/internal/codegen/ComponentBindingExpressions.java
@@ -683,7 +683,6 @@ final class ComponentBindingExpressions {
         modifiableBindingExpressions.maybeWrapInModifiableMethodBindingExpression(
             resolvedBindings,
             request,
-            bindingExpression,
             methodImplementation,
             matchingComponentMethod,
             matchingModifiableBindingMethod);

--- a/java/dagger/internal/codegen/ComponentDescriptor.java
+++ b/java/dagger/internal/codegen/ComponentDescriptor.java
@@ -506,9 +506,9 @@ abstract class ComponentDescriptor {
 
     private ComponentDescriptor create(
         TypeElement componentDefinitionType, Kind kind, Optional<Kind> parentKind) {
-      DeclaredType declaredComponentType = MoreTypes.asDeclared(componentDefinitionType.asType());
       AnnotationMirror componentMirror =
           getAnnotationMirror(componentDefinitionType, kind.annotationType()).get();
+      DeclaredType declaredComponentType = MoreTypes.asDeclared(componentDefinitionType.asType());
       ImmutableSet<ComponentRequirement> componentDependencies =
           kind.isTopLevel()
               ? getComponentDependencies(componentMirror)

--- a/java/dagger/internal/codegen/ComponentModelBuilder.java
+++ b/java/dagger/internal/codegen/ComponentModelBuilder.java
@@ -297,7 +297,7 @@ abstract class ComponentModelBuilder {
 
   private void addSubcomponents() {
     for (BindingGraph subgraph : graph.subgraphs()) {
-      // TODO(b/72748365): Can an abstract inner subcomponent implementation be elided if it's
+      // TODO(b/117833324): Can an abstract inner subcomponent implementation be elided if it's
       // totally empty?
       generatedComponentModel.addSubcomponent(
           subgraph.componentDescriptor(), buildSubcomponentModel(subgraph));

--- a/java/dagger/internal/codegen/ComponentModelBuilder.java
+++ b/java/dagger/internal/codegen/ComponentModelBuilder.java
@@ -32,7 +32,6 @@ import static dagger.internal.codegen.GeneratedComponentModel.MethodSpecKind.INI
 import static dagger.internal.codegen.GeneratedComponentModel.TypeSpecKind.COMPONENT_BUILDER;
 import static dagger.internal.codegen.GeneratedComponentModel.TypeSpecKind.SUBCOMPONENT;
 import static dagger.internal.codegen.ProducerNodeInstanceBindingExpression.MAY_INTERRUPT_IF_RUNNING;
-import static dagger.producers.CancellationPolicy.Propagation.IGNORE;
 import static dagger.producers.CancellationPolicy.Propagation.PROPAGATE;
 import static javax.lang.model.element.Modifier.FINAL;
 import static javax.lang.model.element.Modifier.PRIVATE;
@@ -53,7 +52,6 @@ import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.TypeSpec;
 import dagger.internal.codegen.ComponentDescriptor.ComponentMethodDescriptor;
 import dagger.internal.codegen.ModifiableBindingMethods.ModifiableBindingMethod;
-import dagger.producers.CancellationPolicy;
 import dagger.producers.internal.CancellationListener;
 import java.util.List;
 import java.util.Optional;
@@ -641,9 +639,8 @@ abstract class ComponentModelBuilder {
               .generatedComponentModel
               .componentDescriptor()
               .cancellationPolicy()
-              .map(CancellationPolicy::fromSubcomponents)
-              .orElse(IGNORE)
-              .equals(PROPAGATE);
+              .map(policy -> policy.fromSubcomponents().equals(PROPAGATE))
+              .orElse(false);
     }
   }
 

--- a/java/dagger/internal/codegen/GeneratedComponentModel.java
+++ b/java/dagger/internal/codegen/GeneratedComponentModel.java
@@ -527,11 +527,7 @@ final class GeneratedComponentModel {
    * a multibinding.
    */
   ImmutableSet<DependencyRequest> superclassContributionsMade(Key key) {
-    ImmutableSet.Builder<DependencyRequest> contributionsBuilder = ImmutableSet.builder();
-    if (supermodel.isPresent()) {
-      contributionsBuilder.addAll(supermodel.get().getAllMultibindingContributions(key));
-    }
-    return contributionsBuilder.build();
+    return supermodel.map(s -> s.getAllMultibindingContributions(key)).orElse(ImmutableSet.of());
   }
 
   /**

--- a/java/dagger/internal/codegen/MapFactoryCreationExpression.java
+++ b/java/dagger/internal/codegen/MapFactoryCreationExpression.java
@@ -73,11 +73,7 @@ final class MapFactoryCreationExpression implements FrameworkInstanceCreationExp
     }
 
     ImmutableList<FrameworkDependency> frameworkDependencies = binding.frameworkDependencies();
-    if (binding.bindingType().equals(BindingType.PROVISION)) {
-      builder.add("builder($L)", frameworkDependencies.size());
-    } else {
-      builder.add("builder()");
-    }
+    builder.add("builder($L)", frameworkDependencies.size());
 
     for (FrameworkDependency frameworkDependency : frameworkDependencies) {
       ContributionBinding contributionBinding =

--- a/java/dagger/internal/codegen/ModifiableBindingExpressions.java
+++ b/java/dagger/internal/codegen/ModifiableBindingExpressions.java
@@ -365,7 +365,6 @@ final class ModifiableBindingExpressions {
   Optional<BindingExpression> maybeWrapInModifiableMethodBindingExpression(
       ResolvedBindings resolvedBindings,
       BindingRequest request,
-      BindingExpression bindingExpression,
       BindingMethodImplementation methodImplementation,
       Optional<ComponentMethodDescriptor> matchingComponentMethod,
       Optional<ModifiableBindingMethod> matchingModifiableBindingMethod) {

--- a/java/dagger/producers/internal/MapOfProducedProducer.java
+++ b/java/dagger/producers/internal/MapOfProducedProducer.java
@@ -90,13 +90,17 @@ public final class MapOfProducedProducer<K, V> extends AbstractProducer<Map<K, P
   }
 
   /** Returns a new {@link Builder}. */
-  public static <K, V> Builder<K, V> builder() {
-    return new Builder<>();
+  public static <K, V> Builder<K, V> builder(int size) {
+    return new Builder<>(size);
   }
 
   /** A builder for {@link MapOfProducedProducer}. */
   public static final class Builder<K, V> {
-    private final ImmutableMap.Builder<K, Producer<V>> mapBuilder = ImmutableMap.builder();
+    private final ImmutableMap.Builder<K, Producer<V>> mapBuilder;
+
+    private Builder(int size) {
+      mapBuilder = ImmutableMap.builderWithExpectedSize(size);
+    }
 
     /** Returns a new {@link MapOfProducedProducer}. */
     public MapOfProducedProducer<K, V> build() {

--- a/java/dagger/producers/internal/MapOfProducerProducer.java
+++ b/java/dagger/producers/internal/MapOfProducerProducer.java
@@ -38,8 +38,8 @@ public final class MapOfProducerProducer<K, V> extends AbstractProducer<Map<K, P
   private final ImmutableMap<K, Producer<V>> contributingMap;
 
   /** Returns a new {@link Builder}. */
-  public static <K, V> Builder<K, V> builder() {
-    return new Builder<>();
+  public static <K, V> Builder<K, V> builder(int size) {
+    return new Builder<>(size);
   }
 
   private MapOfProducerProducer(ImmutableMap<K, Producer<V>> contributingMap) {
@@ -53,7 +53,11 @@ public final class MapOfProducerProducer<K, V> extends AbstractProducer<Map<K, P
 
   /** A builder for {@link MapOfProducerProducer} */
   public static final class Builder<K, V> {
-    private final ImmutableMap.Builder<K, Producer<V>> mapBuilder = ImmutableMap.builder();
+    private final ImmutableMap.Builder<K, Producer<V>> mapBuilder;
+
+    private Builder(int size) {
+      mapBuilder = ImmutableMap.builderWithExpectedSize(size);
+    }
 
     /** Associates {@code key} with {@code producerOfValue}. */
     public Builder<K, V> put(K key, Producer<V> producerOfValue) {

--- a/java/dagger/producers/internal/MapProducer.java
+++ b/java/dagger/producers/internal/MapProducer.java
@@ -44,13 +44,17 @@ public final class MapProducer<K, V> extends AbstractProducer<Map<K, V>> {
   }
 
   /** Returns a new {@link Builder}. */
-  public static <K, V> Builder<K, V> builder() {
-    return new Builder<>();
+  public static <K, V> Builder<K, V> builder(int size) {
+    return new Builder<>(size);
   }
 
   /** A builder for {@link MapProducer} */
   public static final class Builder<K, V> {
-    private final ImmutableMap.Builder<K, Producer<V>> mapBuilder = ImmutableMap.builder();
+    private final ImmutableMap.Builder<K, Producer<V>> mapBuilder;
+
+    private Builder(int size) {
+      mapBuilder = ImmutableMap.builderWithExpectedSize(size);
+    }
 
     /** Associates {@code key} with {@code producerOfValue}. */
     public Builder<K, V> put(K key, Producer<V> producerOfValue) {

--- a/javatests/dagger/android/DispatchingAndroidInjectorTest.java
+++ b/javatests/dagger/android/DispatchingAndroidInjectorTest.java
@@ -21,7 +21,10 @@ import static org.junit.Assert.fail;
 
 import android.app.Activity;
 import com.google.common.collect.ImmutableMap;
+import dagger.android.AndroidInjector.Factory;
 import dagger.android.DispatchingAndroidInjector.InvalidInjectorBindingException;
+import java.util.Map;
+import javax.inject.Provider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -34,11 +37,8 @@ public final class DispatchingAndroidInjectorTest {
   @Test
   public void withClassKeys() {
     DispatchingAndroidInjector<Activity> dispatchingAndroidInjector =
-        new DispatchingAndroidInjector<>(
-            ImmutableMap.of(FooActivity.class, FooInjector.Factory::new),
-            ImmutableMap.of(),
-            ImmutableMap.of(),
-            ImmutableMap.of());
+        newDispatchingAndroidInjector(
+            ImmutableMap.of(FooActivity.class, FooInjector.Factory::new), ImmutableMap.of());
 
     FooActivity activity = Robolectric.setupActivity(FooActivity.class);
     assertThat(dispatchingAndroidInjector.maybeInject(activity)).isTrue();
@@ -47,11 +47,9 @@ public final class DispatchingAndroidInjectorTest {
   @Test
   public void withStringKeys() {
     DispatchingAndroidInjector<Activity> dispatchingAndroidInjector =
-        new DispatchingAndroidInjector<>(
+        newDispatchingAndroidInjector(
             ImmutableMap.of(),
-            ImmutableMap.of(FooActivity.class.getName(), FooInjector.Factory::new),
-            ImmutableMap.of(),
-            ImmutableMap.of());
+            ImmutableMap.of(FooActivity.class.getName(), FooInjector.Factory::new));
 
     FooActivity activity = Robolectric.setupActivity(FooActivity.class);
     assertThat(dispatchingAndroidInjector.maybeInject(activity)).isTrue();
@@ -60,11 +58,9 @@ public final class DispatchingAndroidInjectorTest {
   @Test
   public void withMixedKeys() {
     DispatchingAndroidInjector<Activity> dispatchingAndroidInjector =
-        new DispatchingAndroidInjector<>(
+        newDispatchingAndroidInjector(
             ImmutableMap.of(FooActivity.class, FooInjector.Factory::new),
-            ImmutableMap.of(BarActivity.class.getName(), BarInjector.Factory::new),
-            ImmutableMap.of(),
-            ImmutableMap.of());
+            ImmutableMap.of(BarActivity.class.getName(), BarInjector.Factory::new));
 
     FooActivity fooActivity = Robolectric.setupActivity(FooActivity.class);
     assertThat(dispatchingAndroidInjector.maybeInject(fooActivity)).isTrue();
@@ -75,8 +71,7 @@ public final class DispatchingAndroidInjectorTest {
   @Test
   public void maybeInject_returnsFalse_ifNoMatchingInjectorExists() {
     DispatchingAndroidInjector<Activity> dispatchingAndroidInjector =
-        new DispatchingAndroidInjector<>(
-            ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());
+        newDispatchingAndroidInjector(ImmutableMap.of(), ImmutableMap.of());
 
     BarActivity activity = Robolectric.setupActivity(BarActivity.class);
     assertThat(dispatchingAndroidInjector.maybeInject(activity)).isFalse();
@@ -85,11 +80,8 @@ public final class DispatchingAndroidInjectorTest {
   @Test
   public void throwsIfFactoryCreateReturnsNull() {
     DispatchingAndroidInjector<Activity> dispatchingAndroidInjector =
-        new DispatchingAndroidInjector<>(
-            ImmutableMap.of(FooActivity.class, () -> null),
-            ImmutableMap.of(),
-            ImmutableMap.of(),
-            ImmutableMap.of());
+        newDispatchingAndroidInjector(
+            ImmutableMap.of(FooActivity.class, () -> null), ImmutableMap.of());
     FooActivity activity = Robolectric.setupActivity(FooActivity.class);
 
     try {
@@ -102,11 +94,8 @@ public final class DispatchingAndroidInjectorTest {
   @Test
   public void throwsIfClassMismatched() {
     DispatchingAndroidInjector<Activity> dispatchingAndroidInjector =
-        new DispatchingAndroidInjector<>(
-            ImmutableMap.of(FooActivity.class, BarInjector.Factory::new),
-            ImmutableMap.of(),
-            ImmutableMap.of(),
-            ImmutableMap.of());
+        newDispatchingAndroidInjector(
+            ImmutableMap.of(FooActivity.class, BarInjector.Factory::new), ImmutableMap.of());
     FooActivity activity = Robolectric.setupActivity(FooActivity.class);
 
     try {
@@ -114,6 +103,17 @@ public final class DispatchingAndroidInjectorTest {
       fail("Expected InvalidInjectorBindingException");
     } catch (InvalidInjectorBindingException expected) {
     }
+  }
+
+  private static <T> DispatchingAndroidInjector<T> newDispatchingAndroidInjector(
+      Map<Class<?>, Provider<Factory<?>>> injectorFactoriesWithClassKeys,
+      Map<String, Provider<AndroidInjector.Factory<?>>>
+          injectorFactoriesWithStringKeys) {
+    return new DispatchingAndroidInjector<>(
+        injectorFactoriesWithClassKeys,
+        injectorFactoriesWithStringKeys ,
+        ImmutableMap.of(),
+        ImmutableMap.of());
   }
 
   static class FooActivity extends Activity {}

--- a/javatests/dagger/android/processor/AndroidMapKeyValidatorTest.java
+++ b/javatests/dagger/android/processor/AndroidMapKeyValidatorTest.java
@@ -87,15 +87,14 @@ public class AndroidMapKeyValidatorTest {
         moduleWithMethod(
             "@Binds",
             "@IntoMap",
-            "@ActivityKey(FooActivity.class)",
+            "@ClassKey(FooActivity.class)",
             "abstract AndroidInjector.Factory bindRawFactory(FooActivity.Factory factory);");
     Compilation compilation = compile(module, FOO_ACTIVITY);
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
-            "@dagger.android.ActivityKey methods should bind "
-                + "dagger.android.AndroidInjector.Factory<? extends android.app.Activity>, not "
-                + "dagger.android.AndroidInjector.Factory");
+            "should bind dagger.android.AndroidInjector.Factory<?>, "
+                + "not dagger.android.AndroidInjector.Factory");
   }
 
   @Test
@@ -104,15 +103,14 @@ public class AndroidMapKeyValidatorTest {
         moduleWithMethod(
             "@Binds",
             "@IntoMap",
-            "@ActivityKey(FooActivity.class)",
+            "@ClassKey(FooActivity.class)",
             "abstract AndroidInjector.Builder bindRawBuilder(FooActivity.Builder builder);");
     Compilation compilation = compile(module, FOO_ACTIVITY);
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
-            "@dagger.android.ActivityKey methods should bind "
-                + "dagger.android.AndroidInjector.Factory<? extends android.app.Activity>, not "
-                + "dagger.android.AndroidInjector.Builder");
+            "should bind dagger.android.AndroidInjector.Factory<?>, "
+                + "not dagger.android.AndroidInjector.Builder");
   }
 
   @Test
@@ -121,16 +119,15 @@ public class AndroidMapKeyValidatorTest {
         moduleWithMethod(
             "@Binds",
             "@IntoMap",
-            "@ActivityKey(FooActivity.class)",
-            "abstract AndroidInjector.Builder<? extends Activity> bindBuilder(",
+            "@ClassKey(FooActivity.class)",
+            "abstract AndroidInjector.Builder<?> bindBuilder(",
             "    FooActivity.Builder builder);");
     Compilation compilation = compile(module, FOO_ACTIVITY);
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
-            "@dagger.android.ActivityKey methods should bind "
-                + "dagger.android.AndroidInjector.Factory<? extends android.app.Activity>, not "
-                + "dagger.android.AndroidInjector.Builder<? extends android.app.Activity>");
+            "should bind dagger.android.AndroidInjector.Factory<?>, not "
+                + "dagger.android.AndroidInjector.Builder<?>");
   }
 
   @Test
@@ -139,18 +136,16 @@ public class AndroidMapKeyValidatorTest {
         moduleWithMethod(
             "@Provides",
             "@IntoMap",
-            "@ActivityKey(FooActivity.class)",
-            "static AndroidInjector.Builder<? extends Activity> bindBuilder(",
-            "    FooActivity.Builder builder) {",
+            "@ClassKey(FooActivity.class)",
+            "static AndroidInjector.Builder<?> bindBuilder(FooActivity.Builder builder) {",
             "  return builder;",
             "}");
     Compilation compilation = compile(module, FOO_ACTIVITY);
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
-            "@dagger.android.ActivityKey methods should bind "
-                + "dagger.android.AndroidInjector.Factory<? extends android.app.Activity>, not "
-                + "dagger.android.AndroidInjector.Builder<? extends android.app.Activity>");
+            "should bind dagger.android.AndroidInjector.Factory<?>, not "
+                + "dagger.android.AndroidInjector.Builder<?>");
   }
 
   @Test
@@ -166,9 +161,8 @@ public class AndroidMapKeyValidatorTest {
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
-            "@dagger.android.FragmentKey methods should bind "
-                + "dagger.android.AndroidInjector.Factory<? extends android.app.Fragment>, not "
-                + "dagger.android.AndroidInjector.Factory<? extends android.app.Activity>");
+            "should bind dagger.android.AndroidInjector.Factory<? extends android.app.Fragment>, "
+                + "not dagger.android.AndroidInjector.Factory<? extends android.app.Activity>");
     assertThat(compilation)
         .hadErrorContaining(
             "test.FooActivity.Builder does not implement AndroidInjector<test.BazFragment>")
@@ -189,8 +183,7 @@ public class AndroidMapKeyValidatorTest {
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
-            "bindWrongFrameworkType(test.FooActivity.Builder) should bind "
-                + "dagger.android.AndroidInjector.Factory<? extends android.app.Fragment>, not "
+            "should bind dagger.android.AndroidInjector.Factory<?>, not "
                 + "dagger.android.AndroidInjector.Factory<? extends android.app.Activity>");
     assertThat(compilation)
         .hadErrorContaining(
@@ -224,9 +217,8 @@ public class AndroidMapKeyValidatorTest {
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
-            "@dagger.android.FragmentKey methods should bind "
-                + "dagger.android.AndroidInjector.Factory<? extends android.app.Fragment>, not "
-                + "dagger.android.AndroidInjector.Factory<? extends "
+            "should bind dagger.android.AndroidInjector.Factory<? extends android.app.Fragment>, "
+                + "not dagger.android.AndroidInjector.Factory<? extends "
                 + "android.support.v4.app.Fragment>");
     assertThat(compilation)
         .hadErrorContaining(
@@ -241,15 +233,14 @@ public class AndroidMapKeyValidatorTest {
         moduleWithMethod(
             "@Binds",
             "@IntoMap",
-            "@ActivityKey(FooActivity.class)",
+            "@ClassKey(FooActivity.class)",
             "abstract AndroidInjector.Builder<FooActivity> bindBuilder(",
             "    FooActivity.Builder builder);");
     Compilation compilation = compile(module, FOO_ACTIVITY);
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
-            "@dagger.android.ActivityKey methods should bind "
-                + "dagger.android.AndroidInjector.Factory<? extends android.app.Activity>, not "
+            "should bind dagger.android.AndroidInjector.Factory<?>, not "
                 + "dagger.android.AndroidInjector.Builder<test.FooActivity>");
   }
 
@@ -259,7 +250,7 @@ public class AndroidMapKeyValidatorTest {
         moduleWithMethod(
             "@Binds",
             "@IntoMap",
-            "@ActivityKey(FooActivity.class)",
+            "@ClassKey(FooActivity.class)",
             "abstract AndroidInjector.Builder<Activity> bindBuilder(",
             "    FooActivity.Builder builder);");
     Compilation compilation = compile(module, FOO_ACTIVITY);
@@ -307,15 +298,26 @@ public class AndroidMapKeyValidatorTest {
   }
 
   @Test
+  public void bindsCorrectType_AndroidInjectionKey_unbounded() {
+    JavaFileObject module =
+        moduleWithMethod(
+            "@Binds",
+            "@IntoMap",
+            "@AndroidInjectionKey(\"test.FooActivity\")",
+            "abstract AndroidInjector.Factory<?> bindCorrectType(FooActivity.Builder builder);");
+    Compilation compilation = compile(module, FOO_ACTIVITY);
+    assertThat(compilation).succeededWithoutWarnings();
+  }
+
+  @Test
   public void bindsWithScope() {
     JavaFileObject module =
         moduleWithMethod(
             "@Binds",
             "@IntoMap",
-            "@ActivityKey(FooActivity.class)",
+            "@ClassKey(FooActivity.class)",
             "@Singleton",
-            "abstract AndroidInjector.Factory<? extends Activity> bindWithScope(",
-            "    FooActivity.Builder builder);");
+            "abstract AndroidInjector.Factory<?> bindWithScope(FooActivity.Builder builder);");
     Compilation compilation = compile(module, FOO_ACTIVITY);
     assertThat(compilation).failed();
     assertThat(compilation).hadErrorContaining("should not be scoped");
@@ -328,10 +330,9 @@ public class AndroidMapKeyValidatorTest {
             "@SuppressWarnings(\"dagger.android.ScopedInjectorFactory\")",
             "@Binds",
             "@IntoMap",
-            "@ActivityKey(FooActivity.class)",
+            "@ClassKey(FooActivity.class)",
             "@Singleton",
-            "abstract AndroidInjector.Factory<? extends Activity> bindWithScope(",
-            "    FooActivity.Builder builder);");
+            "abstract AndroidInjector.Factory<?> bindWithScope(FooActivity.Builder builder);");
     Compilation compilation = compile(module, FOO_ACTIVITY);
     assertThat(compilation).succeededWithoutWarnings();
   }
@@ -342,9 +343,8 @@ public class AndroidMapKeyValidatorTest {
         moduleWithMethod(
             "@Binds",
             "@IntoMap",
-            "@ActivityKey(BarActivity.class)",
-            "abstract AndroidInjector.Factory<?> mismatchedFactory(",
-            "    FooActivity.Factory factory);");
+            "@ClassKey(BarActivity.class)",
+            "abstract AndroidInjector.Factory<?> mismatchedFactory(FooActivity.Factory factory);");
     Compilation compilation = compile(module, FOO_ACTIVITY, BAR_ACTIVITY);
     assertThat(compilation).failed();
     assertThat(compilation)
@@ -360,9 +360,8 @@ public class AndroidMapKeyValidatorTest {
         moduleWithMethod(
             "@Binds",
             "@IntoMap",
-            "@ActivityKey(BarActivity.class)",
-            "abstract AndroidInjector.Factory<? extends Activity> mismatchedBuilder(",
-            "    FooActivity.Builder builder);");
+            "@ClassKey(BarActivity.class)",
+            "abstract AndroidInjector.Factory<?> mismatchedBuilder(FooActivity.Builder builder);");
     Compilation compilation = compile(module, FOO_ACTIVITY, BAR_ACTIVITY);
     assertThat(compilation).failed();
     assertThat(compilation)
@@ -379,8 +378,7 @@ public class AndroidMapKeyValidatorTest {
             "@Binds",
             "@IntoMap",
             "@AndroidInjectionKey(\"test.BarActivity\")",
-            "abstract AndroidInjector.Factory<? extends Activity> mismatchedBuilder(",
-            "    FooActivity.Builder builder);");
+            "abstract AndroidInjector.Factory<?> mismatchedBuilder(FooActivity.Builder builder);");
     Compilation compilation = compile(module, FOO_ACTIVITY, BAR_ACTIVITY);
     assertThat(compilation).failed();
     assertThat(compilation)
@@ -396,9 +394,8 @@ public class AndroidMapKeyValidatorTest {
         moduleWithMethod(
             "@Provides",
             "@IntoMap",
-            "@ActivityKey(BarActivity.class)",
-            "static AndroidInjector.Factory<? extends Activity> mismatchedBuilder(",
-            "    FooActivity.Builder builder) {",
+            "@ClassKey(BarActivity.class)",
+            "static AndroidInjector.Factory<?> mismatchedBuilder(FooActivity.Builder builder) {",
             "  return builder;",
             "}");
     Compilation compilation = compile(module, FOO_ACTIVITY, BAR_ACTIVITY);
@@ -411,7 +408,7 @@ public class AndroidMapKeyValidatorTest {
         moduleWithMethod(
             "@Binds",
             "@IntoMap",
-            "@ActivityKey(FooActivity.class)",
+            "@ClassKey(FooActivity.class)",
             "@Named(\"unused\")",
             // normally this should fail, since it is binding to a Builder not a Factory
             "abstract AndroidInjector.Builder<?> bindsBuilderWithQualifier(",
@@ -426,7 +423,7 @@ public class AndroidMapKeyValidatorTest {
         moduleWithMethod(
             "@Binds",
             "@IntoMap",
-            "@ActivityKey(FooActivity.class)",
+            "@AndroidInjectionKey(\"test.FooActivity\")",
             "abstract int bindInt(@Named(\"unused\") int otherInt);");
     Compilation compilation = compile(module, FOO_ACTIVITY);
     assertThat(compilation).succeededWithoutWarnings();
@@ -438,7 +435,7 @@ public class AndroidMapKeyValidatorTest {
         moduleWithMethod(
             "@Binds",
             "@IntoMap",
-            "@ActivityKey(FooActivity.class)",
+            "@AndroidInjectionKey(\"test.FooActivity\")",
             "abstract Number bindInt(Integer integer);");
     Compilation compilation = compile(module, FOO_ACTIVITY);
     assertThat(compilation).succeededWithoutWarnings();
@@ -450,7 +447,7 @@ public class AndroidMapKeyValidatorTest {
         moduleWithMethod(
             "@Binds",
             "@IntoMap",
-            "@ActivityKey(FooActivity.class)",
+            "@ClassKey(FooActivity.class)",
             "abstract AndroidInjector.Factory<?> bindCorrectType(",
             "    FooActivity.Builder builder, FooActivity.Builder builder2);");
     Compilation compilation = compile(module, FOO_ACTIVITY);

--- a/javatests/dagger/android/processor/DuplicateAndroidInjectorsCheckerTest.java
+++ b/javatests/dagger/android/processor/DuplicateAndroidInjectorsCheckerTest.java
@@ -87,6 +87,7 @@ public final class DuplicateAndroidInjectorsCheckerTest {
             "  @AndroidInjectionKey(\"test.TestActivity\")",
             "  AndroidInjector.Factory<? extends Activity> boundedStringKey(",
             "      TestInjectorFactory factory);",
+
             "}");
     JavaFileObject component =
         JavaFileObjects.forSourceLines(
@@ -115,6 +116,7 @@ public final class DuplicateAndroidInjectorsCheckerTest {
     assertThat(compilation).hadErrorContaining("stringKey(test.TestInjectorFactory)");
     assertThat(compilation).hadErrorContaining("boundedClassKey(test.TestInjectorFactory)");
     assertThat(compilation).hadErrorContaining("boundedStringKey(test.TestInjectorFactory)");
+
     assertThat(compilation).hadErrorCount(1);
   }
 }

--- a/javatests/dagger/android/support/functional/AllControllersAreDirectChildrenOfApplication.java
+++ b/javatests/dagger/android/support/functional/AllControllersAreDirectChildrenOfApplication.java
@@ -16,29 +16,20 @@
 
 package dagger.android.support.functional;
 
-import android.app.Activity;
-import android.app.Service;
-import android.content.BroadcastReceiver;
-import android.content.ContentProvider;
-import android.support.v4.app.Fragment;
 import dagger.Binds;
 import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
 import dagger.Subcomponent;
-import dagger.android.ActivityKey;
 import dagger.android.AndroidInjector;
-import dagger.android.BroadcastReceiverKey;
-import dagger.android.ContentProviderKey;
-import dagger.android.ServiceKey;
 import dagger.android.support.AndroidSupportInjectionModule;
 import dagger.android.support.DaggerApplication;
-import dagger.android.support.FragmentKey;
 import dagger.android.support.functional.AllControllersAreDirectChildrenOfApplication.ApplicationComponent.BroadcastReceiverSubcomponent.BroadcastReceiverModule;
 import dagger.android.support.functional.AllControllersAreDirectChildrenOfApplication.ApplicationComponent.ContentProviderSubcomponent.ContentProviderModule;
 import dagger.android.support.functional.AllControllersAreDirectChildrenOfApplication.ApplicationComponent.InnerActivitySubcomponent.InnerActivityModule;
 import dagger.android.support.functional.AllControllersAreDirectChildrenOfApplication.ApplicationComponent.IntentServiceSubcomponent.IntentServiceModule;
 import dagger.android.support.functional.AllControllersAreDirectChildrenOfApplication.ApplicationComponent.ServiceSubcomponent.ServiceModule;
+import dagger.multibindings.ClassKey;
 import dagger.multibindings.IntoMap;
 import dagger.multibindings.IntoSet;
 
@@ -76,56 +67,56 @@ public final class AllControllersAreDirectChildrenOfApplication extends DaggerAp
 
       @Binds
       @IntoMap
-      @ActivityKey(TestActivity.class)
-      abstract AndroidInjector.Factory<? extends Activity> bindFactoryForTestActivity(
+      @ClassKey(TestActivity.class)
+      abstract AndroidInjector.Factory<?> bindFactoryForTestActivity(
           ActivitySubcomponent.Builder builder);
 
       @Binds
       @IntoMap
-      @ActivityKey(OuterClass.TestInnerClassActivity.class)
-      abstract AndroidInjector.Factory<? extends Activity> bindFactoryForInnerActivity(
+      @ClassKey(OuterClass.TestInnerClassActivity.class)
+      abstract AndroidInjector.Factory<?> bindFactoryForInnerActivity(
           InnerActivitySubcomponent.Builder builder);
 
       @Binds
       @IntoMap
-      @FragmentKey(TestParentFragment.class)
-      abstract AndroidInjector.Factory<? extends Fragment> bindFactoryForParentFragment(
+      @ClassKey(TestParentFragment.class)
+      abstract AndroidInjector.Factory<?> bindFactoryForParentFragment(
           ParentFragmentSubcomponent.Builder builder);
 
       @Binds
       @IntoMap
-      @FragmentKey(TestChildFragment.class)
-      abstract AndroidInjector.Factory<? extends Fragment> bindFactoryForChildFragment(
+      @ClassKey(TestChildFragment.class)
+      abstract AndroidInjector.Factory<?> bindFactoryForChildFragment(
           ChildFragmentSubcomponent.Builder builder);
 
       @Binds
       @IntoMap
-      @FragmentKey(TestDialogFragment.class)
-      abstract AndroidInjector.Factory<? extends Fragment> bindFactoryForDialogFragment(
+      @ClassKey(TestDialogFragment.class)
+      abstract AndroidInjector.Factory<?> bindFactoryForDialogFragment(
           DialogFragmentSubcomponent.Builder builder);
 
       @Binds
       @IntoMap
-      @ServiceKey(TestService.class)
-      abstract AndroidInjector.Factory<? extends Service> bindFactoryForService(
+      @ClassKey(TestService.class)
+      abstract AndroidInjector.Factory<?> bindFactoryForService(
           ServiceSubcomponent.Builder builder);
 
       @Binds
       @IntoMap
-      @ServiceKey(TestIntentService.class)
-      abstract AndroidInjector.Factory<? extends Service> bindFactoryForIntentService(
+      @ClassKey(TestIntentService.class)
+      abstract AndroidInjector.Factory<?> bindFactoryForIntentService(
           IntentServiceSubcomponent.Builder builder);
 
       @Binds
       @IntoMap
-      @BroadcastReceiverKey(TestBroadcastReceiver.class)
-      abstract AndroidInjector.Factory<? extends BroadcastReceiver> bindFactoryForBroadcastReceiver(
+      @ClassKey(TestBroadcastReceiver.class)
+      abstract AndroidInjector.Factory<?> bindFactoryForBroadcastReceiver(
           BroadcastReceiverSubcomponent.Builder builder);
 
       @Binds
       @IntoMap
-      @ContentProviderKey(TestContentProvider.class)
-      abstract AndroidInjector.Factory<? extends ContentProvider> bindFactoryForContentProvider(
+      @ClassKey(TestContentProvider.class)
+      abstract AndroidInjector.Factory<?> bindFactoryForContentProvider(
           ContentProviderSubcomponent.Builder builder);
     }
 

--- a/javatests/dagger/android/support/functional/ComponentStructureFollowsControllerStructureApplication.java
+++ b/javatests/dagger/android/support/functional/ComponentStructureFollowsControllerStructureApplication.java
@@ -16,29 +16,20 @@
 
 package dagger.android.support.functional;
 
-import android.app.Activity;
-import android.app.Service;
-import android.content.BroadcastReceiver;
-import android.content.ContentProvider;
-import android.support.v4.app.Fragment;
 import dagger.Binds;
 import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
 import dagger.Subcomponent;
-import dagger.android.ActivityKey;
 import dagger.android.AndroidInjector;
-import dagger.android.BroadcastReceiverKey;
-import dagger.android.ContentProviderKey;
-import dagger.android.ServiceKey;
 import dagger.android.support.AndroidSupportInjectionModule;
 import dagger.android.support.DaggerApplication;
-import dagger.android.support.FragmentKey;
 import dagger.android.support.functional.ComponentStructureFollowsControllerStructureApplication.ApplicationComponent.BroadcastReceiverSubcomponent.BroadcastReceiverModule;
 import dagger.android.support.functional.ComponentStructureFollowsControllerStructureApplication.ApplicationComponent.ContentProviderSubcomponent.ContentProviderModule;
 import dagger.android.support.functional.ComponentStructureFollowsControllerStructureApplication.ApplicationComponent.InnerActivitySubcomponent.InnerActivityModule;
 import dagger.android.support.functional.ComponentStructureFollowsControllerStructureApplication.ApplicationComponent.IntentServiceSubcomponent.IntentServiceModule;
 import dagger.android.support.functional.ComponentStructureFollowsControllerStructureApplication.ApplicationComponent.ServiceSubcomponent.ServiceModule;
+import dagger.multibindings.ClassKey;
 import dagger.multibindings.IntoMap;
 import dagger.multibindings.IntoSet;
 
@@ -75,38 +66,38 @@ public final class ComponentStructureFollowsControllerStructureApplication
 
       @Binds
       @IntoMap
-      @ActivityKey(TestActivity.class)
-      abstract AndroidInjector.Factory<? extends Activity> bindFactoryForTestActivity(
+      @ClassKey(TestActivity.class)
+      abstract AndroidInjector.Factory<?> bindFactoryForTestActivity(
           ActivitySubcomponent.Builder builder);
 
       @Binds
       @IntoMap
-      @ActivityKey(OuterClass.TestInnerClassActivity.class)
-      abstract AndroidInjector.Factory<? extends Activity> bindFactoryForInnerActivity(
+      @ClassKey(OuterClass.TestInnerClassActivity.class)
+      abstract AndroidInjector.Factory<?> bindFactoryForInnerActivity(
           InnerActivitySubcomponent.Builder builder);
 
       @Binds
       @IntoMap
-      @ServiceKey(TestService.class)
-      abstract AndroidInjector.Factory<? extends Service> bindFactoryForService(
+      @ClassKey(TestService.class)
+      abstract AndroidInjector.Factory<?> bindFactoryForService(
           ServiceSubcomponent.Builder builder);
 
       @Binds
       @IntoMap
-      @ServiceKey(TestIntentService.class)
-      abstract AndroidInjector.Factory<? extends Service> bindFactoryForIntentService(
+      @ClassKey(TestIntentService.class)
+      abstract AndroidInjector.Factory<?> bindFactoryForIntentService(
           IntentServiceSubcomponent.Builder builder);
 
       @Binds
       @IntoMap
-      @BroadcastReceiverKey(TestBroadcastReceiver.class)
-      abstract AndroidInjector.Factory<? extends BroadcastReceiver> bindFactoryForBroadcastReceiver(
+      @ClassKey(TestBroadcastReceiver.class)
+      abstract AndroidInjector.Factory<?> bindFactoryForBroadcastReceiver(
           BroadcastReceiverSubcomponent.Builder builder);
 
       @Binds
       @IntoMap
-      @ContentProviderKey(TestContentProvider.class)
-      abstract AndroidInjector.Factory<? extends ContentProvider> bindFactoryForContentProvider(
+      @ClassKey(TestContentProvider.class)
+      abstract AndroidInjector.Factory<?> bindFactoryForContentProvider(
           ContentProviderSubcomponent.Builder builder);
     }
 
@@ -122,14 +113,14 @@ public final class ComponentStructureFollowsControllerStructureApplication
 
         @Binds
         @IntoMap
-        @FragmentKey(TestParentFragment.class)
-        abstract AndroidInjector.Factory<? extends Fragment> bindFactoryForParentFragment(
+        @ClassKey(TestParentFragment.class)
+        abstract AndroidInjector.Factory<?> bindFactoryForParentFragment(
             ParentFragmentSubcomponent.Builder builder);
 
         @Binds
         @IntoMap
-        @FragmentKey(TestDialogFragment.class)
-        abstract AndroidInjector.Factory<? extends Fragment> bindFactoryForDialogFragment(
+        @ClassKey(TestDialogFragment.class)
+        abstract AndroidInjector.Factory<?> bindFactoryForDialogFragment(
             DialogFragmentSubcomponent.Builder builder);
       }
 
@@ -148,8 +139,8 @@ public final class ComponentStructureFollowsControllerStructureApplication
 
           @Binds
           @IntoMap
-          @FragmentKey(TestChildFragment.class)
-          abstract AndroidInjector.Factory<? extends Fragment> bindFactoryForChildFragment(
+          @ClassKey(TestChildFragment.class)
+          abstract AndroidInjector.Factory<?> bindFactoryForChildFragment(
               ChildFragmentSubcomponent.Builder builder);
         }
 

--- a/javatests/dagger/functional/jdk8/BUILD
+++ b/javatests/dagger/functional/jdk8/BUILD
@@ -36,4 +36,21 @@ GenJavaTests(
     ],
 )
 
+GenJavaTests(
+    name = "jdk8_tests_with_aot",
+    srcs = glob(["**/*.java"]),
+    javacopts = DOCLINT_HTML_AND_SYNTAX,
+    test_only_deps = [
+        "@google_bazel_common//third_party/java/guava",
+        "@google_bazel_common//third_party/java/junit",
+        "@google_bazel_common//third_party/java/truth:truth8",
+    ],
+    with_aot = True,
+    deps = [
+        "//:dagger_with_compiler",
+        "@google_bazel_common//third_party/java/auto:value",
+        "@google_bazel_common//third_party/java/jsr305_annotations",
+    ],
+)
+
 # TODO(b/72748365): Add "with aot" tests, once they pass.

--- a/javatests/dagger/internal/codegen/AheadOfTimeSubcomponentsTest.java
+++ b/javatests/dagger/internal/codegen/AheadOfTimeSubcomponentsTest.java
@@ -3361,7 +3361,7 @@ public final class AheadOfTimeSubcomponentsTest {
             "        ResponseProducerModule_ResponseFactory.create(",
             "            getExecutorProvider(),",
             "            getProductionComponentMonitorProvider(),",
-            "            getResponseDependencyProducernode());",
+            "            getResponseDependencyProducer());",
             "    this.setOfResponseProducer =",
             // TODO(b/72748365): This initialization should be encapsulated in a method to be
             // modified.
@@ -3380,8 +3380,7 @@ public final class AheadOfTimeSubcomponentsTest {
             "  public abstract Provider<ProductionComponentMonitor>",
             "      getProductionComponentMonitorProvider();",
             "",
-            // TODO(b/72748365): Why is the CamelCase wrong at 'node' here.
-            "  public abstract Producer<ResponseDependency> getResponseDependencyProducernode();",
+            "  public abstract Producer<ResponseDependency> getResponseDependencyProducer();",
             "",
             "  @Override",
             "  public void onProducerFutureCancelled(boolean mayInterruptIfRunning) {",
@@ -3572,7 +3571,7 @@ public final class AheadOfTimeSubcomponentsTest {
             "    }",
             "",
             "    @Override",
-            "    public Producer<ResponseDependency> getResponseDependencyProducernode() {",
+            "    public Producer<ResponseDependency> getResponseDependencyProducer() {",
             "      return DaggerRoot.this.responseDependencyProducer;",
             "    }",
             "",

--- a/javatests/dagger/internal/codegen/AheadOfTimeSubcomponentsTest.java
+++ b/javatests/dagger/internal/codegen/AheadOfTimeSubcomponentsTest.java
@@ -702,9 +702,6 @@ public final class AheadOfTimeSubcomponentsTest {
             "",
             "@Subcomponent",
             "interface Leaf {",
-            // "  Leaf leaf();", // TODO(b/72748365): enable this (and fix the bug that's causing
-            // this to stack overflow
-            "",
             "  @Subcomponent.Builder",
             "  interface Builder {",
             "    Leaf build();",

--- a/javatests/dagger/internal/codegen/MultibindingTest.java
+++ b/javatests/dagger/internal/codegen/MultibindingTest.java
@@ -58,7 +58,7 @@ public class MultibindingTest {
 
   @Test
   public void appliedOnInvalidMethods_failsToCompile() {
-    JavaFileObject component =
+    JavaFileObject someType =
         JavaFileObjects.forSourceLines(
             "test.SomeType",
             "package test;",
@@ -76,23 +76,23 @@ public class MultibindingTest {
             "  @IntoMap Map<Integer, Double> map();",
             "}");
 
-    Compilation compilation = daggerCompiler().compile(component);
+    Compilation compilation = daggerCompiler().compile(someType);
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
             "Multibinding annotations may only be on @Provides, @Produces, or @Binds methods")
-        .inFile(component)
-        .onLine(11);
+        .inFile(someType)
+        .onLineContaining("ints();");
     assertThat(compilation)
         .hadErrorContaining(
             "Multibinding annotations may only be on @Provides, @Produces, or @Binds methods")
-        .inFile(component)
-        .onLine(12);
+        .inFile(someType)
+        .onLineContaining("doubles();");
     assertThat(compilation)
         .hadErrorContaining(
             "Multibinding annotations may only be on @Provides, @Produces, or @Binds methods")
-        .inFile(component)
-        .onLine(13);
+        .inFile(someType)
+        .onLineContaining("map();");
   }
 
   @Test

--- a/javatests/dagger/producers/BUILD
+++ b/javatests/dagger/producers/BUILD
@@ -28,22 +28,8 @@ load("//:test_defs.bzl", "GenJavaTests")
 GenJavaTests(
     name = "producers_tests",
     srcs = glob(["**/*.java"]),
+    functional = 0,
     javacopts = SOURCE_7_TARGET_7 + DOCLINT_REFERENCES + DOCLINT_HTML_AND_SYNTAX,
-    deps = [
-        "//java/dagger/producers",
-        "@google_bazel_common//third_party/java/guava",
-        "@google_bazel_common//third_party/java/guava:testlib",
-        "@google_bazel_common//third_party/java/junit",
-        "@google_bazel_common//third_party/java/mockito",
-        "@google_bazel_common//third_party/java/truth",
-    ],
-)
-
-GenJavaTests(
-    name = "producers_tests_with_aot",
-    srcs = glob(["**/*.java"]),
-    javacopts = SOURCE_7_TARGET_7 + DOCLINT_REFERENCES + DOCLINT_HTML_AND_SYNTAX,
-    with_aot = True,
     deps = [
         "//java/dagger/producers",
         "@google_bazel_common//third_party/java/guava",

--- a/javatests/dagger/producers/internal/MapOfProducerProducerTest.java
+++ b/javatests/dagger/producers/internal/MapOfProducerProducerTest.java
@@ -31,7 +31,7 @@ public final class MapOfProducerProducerTest {
   @Test
   public void success() throws Exception {
     MapOfProducerProducer<Integer, String> mapOfProducerProducer =
-        MapOfProducerProducer.<Integer, String>builder()
+        MapOfProducerProducer.<Integer, String>builder(2)
             .put(15, Producers.<String>immediateProducer("fifteen"))
             .put(42, Producers.<String>immediateProducer("forty two"))
             .build();
@@ -47,7 +47,7 @@ public final class MapOfProducerProducerTest {
   public void failingContributionDoesNotFailMap() throws Exception {
     RuntimeException cause = new RuntimeException("monkey");
     MapOfProducerProducer<Integer, String> mapOfProducerProducer =
-        MapOfProducerProducer.<Integer, String>builder()
+        MapOfProducerProducer.<Integer, String>builder(2)
             .put(15, Producers.<String>immediateProducer("fifteen"))
             .put(42, Producers.<String>immediateFailedProducer(cause))
             .build();

--- a/javatests/dagger/producers/internal/MapProducerTest.java
+++ b/javatests/dagger/producers/internal/MapProducerTest.java
@@ -31,7 +31,7 @@ public final class MapProducerTest {
   @Test
   public void success() throws Exception {
     Producer<Map<Integer, String>> mapProducer =
-        MapProducer.<Integer, String>builder()
+        MapProducer.<Integer, String>builder(2)
             .put(15, Producers.immediateProducer("fifteen"))
             .put(42, Producers.immediateProducer("forty two"))
             .build();
@@ -45,7 +45,7 @@ public final class MapProducerTest {
   public void failingContribution() throws Exception {
     RuntimeException cause = new RuntimeException("monkey");
     Producer<Map<Integer, String>> mapProducer =
-        MapProducer.<Integer, String>builder()
+        MapProducer.<Integer, String>builder(2)
             .put(15, Producers.immediateProducer("fifteen"))
             // TODO(ronshapiro): remove the type parameter when we drop java7 support
             .put(42, Producers.<String>immediateFailedProducer(cause))


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Internal change

12ecf764649052b420d2f3ecdc2214b4dd80974d

-------

<p> Update Bazel Common

9c2ce2c9f5a04ebcc5d41e003150c4c945b72e2c

-------

<p> Simplify the binding types of dagger.android injector factories

We've removed the need for "extends FrameworkType" in the return type and are converging on @ClassKey instead of all of the different map keys for each framework type. This will allow us to easily add support for new AndroidX types in dagger.android in the future.

bebcee21438d86eee7e19498f0bb10bd73e0bb29

-------

<p> Add an ErrorProne refactoring for moving between @ActivityKey/@FragmentKey/etc to @ClassKey, and AndroidInjector.Factory<? extends Activity> to AndroidInjector.Factory<?>

RELNOTES=ErrorProne refactoring for migrating to the new format of binding `AndroidInjector.Factory`s with `dagger.android`.

7a3106dcfd73c94bef7f505edbcfec2d102419cf

-------

<p> Simplify Optional-map-chain

92dee5161e0afd47f92b9ff05d4ec360a6cbd80e

-------

<p> Use ComponentDescriptor.entryPoints() to iterate through the entry points.

daebdd0a8d33a77a3e2cabef41e52db4354dfa89

-------

<p> Fix weird method-naming bug where Producer methods were being named ...Producernode()

35b1a854bdfc2b38372038852afa35d8f26e06f2

-------

<p> Simplify superclassContributionsMade()

e39662b011a9a9d7465892b01e671d3836e24480

-------

<p> Check the number of multibinding annotations while validating the module, instead of in the processing step for the multibinding annotations. Otherwise, an error in a module compiled at the same time as the component will not prevent trying to implement the component and can mean thrown exceptions at compile time.

RELNOTES=Avoid some thrown errors during Dagger compilation for invalid modules.

f808b296885a2c0b7937ee0684bc23f702aad578

-------

<p> Add the expected size for Producer map factories

aa2991d2355f20fcdd055488225b15c908d59f3c

-------

<p> Remove the dagger.android multibindings that have bounded wildcards (e.g. ? extends Activity) internally.

This is intentionally keeping them available in the opensource build so that it's easier for external users to have a version in between where they can migrate.

0ae21e4e07d9e859629daf8865f679e213f3ac86

-------

<p> Remove an unused parameter

f6b4624752accb19798c3275f8b55c064d3baf24

-------

<p> Add AOT tests for JDK8

dac7f2d8faafc60cf2e493af905fb6edbc92e4f5

-------

<p> Remove one TODO that I incorrectly thought was related to AOT, and also switch another TODO to AOT after-work

3516a0a81b092b3af9e2fc85d373601e93782459