### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/BindingGraphConverter.java
+++ b/java/dagger/internal/codegen/BindingGraphConverter.java
@@ -57,8 +57,11 @@ final class BindingGraphConverter {
   /**
    * Creates the external {@link dagger.model.BindingGraph} representing the given internal {@link
    * dagger.internal.codegen.BindingGraph}.
+   *
+   * @param fullBindingGraph if {@code true}, include bindings that are not reachable from any entry
+   *     points
    */
-  dagger.model.BindingGraph convert(BindingGraph bindingGraph) {
+  dagger.model.BindingGraph convert(BindingGraph bindingGraph, boolean fullBindingGraph) {
     Traverser traverser = new Traverser(bindingGraph);
     traverser.traverseComponents();
 
@@ -66,15 +69,13 @@ final class BindingGraphConverter {
     // multibindings or optional bindings, the parent-owned binding is still there. If that
     // parent-owned binding is not reachable from its component, it doesn't need to be in the graph
     // because it will never be used. So remove all nodes that are not reachable from the root
-    // component—unless the component is a module-binding validation component.
-    if (!bindingGraph.componentDescriptor().kind().isForModuleValidation()) {
+    // component—unless we're building a full binding graph.
+    if (!fullBindingGraph) {
       unreachableNodes(traverser.network.asGraph(), rootComponentNode(traverser.network))
           .forEach(traverser.network::removeNode);
     }
 
-    ComponentKind componentKind = bindingGraph.componentDescriptor().kind();
-    return BindingGraphProxies.bindingGraph(
-        traverser.network, componentKind.isForModuleValidation());
+    return BindingGraphProxies.bindingGraph(traverser.network, fullBindingGraph);
   }
 
   // TODO(dpb): Example of BindingGraph logic applied to derived networks.

--- a/java/dagger/internal/codegen/ComponentProcessingStep.java
+++ b/java/dagger/internal/codegen/ComponentProcessingStep.java
@@ -150,7 +150,7 @@ final class ComponentProcessingStep extends TypeCheckingProcessingStep<TypeEleme
   }
 
   private boolean isValid(BindingGraph bindingGraph) {
-    dagger.model.BindingGraph modelGraph = bindingGraphConverter.convert(bindingGraph);
+    dagger.model.BindingGraph modelGraph = bindingGraphConverter.convert(bindingGraph, false);
     return bindingGraphValidator.isValid(modelGraph);
   }
 

--- a/java/dagger/internal/codegen/GenerationOptionsModule.java
+++ b/java/dagger/internal/codegen/GenerationOptionsModule.java
@@ -19,6 +19,7 @@ package dagger.internal.codegen;
 import dagger.Module;
 import dagger.Provides;
 import dagger.internal.GenerationOptions;
+import java.util.Optional;
 
 /** Adds bindings for serializing and rereading {@link GenerationOptions}. */
 @Module
@@ -30,9 +31,18 @@ interface GenerationOptionsModule {
       CompilerOptions defaultOptions,
       ComponentImplementation componentImplementation,
       DaggerElements elements) {
-    return componentImplementation
-        .baseImplementation()
+    // Inspect the base implementation for the @GenerationOptions annotation. Even if
+    // componentImplementation is the base implementation, inspect it for the case where we are
+    // recomputing the ComponentImplementation from a previous compilation.
+    // TODO(b/117833324): consider adding a method that returns baseImplementation.orElse(this).
+    // The current state of the world is a little confusing and maybe not intuitive: the base
+    // implementation has no base implementation, but it _is_ a base implementation.
+    return Optional.of(componentImplementation.baseImplementation().orElse(componentImplementation))
         .map(baseImplementation -> elements.getTypeElement(baseImplementation.name()))
+        // If this returns null, the type has not been generated yet and Optional will switch to an
+        // empty state. This means that we're currently generating componentImplementation, or that
+        // the base implementation is being generated in this round, and thus the options passed to
+        // this compilation are applicable
         .map(typeElement -> typeElement.getAnnotation(GenerationOptions.class))
         .map(defaultOptions::withGenerationOptions)
         .orElse(defaultOptions);

--- a/java/dagger/internal/codegen/ModuleValidator.java
+++ b/java/dagger/internal/codegen/ModuleValidator.java
@@ -590,7 +590,7 @@ final class ModuleValidator {
       TypeElement module, ValidationReport.Builder<TypeElement> report) {
     BindingGraph bindingGraph =
         bindingGraphConverter.convert(
-            bindingGraphFactory.create(componentDescriptorFactory.forTypeElement(module)));
+            bindingGraphFactory.create(componentDescriptorFactory.forTypeElement(module)), true);
     if (!bindingGraphValidator.isValid(bindingGraph)) {
       // Since the validator uses a DiagnosticReporter to report errors, the ValdiationReport won't
       // have any Items for them. We have to tell the ValidationReport that some errors were

--- a/javatests/dagger/internal/codegen/Compilers.java
+++ b/javatests/dagger/internal/codegen/Compilers.java
@@ -35,9 +35,7 @@ final class Compilers {
   static final ImmutableList<String> CLASS_PATH_WITHOUT_GUAVA_OPTION =
       ImmutableList.of(
           "-classpath",
-          Splitter.on(PATH_SEPARATOR.value())
-              .splitToList(JAVA_CLASS_PATH.value())
-              .stream()
+          Splitter.on(PATH_SEPARATOR.value()).splitToList(JAVA_CLASS_PATH.value()).stream()
               .filter(jar -> !jar.contains(GUAVA))
               .collect(joining(PATH_SEPARATOR.value())));
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix coverage runs

313fe662a78ca82e07b4fc3ef8c6bd991c809e8f

-------

<p> Explicitly tell BindingGraphConverter whether it's creating a full binding graph, or else it will prune unreachable bindings.

5adc52ccfb95892f70551bfbf5487c210491d137

-------

<p> Fix the @GenerationOptions retrieval and enable a build_test for the dagger.functional.aot.fastinit libraries so that we catch this in presubmit.

I originally had this and dpb@ asked what it was doing, and I wasn't able to remember why I had done it that way, and all of the tests were passing so I "simplified" it. I added a comment about what's going on so it's clearer in the future.

b0e964ce8959f0077ec7ea52760960acb02b42a9