### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/BindingGraphFactory.java
+++ b/java/dagger/internal/codegen/BindingGraphFactory.java
@@ -188,7 +188,7 @@ final class BindingGraphFactory {
     // done in a queue since resolving one subcomponent might resolve a key for a subcomponent
     // from a parent graph. This is done until no more new subcomponents are resolved.
     Set<ComponentDescriptor> resolvedSubcomponents = new HashSet<>();
-    ImmutableSet.Builder<BindingGraph> subgraphs = ImmutableSet.builder();
+    ImmutableList.Builder<BindingGraph> subgraphs = ImmutableList.builder();
     for (ComponentDescriptor subcomponent :
         Iterables.consumingIterable(requestResolver.subcomponentsToResolve)) {
       if (resolvedSubcomponents.add(subcomponent)) {

--- a/java/dagger/internal/codegen/DuplicateBindingsValidator.java
+++ b/java/dagger/internal/codegen/DuplicateBindingsValidator.java
@@ -18,32 +18,34 @@ package dagger.internal.codegen;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.common.collect.Maps.filterValues;
-import static com.google.common.collect.Maps.transformValues;
 import static dagger.internal.codegen.DaggerStreams.toImmutableSet;
 import static dagger.internal.codegen.DaggerStreams.toImmutableSetMultimap;
 import static dagger.internal.codegen.Formatter.INDENT;
 import static dagger.internal.codegen.Optionals.emptiesLast;
+import static dagger.model.BindingKind.MEMBERS_INJECTION;
 import static java.util.Comparator.comparing;
 import static javax.tools.Diagnostic.Kind.ERROR;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Equivalence;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 import dagger.model.Binding;
 import dagger.model.BindingGraph;
 import dagger.model.BindingGraph.Node;
+import dagger.model.ComponentPath;
 import dagger.model.DependencyRequest;
 import dagger.model.Key;
 import dagger.spi.BindingGraphPlugin;
 import dagger.spi.DiagnosticReporter;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import javax.inject.Inject;
@@ -109,36 +111,69 @@ final class DuplicateBindingsValidator implements BindingGraphPlugin {
     // subcomponent to fix.
     // TODO(ronshapiro): Explore ways to address such underreporting without overreporting.
     Set<ImmutableSet<Equivalence.Wrapper<Binding>>> reportedDuplicateBindingSets = new HashSet<>();
-    duplicateBindings(bindingGraph)
+    duplicateBindingSets(bindingGraph)
         .forEach(
-            (sourceAndRequest, resolvedBindings) -> {
+            duplicateBindings -> {
               // Only report each set of duplicate bindings once, ignoring the installed component.
-              if (reportedDuplicateBindingSets.add(
-                  equivalentSetIgnoringComponentPath(resolvedBindings))) {
-                reportDuplicateBindings(resolvedBindings, bindingGraph, diagnosticReporter);
+              if (reportedDuplicateBindingSets.add(duplicateBindings)) {
+                reportDuplicateBindings(
+                    duplicateBindings.stream()
+                        .map(Equivalence.Wrapper::get)
+                        .collect(toImmutableSet()),
+                    bindingGraph,
+                    diagnosticReporter);
               }
             });
   }
 
   /**
-   * Returns duplicate bindings for each dependency request, counting the same dependency request
-   * separately when coming from separate source nodes.
+   * Returns sets of duplicate bindings. Bindings are duplicates if they bind the same key and are
+   * visible from the same component. Two bindings that differ only in the component that owns them
+   * are not considered to be duplicates, because that means the same binding was "copied" down to a
+   * descendant component because it depends on local multibindings or optional bindings.
    */
-  private Map<SourceAndRequest, ImmutableSet<Binding>> duplicateBindings(
+  private ImmutableSet<ImmutableSet<Equivalence.Wrapper<Binding>>> duplicateBindingSets(
       BindingGraph bindingGraph) {
-    ImmutableSetMultimap<SourceAndRequest, Binding> bindingsByDependencyRequest =
-        bindingGraph.dependencyEdges().stream()
-            .filter(edge -> bindingGraph.network().incidentNodes(edge).target() instanceof Binding)
-            .collect(
-                toImmutableSetMultimap(
-                    edge ->
-                        SourceAndRequest.create(
-                            bindingGraph.network().incidentNodes(edge).source(),
-                            edge.dependencyRequest()),
-                    edge -> ((Binding) bindingGraph.network().incidentNodes(edge).target())));
-    return transformValues(
-        filterValues(bindingsByDependencyRequest.asMap(), bindings -> bindings.size() > 1),
-        ImmutableSet::copyOf);
+    return groupBindingsByKey(bindingGraph).stream()
+        .flatMap(bindings -> mutuallyVisibleSubsets(bindings).stream())
+        .map(DuplicateBindingsValidator::equivalentSetIgnoringComponentPath)
+        .filter(duplicates -> duplicates.size() > 1)
+        .collect(toImmutableSet());
+  }
+
+  private static ImmutableSet<ImmutableSet<Binding>> groupBindingsByKey(BindingGraph bindingGraph) {
+    return valueSetsForEachKey(
+        bindingGraph.bindings().stream()
+            .filter(binding -> !binding.kind().equals(MEMBERS_INJECTION))
+            .collect(toImmutableSetMultimap(Binding::key, binding -> binding)));
+  }
+
+  /**
+   * Returns the subsets of the input set that contain bindings that are all visible from the same
+   * component. A binding is visible from its component and all its descendants.
+   */
+  private static ImmutableSet<ImmutableSet<Binding>> mutuallyVisibleSubsets(
+      Set<Binding> duplicateBindings) {
+    ImmutableListMultimap<ComponentPath, Binding> bindingsByComponentPath =
+        Multimaps.index(duplicateBindings, Binding::componentPath);
+    ImmutableSetMultimap.Builder<ComponentPath, Binding> mutuallyVisibleBindings =
+        ImmutableSetMultimap.builder();
+    bindingsByComponentPath
+        .asMap()
+        .forEach(
+            (componentPath, bindings) -> {
+              mutuallyVisibleBindings.putAll(componentPath, bindings);
+              for (ComponentPath ancestor = componentPath; !ancestor.atRoot(); ) {
+                ancestor = ancestor.parent();
+                ImmutableList<Binding> bindingsInAncestor = bindingsByComponentPath.get(ancestor);
+                mutuallyVisibleBindings.putAll(componentPath, bindingsInAncestor);
+              }
+            });
+    return valueSetsForEachKey(mutuallyVisibleBindings.build());
+  }
+
+  private static <E> ImmutableSet<ImmutableSet<E>> valueSetsForEachKey(Multimap<?, E> multimap) {
+    return multimap.asMap().values().stream().map(ImmutableSet::copyOf).collect(toImmutableSet());
   }
 
   private void reportDuplicateBindings(

--- a/java/dagger/producers/ProductionComponent.java
+++ b/java/dagger/producers/ProductionComponent.java
@@ -17,12 +17,14 @@
 package dagger.producers;
 
 import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import dagger.Module;
 import dagger.Provides;
 import dagger.internal.Beta;
 import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import javax.inject.Inject;
 import javax.inject.Qualifier;
@@ -31,22 +33,24 @@ import javax.inject.Qualifier;
  * Annotates an interface or abstract class for which a fully-formed, dependency-injected
  * implementation is to be generated from a set of {@linkplain #modules modules}. The generated
  * class will have the name of the type annotated with {@code @ProductionComponent} prepended with
- * {@code Dagger}.  For example, {@code @ProductionComponent interface MyComponent {...}} will
+ * {@code Dagger}. For example, {@code @ProductionComponent interface MyComponent {...}} will
  * produce an implementation named {@code DaggerMyComponent}.
  *
  * <p>Each {@link Produces} method that contributes to the component will be called at most once per
- * component instance, no matter how many times that binding is used as a dependency.
- * TODO(beder): Decide on how scope works for producers.
+ * component instance, no matter how many times that binding is used as a dependency. TODO(beder):
+ * Decide on how scope works for producers.
  *
  * <h2>Component methods</h2>
  *
  * <p>Every type annotated with {@code @ProductionComponent} must contain at least one abstract
  * component method. Component methods must represent {@linkplain Producer production}.
  *
- * Production methods have no arguments and return either a {@link ListenableFuture} or
- * {@link Producer} of a type that is {@link Inject injected}, {@link Provides provided}, or
- * {@link Produces produced}. Each may have a {@link Qualifier} annotation as well. The following
- * are all valid production method declarations: <pre><code>
+ * <p>Production methods have no arguments and return either a {@link ListenableFuture} or {@link
+ * Producer} of a type that is {@link Inject injected}, {@link Provides provided}, or {@link
+ * Produces produced}. Each may have a {@link Qualifier} annotation as well. The following are all
+ * valid production method declarations:
+ *
+ * <pre><code>
  *   {@literal ListenableFuture<SomeType>} getSomeType();
  *   {@literal Producer<Set<SomeType>>} getSomeTypes();
  *   {@literal @Response ListenableFuture<Html>} getResponse();
@@ -60,9 +64,9 @@ import javax.inject.Qualifier;
  * and if the downstream producer injects a {@code Produced<T>}, then the downstream producer will
  * be run with the exception stored in the {@code Produced<T>}.
  *
- * <p>If a non-execution exception is thrown (e.g., an {@code InterruptedException} or
- * {@code CancellationException}), then exception is handled as in
- * {@link com.google.common.util.concurrent.Futures#transform}.
+ * <p>If a non-execution exception is thrown (e.g., an {@code InterruptedException} or {@code
+ * CancellationException}), then exception is handled as in {@link
+ * com.google.common.util.concurrent.Futures#transform}.
  * <!-- TODO(beder): Explain this more thoroughly, and update the javadocs of those utilities. -->
  *
  * <h2>Executor</h2>
@@ -74,6 +78,7 @@ import javax.inject.Qualifier;
  *
  * @since 2.0
  */
+@Retention(RUNTIME) // Allows runtimes to have specialized behavior interoperating with Dagger.
 @Documented
 @Target(TYPE)
 @Beta


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> When detecting a child subcomponent's superclass implementation, don't assume that that it must be nested directly in the current component's superclass implementation. The child subcomponent builder may have been a pruned binding there, causing no generation of the subcomponent to occur.

2f437fa08b291c6fbaef0f3109f1e7a151d4494d

-------

<p> Make @ProductionComponent have runtime retention so tools can interpret it like all of the other component annotations

RELNOTES=Make `@ProductionComponent` have runtime retention so tools can interpret it like all of the other component annotations

df644317fa9ca9e37d95b3332ed2a0fd0e42aa59

-------

<p> Store a binding graph's subgraphs as a list instead of a set

BindingGraph.hashCode() is extremely slow as has already been discovered, but even memoizing the value doesn't do much value in cases where it is unlikely for the hash code to be computed and it is only computed once.

It should be impossible to try and resolve the same child graph twice for the same graph, and I'd argue that doing so represents a deeper bug in the binding graph resolution algorithm. Not catching the bug will likely result in Dagger attempting to generate the same component implementation twice, in turn causing a compiler error and a better indication of the bug than what we have by keeping a set.

We never use this set for set-like properties. We only use it for iteration purposes.

This is particularly devastating in ahead-of-time components, where we create N BindingGraph instances for a particular component in a hierarchy, where N is the depth in the hierarchy. Profiling a large component internally with AOT turned on showed BindingGraph.hashCode() taking 7.3s, or 2.8% of the entire compilation (12.4% of total annotation processing).

RELNOTES=Peformance improvements in annotation processing

543fd21e6813dd4eceae48a8ef8074e86c33d906

-------

<p> Report duplicate bindings even if they have no incoming dependency requests. This is in preparation for module binding validation, where there may not be any incoming dependency requests for a binding.

15b3981b81add58527abc74b6abca8aeeae4c468

-------

<p> Automated rollback of 15b3981b81add58527abc74b6abca8aeeae4c468

*** Reason for rollback ***

Breaks projects that had (hidden?) duplicate bindings. Maybe this check is overzealous.

*** Original change description ***

Report duplicate bindings even if they have no incoming dependency requests. This is in preparation for module binding validation, where there may not be any incoming dependency requests for a binding.

***

125dd1d825593ab8c9c65f2e7cde90bcf7efda09