### PR TITLE
tools: simple_jar: fix external package path.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+workspace(name = "com_github_google_dagger")
+
 http_archive(
     name = "google_bazel_common",
     strip_prefix = "bazel-common-1c225e62390566a9e88916471948ddd56e5f111c",

--- a/tools/simple_jar.bzl
+++ b/tools/simple_jar.bzl
@@ -27,8 +27,8 @@ def simple_jar(name, srcs):
         OUT="$$(pwd)/$@"
         if [[ -e "{package_name}" ]]; then
           cd "{package_name}"
-        elif [[ -e "external/{package_name}" ]]; then
-          cd "external/{package_name}"
+        elif [[ -e "external/dagger/{package_name}" ]]; then
+          cd "external/dagger/{package_name}"
         else
           echo "Cannot find {package_name} directory"
           exit 1

--- a/tools/simple_jar.bzl
+++ b/tools/simple_jar.bzl
@@ -27,8 +27,8 @@ def simple_jar(name, srcs):
         OUT="$$(pwd)/$@"
         if [[ -e "{package_name}" ]]; then
           cd "{package_name}"
-        elif [[ -e "external/dagger/{package_name}" ]]; then
-          cd "external/dagger/{package_name}"
+        elif [[ -e "external/com_github_google_dagger/{package_name}" ]]; then
+          cd "external/com_github_google_dagger/{package_name}"
         else
           echo "Cannot find {package_name} directory"
           exit 1


### PR DESCRIPTION
It was missing the workspace prefix (`dagger`).

Tested: manually built `//java/dagger/internal/codegen:processor_manifest_files` from the
dagger repo and from a downstream repo.