### PR TITLE
Update Java Gradle example for Gradle 4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,17 +126,14 @@ parallelizable execution graphs), then add this to your maven configuration:
 
 #### Java Gradle
 ```groovy
-// Add plugin https://plugins.gradle.org/plugin/net.ltgt.apt
-plugins {
-  id "net.ltgt.apt" version "0.10"
-}
-
 // Add Dagger dependencies
 dependencies {
-  compile 'com.google.dagger:dagger:2.x'
-  apt 'com.google.dagger:dagger-compiler:2.x'
+  implementation 'com.google.dagger:dagger:2.x'
+  annotationProcessor 'com.google.dagger:dagger-compiler:2.x'
 }
 ```
+
+For Gradle 4.5 and lower, see https://plugins.gradle.org/plugin/net.ltgt.apt
 
 #### Android Gradle
 ```groovy


### PR DESCRIPTION
The `net.ltgt.apt` plugin is not required as of Gradle 4.6 which [supports the annotationProcessor configuration natively](https://docs.gradle.org/4.6/release-notes.html#convenient-declaration-of-annotation-processor-dependencies).

The new example should be functionally identical to the old.