### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -139,6 +139,7 @@ java_library(
         "ChildFactoryMethodEdgeImpl.java",
         "ComponentCreatorDescriptor.java",
         "ComponentDescriptor.java",
+        "ComponentDescriptorFactory.java",
         "ComponentKind.java",
         "ComponentNodeImpl.java",
         "ComponentRequirement.java",

--- a/java/dagger/internal/codegen/ComponentDescriptor.java
+++ b/java/dagger/internal/codegen/ComponentDescriptor.java
@@ -16,40 +16,24 @@
 
 package dagger.internal.codegen;
 
-import static com.google.auto.common.MoreElements.isAnnotationPresent;
 import static com.google.auto.common.MoreTypes.isTypeOf;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.Iterables.getOnlyElement;
-import static dagger.internal.codegen.ConfigurationAnnotations.enclosedAnnotatedTypes;
-import static dagger.internal.codegen.ConfigurationAnnotations.getComponentDependencies;
-import static dagger.internal.codegen.ConfigurationAnnotations.getComponentModules;
-import static dagger.internal.codegen.ConfigurationAnnotations.isSubcomponentCreator;
-import static dagger.internal.codegen.DaggerElements.getAnnotationMirror;
 import static dagger.internal.codegen.DaggerStreams.toImmutableMap;
 import static dagger.internal.codegen.DaggerStreams.toImmutableSet;
 import static dagger.internal.codegen.DaggerTypes.isFutureType;
-import static dagger.internal.codegen.InjectionAnnotations.getQualifier;
-import static dagger.internal.codegen.Scopes.productionScope;
-import static dagger.internal.codegen.Scopes.scopesOf;
 import static javax.lang.model.element.Modifier.ABSTRACT;
-import static javax.lang.model.type.TypeKind.DECLARED;
 import static javax.lang.model.type.TypeKind.VOID;
-import static javax.lang.model.util.ElementFilter.methodsIn;
 
-import com.google.auto.common.MoreElements;
-import com.google.auto.common.MoreTypes;
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.memoized.Memoized;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableBiMap;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import dagger.Component;
-import dagger.Lazy;
 import dagger.Module;
 import dagger.Subcomponent;
 import dagger.model.DependencyRequest;
@@ -59,19 +43,14 @@ import dagger.producers.ProducerModule;
 import dagger.producers.ProductionComponent;
 import dagger.producers.ProductionSubcomponent;
 import java.lang.annotation.Annotation;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeMirror;
 
 /**
@@ -378,237 +357,14 @@ abstract class ComponentDescriptor {
     }
   }
 
-  static final class Factory {
-    private final DaggerElements elements;
-    private final DaggerTypes types;
-    private final DependencyRequestFactory dependencyRequestFactory;
-    private final ModuleDescriptor.Factory moduleDescriptorFactory;
-    private final CompilerOptions compilerOptions;
-
-    @Inject
-    Factory(
-        DaggerElements elements,
-        DaggerTypes types,
-        DependencyRequestFactory dependencyRequestFactory,
-        ModuleDescriptor.Factory moduleDescriptorFactory,
-        CompilerOptions compilerOptions) {
-      this.elements = elements;
-      this.types = types;
-      this.dependencyRequestFactory = dependencyRequestFactory;
-      this.moduleDescriptorFactory = moduleDescriptorFactory;
-      this.compilerOptions = compilerOptions;
-    }
-
-    /**
-     * Returns a component descriptor for a type.
-     *
-     * <p>The type must be annotated with a top-level component annotation unless ahead-of-time
-     * subcomponents are being generated or we are creating a descriptor for a module in order to
-     * validate its bindings.
-     */
-    ComponentDescriptor forTypeElement(TypeElement typeElement) {
-      Optional<ComponentKind> kind = ComponentKind.forAnnotatedElement(typeElement);
-      checkArgument(
-          kind.isPresent(),
-          "%s must have a component or subcomponent or module annotation",
-          typeElement);
-      if (!compilerOptions.aheadOfTimeSubcomponents()) {
-        checkArgument(kind.get().isRoot(), "%s must be a top-level component.", typeElement);
-      }
-      return create(typeElement, kind.get());
-    }
-
-    private ComponentDescriptor create(TypeElement typeElement, ComponentKind kind) {
-      AnnotationMirror componentAnnotation =
-          getAnnotationMirror(typeElement, kind.annotation()).get();
-      DeclaredType declaredComponentType = MoreTypes.asDeclared(typeElement.asType());
-      ImmutableSet<ComponentRequirement> componentDependencies =
-          kind.isRoot() && !kind.isForModuleValidation()
-              ? getComponentDependencies(componentAnnotation).stream()
-                  .map(ComponentRequirement::forDependency)
-                  .collect(toImmutableSet())
-              : ImmutableSet.of();
-
-      ImmutableMap.Builder<ExecutableElement, ComponentRequirement> dependenciesByDependencyMethod =
-          ImmutableMap.builder();
-
-      for (ComponentRequirement componentDependency : componentDependencies) {
-        for (ExecutableElement dependencyMethod :
-            methodsIn(elements.getAllMembers(componentDependency.typeElement()))) {
-          if (isComponentContributionMethod(elements, dependencyMethod)) {
-            dependenciesByDependencyMethod.put(dependencyMethod, componentDependency);
-          }
-        }
-      }
-
-      ImmutableSet<TypeElement> modules =
-          kind.isForModuleValidation()
-              ? ImmutableSet.of(typeElement)
-              : getComponentModules(componentAnnotation).stream()
-                  .map(MoreTypes::asTypeElement)
-                  .collect(toImmutableSet());
-
-      ImmutableSet<ModuleDescriptor> transitiveModules =
-          moduleDescriptorFactory.transitiveModules(modules);
-
-      ImmutableSet.Builder<ComponentDescriptor> subcomponentsFromModules = ImmutableSet.builder();
-      for (ModuleDescriptor module : transitiveModules) {
-        for (SubcomponentDeclaration subcomponentDeclaration : module.subcomponentDeclarations()) {
-          TypeElement subcomponent = subcomponentDeclaration.subcomponentType();
-          subcomponentsFromModules.add(
-              create(subcomponent, ComponentKind.forAnnotatedElement(subcomponent).get()));
-        }
-      }
-
-      ImmutableSet.Builder<ComponentMethodDescriptor> componentMethodsBuilder =
-          ImmutableSet.builder();
-      ImmutableBiMap.Builder<ComponentMethodDescriptor, ComponentDescriptor>
-          subcomponentsByFactoryMethod = ImmutableBiMap.builder();
-      ImmutableBiMap.Builder<ComponentMethodDescriptor, ComponentDescriptor>
-          subcomponentsByBuilderMethod = ImmutableBiMap.builder();
-      if (!kind.isForModuleValidation()) {
-        ImmutableSet<ExecutableElement> unimplementedMethods =
-            elements.getUnimplementedMethods(typeElement);
-        for (ExecutableElement componentMethod : unimplementedMethods) {
-          ExecutableType resolvedMethod =
-              MoreTypes.asExecutable(types.asMemberOf(declaredComponentType, componentMethod));
-          ComponentMethodDescriptor componentMethodDescriptor =
-              getDescriptorForComponentMethod(typeElement, kind, componentMethod);
-          componentMethodsBuilder.add(componentMethodDescriptor);
-          switch (componentMethodDescriptor.kind()) {
-            case SUBCOMPONENT:
-            case PRODUCTION_SUBCOMPONENT:
-              subcomponentsByFactoryMethod.put(
-                  componentMethodDescriptor,
-                  create(
-                      MoreElements.asType(MoreTypes.asElement(resolvedMethod.getReturnType())),
-                      componentMethodDescriptor.kind().componentKind()));
-              break;
-
-            case SUBCOMPONENT_BUILDER:
-            case PRODUCTION_SUBCOMPONENT_BUILDER:
-              subcomponentsByBuilderMethod.put(
-                  componentMethodDescriptor,
-                  create(
-                      MoreElements.asType(
-                          MoreTypes.asElement(resolvedMethod.getReturnType())
-                              .getEnclosingElement()),
-                      componentMethodDescriptor.kind().componentKind()));
-              break;
-
-            default: // nothing special to do for other methods.
-          }
-        }
-      }
-
-      ImmutableList<DeclaredType> enclosedCreators =
-          kind.builderAnnotation()
-              .map(builderAnnotation -> enclosedAnnotatedTypes(typeElement, builderAnnotation))
-              .orElse(ImmutableList.of());
-      Optional<ComponentCreatorDescriptor> creatorDescriptor =
-          enclosedCreators.isEmpty()
-              ? Optional.empty()
-              : Optional.of(
-                  ComponentCreatorDescriptor.create(
-                      getOnlyElement(enclosedCreators), elements, types, dependencyRequestFactory));
-
-      ImmutableSet<Scope> scopes = scopesOf(typeElement);
-      if (kind.isProducer()) {
-        scopes =
-            ImmutableSet.<Scope>builder().addAll(scopes).add(productionScope(elements)).build();
-      }
-
-      return new AutoValue_ComponentDescriptor(
-          componentAnnotation,
-          typeElement,
-          componentDependencies,
-          transitiveModules,
-          dependenciesByDependencyMethod.build(),
-          scopes,
-          subcomponentsFromModules.build(),
-          subcomponentsByFactoryMethod.build(),
-          subcomponentsByBuilderMethod.build(),
-          componentMethodsBuilder.build(),
-          creatorDescriptor);
-    }
-
-    private ComponentMethodDescriptor getDescriptorForComponentMethod(
-        TypeElement componentElement,
-        ComponentKind componentKind,
-        ExecutableElement componentMethod) {
-      ExecutableType resolvedComponentMethod =
-          MoreTypes.asExecutable(
-              types.asMemberOf(MoreTypes.asDeclared(componentElement.asType()), componentMethod));
-      TypeMirror returnType = resolvedComponentMethod.getReturnType();
-      if (returnType.getKind().equals(DECLARED)) {
-        if (isTypeOf(Provider.class, returnType) || isTypeOf(Lazy.class, returnType)) {
-          return ComponentMethodDescriptor.forProvision(
-              componentMethod,
-              dependencyRequestFactory.forComponentProvisionMethod(
-                  componentMethod, resolvedComponentMethod));
-        } else if (!getQualifier(componentMethod).isPresent()) {
-          Element returnTypeElement = MoreTypes.asElement(returnType);
-          if (ConfigurationAnnotations.isSubcomponent(returnTypeElement)) {
-            return ComponentMethodDescriptor.forSubcomponent(
-                isAnnotationPresent(returnTypeElement, Subcomponent.class)
-                    ? ComponentMethodKind.SUBCOMPONENT
-                    : ComponentMethodKind.PRODUCTION_SUBCOMPONENT,
-                componentMethod);
-          } else if (isSubcomponentCreator(returnTypeElement)) {
-            DependencyRequest dependencyRequest =
-                dependencyRequestFactory.forComponentProvisionMethod(
-                    componentMethod, resolvedComponentMethod);
-            return ComponentMethodDescriptor.forSubcomponentCreator(
-                isAnnotationPresent(returnTypeElement, Subcomponent.Builder.class)
-                    ? ComponentMethodKind.SUBCOMPONENT_BUILDER
-                    : ComponentMethodKind.PRODUCTION_SUBCOMPONENT_BUILDER,
-                dependencyRequest,
-                componentMethod);
-          }
-        }
-      }
-
-      // a typical provision method
-      if (componentMethod.getParameters().isEmpty()
-          && !componentMethod.getReturnType().getKind().equals(VOID)) {
-        switch (componentKind) {
-          case COMPONENT:
-          case SUBCOMPONENT:
-            return ComponentMethodDescriptor.forProvision(
-                componentMethod,
-                dependencyRequestFactory.forComponentProvisionMethod(
-                    componentMethod, resolvedComponentMethod));
-          case PRODUCTION_COMPONENT:
-          case PRODUCTION_SUBCOMPONENT:
-            return ComponentMethodDescriptor.forProvision(
-                componentMethod,
-                dependencyRequestFactory.forComponentProductionMethod(
-                    componentMethod, resolvedComponentMethod));
-          default:
-            throw new AssertionError();
-        }
-      }
-
-      List<? extends TypeMirror> parameterTypes = resolvedComponentMethod.getParameterTypes();
-      if (parameterTypes.size() == 1
-          && (returnType.getKind().equals(VOID)
-              || MoreTypes.equivalence().equivalent(returnType, parameterTypes.get(0)))) {
-        return ComponentMethodDescriptor.forMembersInjection(
-            componentMethod,
-            dependencyRequestFactory.forComponentMembersInjectionMethod(
-                componentMethod, resolvedComponentMethod));
-      }
-
-      throw new IllegalArgumentException("not a valid component method: " + componentMethod);
-    }
-  }
-
-  /**
-   * No-argument methods defined on {@link Object} that are ignored for contribution.
-   */
+  /** No-argument methods defined on {@link Object} that are ignored for contribution. */
   private static final ImmutableSet<String> NON_CONTRIBUTING_OBJECT_METHOD_NAMES =
       ImmutableSet.of("toString", "hashCode", "clone", "getClass");
 
+  /**
+   * Returns {@code true} if a method could be a component entry point but not a members-injection
+   * method.
+   */
   static boolean isComponentContributionMethod(DaggerElements elements, ExecutableElement method) {
     return method.getParameters().isEmpty()
         && !method.getReturnType().getKind().equals(VOID)
@@ -616,6 +372,7 @@ abstract class ComponentDescriptor {
         && !NON_CONTRIBUTING_OBJECT_METHOD_NAMES.contains(method.getSimpleName().toString());
   }
 
+  /** Returns {@code true} if a method could be a component production entry point. */
   static boolean isComponentProductionMethod(DaggerElements elements, ExecutableElement method) {
     return isComponentContributionMethod(elements, method) && isFutureType(method.getReturnType());
   }

--- a/java/dagger/internal/codegen/ComponentDescriptorFactory.java
+++ b/java/dagger/internal/codegen/ComponentDescriptorFactory.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (C) 2014 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen;
+
+import static com.google.auto.common.MoreElements.isAnnotationPresent;
+import static com.google.auto.common.MoreTypes.isTypeOf;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static dagger.internal.codegen.ComponentDescriptor.isComponentContributionMethod;
+import static dagger.internal.codegen.ConfigurationAnnotations.enclosedAnnotatedTypes;
+import static dagger.internal.codegen.ConfigurationAnnotations.getComponentDependencies;
+import static dagger.internal.codegen.ConfigurationAnnotations.getComponentModules;
+import static dagger.internal.codegen.ConfigurationAnnotations.isSubcomponentCreator;
+import static dagger.internal.codegen.DaggerElements.getAnnotationMirror;
+import static dagger.internal.codegen.DaggerStreams.toImmutableSet;
+import static dagger.internal.codegen.InjectionAnnotations.getQualifier;
+import static dagger.internal.codegen.Scopes.productionScope;
+import static dagger.internal.codegen.Scopes.scopesOf;
+import static javax.lang.model.type.TypeKind.DECLARED;
+import static javax.lang.model.type.TypeKind.VOID;
+import static javax.lang.model.util.ElementFilter.methodsIn;
+
+import com.google.auto.common.MoreElements;
+import com.google.auto.common.MoreTypes;
+import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import dagger.Lazy;
+import dagger.Subcomponent;
+import dagger.internal.codegen.ComponentDescriptor.ComponentMethodDescriptor;
+import dagger.internal.codegen.ComponentDescriptor.ComponentMethodKind;
+import dagger.model.DependencyRequest;
+import dagger.model.Scope;
+import java.util.List;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.TypeMirror;
+
+/** A factory for {@link ComponentDescriptor}s. */
+final class ComponentDescriptorFactory {
+  private final DaggerElements elements;
+  private final DaggerTypes types;
+  private final DependencyRequestFactory dependencyRequestFactory;
+  private final ModuleDescriptor.Factory moduleDescriptorFactory;
+  private final CompilerOptions compilerOptions;
+
+  @Inject
+  ComponentDescriptorFactory(
+      DaggerElements elements,
+      DaggerTypes types,
+      DependencyRequestFactory dependencyRequestFactory,
+      ModuleDescriptor.Factory moduleDescriptorFactory,
+      CompilerOptions compilerOptions) {
+    this.elements = elements;
+    this.types = types;
+    this.dependencyRequestFactory = dependencyRequestFactory;
+    this.moduleDescriptorFactory = moduleDescriptorFactory;
+    this.compilerOptions = compilerOptions;
+  }
+
+  /**
+   * Returns a component descriptor for a type.
+   *
+   * <p>The type must be annotated with a top-level component annotation unless ahead-of-time
+   * subcomponents are being generated or we are creating a descriptor for a module in order to
+   * validate its bindings.
+   */
+  ComponentDescriptor forTypeElement(TypeElement typeElement) {
+    Optional<ComponentKind> kind = ComponentKind.forAnnotatedElement(typeElement);
+    checkArgument(
+        kind.isPresent(),
+        "%s must have a component or subcomponent or module annotation",
+        typeElement);
+    if (!compilerOptions.aheadOfTimeSubcomponents()) {
+      checkArgument(kind.get().isRoot(), "%s must be a top-level component.", typeElement);
+    }
+    return create(typeElement, kind.get());
+  }
+
+  private ComponentDescriptor create(TypeElement typeElement, ComponentKind kind) {
+    AnnotationMirror componentAnnotation =
+        getAnnotationMirror(typeElement, kind.annotation()).get();
+    DeclaredType declaredComponentType = MoreTypes.asDeclared(typeElement.asType());
+    ImmutableSet<ComponentRequirement> componentDependencies =
+        kind.isRoot() && !kind.isForModuleValidation()
+            ? getComponentDependencies(componentAnnotation).stream()
+                .map(ComponentRequirement::forDependency)
+                .collect(toImmutableSet())
+            : ImmutableSet.of();
+
+    ImmutableMap.Builder<ExecutableElement, ComponentRequirement> dependenciesByDependencyMethod =
+        ImmutableMap.builder();
+
+    for (ComponentRequirement componentDependency : componentDependencies) {
+      for (ExecutableElement dependencyMethod :
+          methodsIn(elements.getAllMembers(componentDependency.typeElement()))) {
+        if (isComponentContributionMethod(elements, dependencyMethod)) {
+          dependenciesByDependencyMethod.put(dependencyMethod, componentDependency);
+        }
+      }
+    }
+
+    ImmutableSet<TypeElement> modules =
+        kind.isForModuleValidation()
+            ? ImmutableSet.of(typeElement)
+            : getComponentModules(componentAnnotation).stream()
+                .map(MoreTypes::asTypeElement)
+                .collect(toImmutableSet());
+
+    ImmutableSet<ModuleDescriptor> transitiveModules =
+        moduleDescriptorFactory.transitiveModules(modules);
+
+    ImmutableSet.Builder<ComponentDescriptor> subcomponentsFromModules = ImmutableSet.builder();
+    for (ModuleDescriptor module : transitiveModules) {
+      for (SubcomponentDeclaration subcomponentDeclaration : module.subcomponentDeclarations()) {
+        TypeElement subcomponent = subcomponentDeclaration.subcomponentType();
+        subcomponentsFromModules.add(
+            create(subcomponent, ComponentKind.forAnnotatedElement(subcomponent).get()));
+      }
+    }
+
+    ImmutableSet.Builder<ComponentMethodDescriptor> componentMethodsBuilder =
+        ImmutableSet.builder();
+    ImmutableBiMap.Builder<ComponentMethodDescriptor, ComponentDescriptor>
+        subcomponentsByFactoryMethod = ImmutableBiMap.builder();
+    ImmutableBiMap.Builder<ComponentMethodDescriptor, ComponentDescriptor>
+        subcomponentsByBuilderMethod = ImmutableBiMap.builder();
+    if (!kind.isForModuleValidation()) {
+      ImmutableSet<ExecutableElement> unimplementedMethods =
+          elements.getUnimplementedMethods(typeElement);
+      for (ExecutableElement componentMethod : unimplementedMethods) {
+        ExecutableType resolvedMethod =
+            MoreTypes.asExecutable(types.asMemberOf(declaredComponentType, componentMethod));
+        ComponentMethodDescriptor componentMethodDescriptor =
+            getDescriptorForComponentMethod(typeElement, kind, componentMethod);
+        componentMethodsBuilder.add(componentMethodDescriptor);
+        switch (componentMethodDescriptor.kind()) {
+          case SUBCOMPONENT:
+          case PRODUCTION_SUBCOMPONENT:
+            subcomponentsByFactoryMethod.put(
+                componentMethodDescriptor,
+                create(
+                    MoreElements.asType(MoreTypes.asElement(resolvedMethod.getReturnType())),
+                    componentMethodDescriptor.kind().componentKind()));
+            break;
+
+          case SUBCOMPONENT_BUILDER:
+          case PRODUCTION_SUBCOMPONENT_BUILDER:
+            subcomponentsByBuilderMethod.put(
+                componentMethodDescriptor,
+                create(
+                    MoreElements.asType(
+                        MoreTypes.asElement(resolvedMethod.getReturnType()).getEnclosingElement()),
+                    componentMethodDescriptor.kind().componentKind()));
+            break;
+
+          default: // nothing special to do for other methods.
+        }
+      }
+    }
+
+    ImmutableList<DeclaredType> enclosedCreators =
+        kind.builderAnnotation()
+            .map(builderAnnotation -> enclosedAnnotatedTypes(typeElement, builderAnnotation))
+            .orElse(ImmutableList.of());
+    Optional<ComponentCreatorDescriptor> creatorDescriptor =
+        enclosedCreators.isEmpty()
+            ? Optional.empty()
+            : Optional.of(
+                ComponentCreatorDescriptor.create(
+                    getOnlyElement(enclosedCreators), elements, types, dependencyRequestFactory));
+
+    ImmutableSet<Scope> scopes = scopesOf(typeElement);
+    if (kind.isProducer()) {
+      scopes = ImmutableSet.<Scope>builder().addAll(scopes).add(productionScope(elements)).build();
+    }
+
+    return new AutoValue_ComponentDescriptor(
+        componentAnnotation,
+        typeElement,
+        componentDependencies,
+        transitiveModules,
+        dependenciesByDependencyMethod.build(),
+        scopes,
+        subcomponentsFromModules.build(),
+        subcomponentsByFactoryMethod.build(),
+        subcomponentsByBuilderMethod.build(),
+        componentMethodsBuilder.build(),
+        creatorDescriptor);
+  }
+
+  private ComponentMethodDescriptor getDescriptorForComponentMethod(
+      TypeElement componentElement,
+      ComponentKind componentKind,
+      ExecutableElement componentMethod) {
+    ExecutableType resolvedComponentMethod =
+        MoreTypes.asExecutable(
+            types.asMemberOf(MoreTypes.asDeclared(componentElement.asType()), componentMethod));
+    TypeMirror returnType = resolvedComponentMethod.getReturnType();
+    if (returnType.getKind().equals(DECLARED)) {
+      if (isTypeOf(Provider.class, returnType) || isTypeOf(Lazy.class, returnType)) {
+        return ComponentMethodDescriptor.forProvision(
+            componentMethod,
+            dependencyRequestFactory.forComponentProvisionMethod(
+                componentMethod, resolvedComponentMethod));
+      } else if (!getQualifier(componentMethod).isPresent()) {
+        Element returnTypeElement = MoreTypes.asElement(returnType);
+        if (ConfigurationAnnotations.isSubcomponent(returnTypeElement)) {
+          return ComponentMethodDescriptor.forSubcomponent(
+              isAnnotationPresent(returnTypeElement, Subcomponent.class)
+                  ? ComponentMethodKind.SUBCOMPONENT
+                  : ComponentMethodKind.PRODUCTION_SUBCOMPONENT,
+              componentMethod);
+        } else if (isSubcomponentCreator(returnTypeElement)) {
+          DependencyRequest dependencyRequest =
+              dependencyRequestFactory.forComponentProvisionMethod(
+                  componentMethod, resolvedComponentMethod);
+          return ComponentMethodDescriptor.forSubcomponentCreator(
+              isAnnotationPresent(returnTypeElement, Subcomponent.Builder.class)
+                  ? ComponentMethodKind.SUBCOMPONENT_BUILDER
+                  : ComponentMethodKind.PRODUCTION_SUBCOMPONENT_BUILDER,
+              dependencyRequest,
+              componentMethod);
+        }
+      }
+    }
+
+    // a typical provision method
+    if (componentMethod.getParameters().isEmpty()
+        && !componentMethod.getReturnType().getKind().equals(VOID)) {
+      switch (componentKind) {
+        case COMPONENT:
+        case SUBCOMPONENT:
+          return ComponentMethodDescriptor.forProvision(
+              componentMethod,
+              dependencyRequestFactory.forComponentProvisionMethod(
+                  componentMethod, resolvedComponentMethod));
+        case PRODUCTION_COMPONENT:
+        case PRODUCTION_SUBCOMPONENT:
+          return ComponentMethodDescriptor.forProvision(
+              componentMethod,
+              dependencyRequestFactory.forComponentProductionMethod(
+                  componentMethod, resolvedComponentMethod));
+        default:
+          throw new AssertionError();
+      }
+    }
+
+    List<? extends TypeMirror> parameterTypes = resolvedComponentMethod.getParameterTypes();
+    if (parameterTypes.size() == 1
+        && (returnType.getKind().equals(VOID)
+            || MoreTypes.equivalence().equivalent(returnType, parameterTypes.get(0)))) {
+      return ComponentMethodDescriptor.forMembersInjection(
+          componentMethod,
+          dependencyRequestFactory.forComponentMembersInjectionMethod(
+              componentMethod, resolvedComponentMethod));
+    }
+
+    throw new IllegalArgumentException("not a valid component method: " + componentMethod);
+  }
+}

--- a/java/dagger/internal/codegen/ComponentHjarProcessingStep.java
+++ b/java/dagger/internal/codegen/ComponentHjarProcessingStep.java
@@ -41,7 +41,6 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import dagger.BindsInstance;
-import dagger.internal.codegen.ComponentDescriptor.Factory;
 import dagger.internal.codegen.ComponentValidator.ComponentValidationReport;
 import dagger.producers.internal.CancellationListener;
 import java.lang.annotation.Annotation;
@@ -77,7 +76,7 @@ final class ComponentHjarProcessingStep extends TypeCheckingProcessingStep<TypeE
   private final Filer filer;
   private final Messager messager;
   private final ComponentValidator componentValidator;
-  private final ComponentDescriptor.Factory componentDescriptorFactory;
+  private final ComponentDescriptorFactory componentDescriptorFactory;
 
   @Inject
   ComponentHjarProcessingStep(
@@ -87,7 +86,7 @@ final class ComponentHjarProcessingStep extends TypeCheckingProcessingStep<TypeE
       Filer filer,
       Messager messager,
       ComponentValidator componentValidator,
-      Factory componentDescriptorFactory) {
+      ComponentDescriptorFactory componentDescriptorFactory) {
     super(MoreElements::asType);
     this.sourceVersion = sourceVersion;
     this.elements = elements;

--- a/java/dagger/internal/codegen/ComponentProcessingStep.java
+++ b/java/dagger/internal/codegen/ComponentProcessingStep.java
@@ -49,7 +49,7 @@ final class ComponentProcessingStep extends TypeCheckingProcessingStep<TypeEleme
   private final ComponentValidator componentValidator;
   private final ComponentCreatorValidator creatorValidator;
   private final ComponentDescriptorValidator componentDescriptorValidator;
-  private final ComponentDescriptor.Factory componentDescriptorFactory;
+  private final ComponentDescriptorFactory componentDescriptorFactory;
   private final BindingGraphFactory bindingGraphFactory;
   private final SourceFileGenerator<BindingGraph> componentGenerator;
   private final BindingGraphConverter bindingGraphConverter;
@@ -67,7 +67,7 @@ final class ComponentProcessingStep extends TypeCheckingProcessingStep<TypeEleme
       ComponentValidator componentValidator,
       ComponentCreatorValidator creatorValidator,
       ComponentDescriptorValidator componentDescriptorValidator,
-      ComponentDescriptor.Factory componentDescriptorFactory,
+      ComponentDescriptorFactory componentDescriptorFactory,
       BindingGraphFactory bindingGraphFactory,
       SourceFileGenerator<BindingGraph> componentGenerator,
       BindingGraphConverter bindingGraphConverter,

--- a/java/dagger/internal/codegen/DaggerElements.java
+++ b/java/dagger/internal/codegen/DaggerElements.java
@@ -30,7 +30,6 @@ import static javax.lang.model.element.Modifier.ABSTRACT;
 
 import com.google.auto.common.MoreElements;
 import com.google.auto.common.MoreTypes;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -69,7 +68,6 @@ final class DaggerElements implements Elements {
   private final Elements elements;
   private final Types types;
 
-  @VisibleForTesting
   DaggerElements(Elements elements, Types types) {
     this.elements = checkNotNull(elements);
     this.types = checkNotNull(types);

--- a/java/dagger/internal/codegen/DaggerKythePlugin.java
+++ b/java/dagger/internal/codegen/DaggerKythePlugin.java
@@ -53,7 +53,7 @@ public class DaggerKythePlugin extends Plugin.Scanner<Void, Void> {
   // TODO(ronshapiro): use flogger
   private static final Logger logger = Logger.getLogger(DaggerKythePlugin.class.getCanonicalName());
   private FactEmitter emitter;
-  @Inject ComponentDescriptor.Factory componentDescriptorFactory;
+  @Inject ComponentDescriptorFactory componentDescriptorFactory;
   @Inject BindingGraphFactory bindingGraphFactory;
 
   @Override

--- a/java/dagger/internal/codegen/JavacPluginModule.java
+++ b/java/dagger/internal/codegen/JavacPluginModule.java
@@ -34,7 +34,7 @@ import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 
 /**
- * A module that provides a {@link BindingGraphFactory} and {@link ComponentDescriptor.Factory} for
+ * A module that provides a {@link BindingGraphFactory} and {@link ComponentDescriptorFactory} for
  * use in {@code javac} plugins. Requires a binding for the {@code javac} {@link Context}.
  */
 @Module(includes = InjectBindingRegistryModule.class)

--- a/java/dagger/internal/codegen/MembersInjectionBinding.java
+++ b/java/dagger/internal/codegen/MembersInjectionBinding.java
@@ -80,6 +80,11 @@ abstract class MembersInjectionBinding extends Binding {
                 injectionSite.element().getEnclosingElement().equals(membersInjectedType()));
   }
 
+  @Override
+  boolean requiresModuleInstance() {
+    return false;
+  }
+
   @AutoValue
   abstract static class InjectionSite {
     enum Kind {

--- a/java/dagger/internal/codegen/ModuleValidator.java
+++ b/java/dagger/internal/codegen/ModuleValidator.java
@@ -105,7 +105,7 @@ final class ModuleValidator {
   private final DaggerElements elements;
   private final AnyBindingMethodValidator anyBindingMethodValidator;
   private final MethodSignatureFormatter methodSignatureFormatter;
-  private final ComponentDescriptor.Factory componentDescriptorFactory;
+  private final ComponentDescriptorFactory componentDescriptorFactory;
   private final BindingGraphFactory bindingGraphFactory;
   private final BindingGraphConverter bindingGraphConverter;
   private final BindingGraphValidator bindingGraphValidator;
@@ -119,7 +119,7 @@ final class ModuleValidator {
       DaggerElements elements,
       AnyBindingMethodValidator anyBindingMethodValidator,
       MethodSignatureFormatter methodSignatureFormatter,
-      ComponentDescriptor.Factory componentDescriptorFactory,
+      ComponentDescriptorFactory componentDescriptorFactory,
       BindingGraphFactory bindingGraphFactory,
       BindingGraphConverter bindingGraphConverter,
       @ModuleValidation BindingGraphValidator bindingGraphValidator,

--- a/java/dagger/internal/codegen/ProductionBinding.java
+++ b/java/dagger/internal/codegen/ProductionBinding.java
@@ -20,6 +20,7 @@ import static dagger.internal.codegen.DaggerStreams.toImmutableSet;
 import static dagger.internal.codegen.DaggerTypes.isFutureType;
 
 import com.google.auto.value.AutoValue;
+import com.google.auto.value.extension.memoized.Memoized;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -97,6 +98,14 @@ abstract class ProductionBinding extends ContributionBinding {
    * production bindings may not.
    */
   abstract Optional<DependencyRequest> monitorRequest();
+
+  // Profiling determined that this method is called enough times that memoizing it had a measurable
+  // performance improvement for large components.
+  @Memoized
+  @Override
+  boolean requiresModuleInstance() {
+    return super.requiresModuleInstance();
+  }
 
   static Builder builder() {
     return new AutoValue_ProductionBinding.Builder()

--- a/java/dagger/internal/codegen/ProvisionBinding.java
+++ b/java/dagger/internal/codegen/ProvisionBinding.java
@@ -97,6 +97,14 @@ abstract class ProvisionBinding extends ContributionBinding {
         && compilerOptions.doCheckForNulls();
   }
 
+  // Profiling determined that this method is called enough times that memoizing it had a measurable
+  // performance improvement for large components.
+  @Memoized
+  @Override
+  boolean requiresModuleInstance() {
+    return super.requiresModuleInstance();
+  }
+
   @AutoValue.Builder
   @CanIgnoreReturnValue
   abstract static class Builder extends ContributionBinding.Builder<ProvisionBinding, Builder> {

--- a/java/dagger/internal/codegen/ResolvedBindings.java
+++ b/java/dagger/internal/codegen/ResolvedBindings.java
@@ -131,7 +131,8 @@ abstract class ResolvedBindings implements HasContributionType {
    * All contribution bindings, regardless of owning component. Empty if this is a members-injection
    * binding.
    */
-  final ImmutableSet<ContributionBinding> contributionBindings() {
+  @Memoized
+  ImmutableSet<ContributionBinding> contributionBindings() {
     return ImmutableSet.copyOf(allContributionBindings().values());
   }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Extract ComponentDescriptor.Factory to its own file.

cb2c29bb6889b9c51a464a09d5b6450106254f4c

-------

<p> Remove @VisibleForTesting from DaggerElements's constructor since it's used from JavacPluginModule.

38b8d0861676fed99b8b4f402ad8c32b3fb4b4a2

-------

<p> Optimize to BindingGraph.componentRequirements() by passing a Stream directly instead of materializing to an intermediate ImmutableSet<ContributionBinding> that is just used to get a new stream.

In and of itself, passing the Stream directly is actually more expensive as there can be a number of duplicates, so this CL also memoizes some the accessors of properties that are called during stream processing so that this can become faster overall.

For a large internal component with AOT turned on, this saves 1.6s/build, or 3.4% of their Dagger processing time.

RELNOTES=Build performance improvements for large components.

738ab65b950464463487cd8e07e1d10e0d461fca