### PR TITLE
WORKSPACE: use non-deprecated http_archive().

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "google_bazel_common",
     strip_prefix = "bazel-common-1c225e62390566a9e88916471948ddd56e5f111c",


### PR DESCRIPTION
The Starlark builtin `http_archive` has been deprecated for a while in favor of the http_archive rule defined in @bazel_tools//tools/build_defs/repo:http.bzl. bazel 0.20 makes this a [breaking change](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+label%3Abreaking-change-0.20), meaning that it is not possible to build Dagger at head with bazel 0.20+.

The [corresponding change](https://github.com/google/bazel-common/commit/857ff967593ec4022a9b99cba038a4779c3e1a35) was made in bazel-common recently.