### PR TITLE
changed compile to implementation for android gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ dependencies {
 ```groovy
 // Add Dagger dependencies
 dependencies {
-  compile 'com.google.dagger:dagger:2.x'
+  implementations 'com.google.dagger:dagger:2.x'
   annotationProcessor 'com.google.dagger:dagger-compiler:2.x'
 }
 ```


### PR DESCRIPTION
change the keyword of compile to implementation in README.md as compile is about to become obsolete.  