### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/BindingGraph.java
+++ b/java/dagger/internal/codegen/BindingGraph.java
@@ -202,14 +202,14 @@ abstract class BindingGraph {
         .map(module -> ComponentRequirement.forModule(module.asType()))
         .forEach(requirements::add);
     if (factoryMethod().isPresent()) {
-      factoryMethodParameters().keySet().forEach(requirements::add);
+      requirements.addAll(factoryMethodParameters().keySet());
     }
     requirements.addAll(componentDescriptor().dependencies());
     componentDescriptor()
         .creatorDescriptor()
         .ifPresent(
             creatorDescriptor ->
-                creatorDescriptor.boundInstanceRequirements().forEach(requirements::add));
+                requirements.addAll(creatorDescriptor.boundInstanceRequirements()));
     return requirements.build();
   }
 

--- a/java/dagger/internal/codegen/ComponentProcessor.java
+++ b/java/dagger/internal/codegen/ComponentProcessor.java
@@ -55,7 +55,10 @@ public class ComponentProcessor extends BasicAnnotationProcessor {
   @Inject BindingGraphPlugins bindingGraphPlugins;
   @Inject CompilerOptions compilerOptions;
   @Inject DaggerStatistics daggerStatistics;
+
+  // TODO(ronshapiro): inject a multibinding for all instances that retain caches?
   @Inject ModuleDescriptor.Factory moduleDescriptorFactory;
+  @Inject BindingGraphFactory bindingGraphFactory;
 
   public ComponentProcessor() {
     this.testingPlugins = Optional.empty();
@@ -190,5 +193,6 @@ public class ComponentProcessor extends BasicAnnotationProcessor {
       }
     }
     moduleDescriptorFactory.clearCache();
+    bindingGraphFactory.clearCache();
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Correctly cast expressions that are derived from framework instances that are returned from component methods in AOT.

Because they use a ComponentMethodBindingExpression instead of a ModifiableConcreteMethodBindingExpression, they don't cross the code path that checks for assignability to the return type.

edb524b0effa04bf17fec6edb82988cdb4a2043f

-------

<p> Switch a forEach and ::add to addAll()

4d7a2c00d3d188095e233f67b069175a07019e05

-------

<p> Cache BindingGraphFactory.Resolver.keysMatchingRequest()

This has repeated blocks show up in profiles, amounting to 2s/build for a large internal component with with AOT:

This should still have gains without AOT turned on, though the gains will be smaller since fewer BindingGraph instances are created+resolved.

RELNOTES=Build performance improvements for large components

e4e501cd2e8a12e73fc21c223ebafeb7bd4bdc2d