### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/DelegateDeclaration.java
+++ b/java/dagger/internal/codegen/DelegateDeclaration.java
@@ -23,6 +23,7 @@ import static dagger.internal.codegen.MoreAnnotationMirrors.wrapOptionalInEquiva
 import com.google.auto.common.MoreElements;
 import com.google.auto.common.MoreTypes;
 import com.google.auto.value.AutoValue;
+import com.google.auto.value.extension.memoized.Memoized;
 import com.google.common.base.Equivalence;
 import com.google.common.collect.Iterables;
 import dagger.Binds;
@@ -44,6 +45,13 @@ abstract class DelegateDeclaration extends BindingDeclaration implements HasCont
   abstract DependencyRequest delegateRequest();
 
   abstract Optional<Equivalence.Wrapper<AnnotationMirror>> wrappedMapKey();
+
+  @Memoized
+  @Override
+  public abstract int hashCode();
+
+  @Override
+  public abstract boolean equals(Object obj);
 
   static final class Factory {
     private final DaggerTypes types;

--- a/java/dagger/internal/codegen/MembersInjectionBinding.java
+++ b/java/dagger/internal/codegen/MembersInjectionBinding.java
@@ -85,6 +85,14 @@ abstract class MembersInjectionBinding extends Binding {
     return false;
   }
 
+  @Memoized
+  @Override
+  public abstract int hashCode();
+
+  // TODO(ronshapiro,dpb): simplify the equality semantics
+  @Override
+  public abstract boolean equals(Object obj);
+
   @AutoValue
   abstract static class InjectionSite {
     enum Kind {

--- a/java/dagger/internal/codegen/MultibindingDeclaration.java
+++ b/java/dagger/internal/codegen/MultibindingDeclaration.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.auto.common.MoreTypes;
 import com.google.auto.value.AutoValue;
+import com.google.auto.value.extension.memoized.Memoized;
 import dagger.internal.codegen.ContributionType.HasContributionType;
 import dagger.model.Key;
 import dagger.multibindings.Multibinds;
@@ -55,6 +56,13 @@ abstract class MultibindingDeclaration extends BindingDeclaration implements Has
    */
   @Override
   public abstract ContributionType contributionType();
+
+  @Memoized
+  @Override
+  public abstract int hashCode();
+
+  @Override
+  public abstract boolean equals(Object obj);
 
   /**
    * A factory for {@link MultibindingDeclaration}s.

--- a/java/dagger/internal/codegen/OptionalBindingDeclaration.java
+++ b/java/dagger/internal/codegen/OptionalBindingDeclaration.java
@@ -20,6 +20,7 @@ import static com.google.auto.common.MoreElements.isAnnotationPresent;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.auto.value.AutoValue;
+import com.google.auto.value.extension.memoized.Memoized;
 import dagger.BindsOptionalOf;
 import dagger.model.Key;
 import java.util.Optional;
@@ -40,6 +41,13 @@ abstract class OptionalBindingDeclaration extends BindingDeclaration {
    */
   @Override
   public abstract Key key();
+
+  @Memoized
+  @Override
+  public abstract int hashCode();
+
+  @Override
+  public abstract boolean equals(Object obj);
 
   static class Factory {
     private final KeyFactory keyFactory;

--- a/java/dagger/internal/codegen/ProductionBinding.java
+++ b/java/dagger/internal/codegen/ProductionBinding.java
@@ -113,6 +113,14 @@ abstract class ProductionBinding extends ContributionBinding {
         .thrownTypes(ImmutableList.<TypeMirror>of());
   }
 
+  @Memoized
+  @Override
+  public abstract int hashCode();
+
+  // TODO(ronshapiro,dpb): simplify the equality semantics
+  @Override
+  public abstract boolean equals(Object obj);
+
   @AutoValue.Builder
   @CanIgnoreReturnValue
   abstract static class Builder extends ContributionBinding.Builder<ProductionBinding, Builder> {

--- a/java/dagger/internal/codegen/ProvisionBinding.java
+++ b/java/dagger/internal/codegen/ProvisionBinding.java
@@ -105,6 +105,14 @@ abstract class ProvisionBinding extends ContributionBinding {
     return super.requiresModuleInstance();
   }
 
+  @Memoized
+  @Override
+  public abstract int hashCode();
+
+  // TODO(ronshapiro,dpb): simplify the equality semantics
+  @Override
+  public abstract boolean equals(Object obj);
+
   @AutoValue.Builder
   @CanIgnoreReturnValue
   abstract static class Builder extends ContributionBinding.Builder<ProvisionBinding, Builder> {

--- a/java/dagger/internal/codegen/SubcomponentDeclaration.java
+++ b/java/dagger/internal/codegen/SubcomponentDeclaration.java
@@ -20,6 +20,7 @@ import static com.google.auto.common.AnnotationMirrors.getAnnotationElementAndVa
 import static dagger.internal.codegen.ConfigurationAnnotations.getSubcomponentCreator;
 
 import com.google.auto.value.AutoValue;
+import com.google.auto.value.extension.memoized.Memoized;
 import com.google.common.collect.ImmutableSet;
 import dagger.model.Key;
 import java.util.Optional;
@@ -48,6 +49,13 @@ abstract class SubcomponentDeclaration extends BindingDeclaration {
 
   /** The module annotation. */
   abstract ModuleAnnotation moduleAnnotation();
+
+  @Memoized
+  @Override
+  public abstract int hashCode();
+
+  @Override
+  public abstract boolean equals(Object obj);
 
   static class Factory {
     private final KeyFactory keyFactory;

--- a/javatests/dagger/internal/codegen/AheadOfTimeSubcomponentsMultibindingsTest.java
+++ b/javatests/dagger/internal/codegen/AheadOfTimeSubcomponentsMultibindingsTest.java
@@ -39,7 +39,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void setMultibindings_contributionsInLeaf() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "InLeaf");
+    createSimplePackagePrivateClasses(filesToCompile, "InLeaf");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -99,7 +99,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void setMultibindings_contributionsInAncestorOnly() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "InAncestor");
+    createSimplePackagePrivateClasses(filesToCompile, "InAncestor");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -196,7 +196,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void setMultibindings_contributionsInLeafAndAncestor() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "InEachSubcomponent");
+    createSimplePackagePrivateClasses(filesToCompile, "InEachSubcomponent");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -326,7 +326,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void setMultibindings_contributionsInLeafAndGrandAncestor() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "InLeafAndGrandAncestor");
+    createSimplePackagePrivateClasses(filesToCompile, "InLeafAndGrandAncestor");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -493,7 +493,8 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void setMultibindings_nonComponentMethodDependency() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "InAllSubcomponents", "RequresInAllSubcomponentsSet");
+    createSimplePackagePrivateClasses(
+        filesToCompile, "InAllSubcomponents", "RequresInAllSubcomponentsSet");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -627,7 +628,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void setMultibindings_newSubclass() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "InAncestor", "RequiresInAncestorSet");
+    createSimplePackagePrivateClasses(filesToCompile, "InAncestor", "RequiresInAncestorSet");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -737,7 +738,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void setMultibinding_requestedAsInstanceInLeaf_requestedAsFrameworkInstanceFromAncestor() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(
+    createSimplePackagePrivateClasses(
         filesToCompile, "Multibound", "MissingInLeaf_WillDependOnFrameworkInstance");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
@@ -883,7 +884,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void setMultibindings_contributionsInLeafAndAncestor_frameworkInstances() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "InEachSubcomponent");
+    createSimplePackagePrivateClasses(filesToCompile, "InEachSubcomponent");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -1047,7 +1048,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void mapMultibindings_contributionsInLeaf() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "InLeaf");
+    createSimplePackagePrivateClasses(filesToCompile, "InLeaf");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -1111,7 +1112,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void mapMultibindings_contributionsInAncestorOnly() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "InAncestor");
+    createSimplePackagePrivateClasses(filesToCompile, "InAncestor");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -1208,7 +1209,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void mapMultibindings_contributionsInLeafAndAncestor() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "InEachSubcomponent");
+    createSimplePackagePrivateClasses(filesToCompile, "InEachSubcomponent");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -1335,7 +1336,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void mapMultibindings_contributionsInLeafAndAncestor_frameworkInstance() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "InEachSubcomponent");
+    createSimplePackagePrivateClasses(filesToCompile, "InEachSubcomponent");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -1499,7 +1500,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void mapMultibindings_contributionsInLeafAndGrandAncestor() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "InLeafAndGrandAncestor");
+    createSimplePackagePrivateClasses(filesToCompile, "InLeafAndGrandAncestor");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -1667,7 +1668,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void mapMultibindings_contributionsInLeafAndAncestorWithoutGuava() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "InEachSubcomponent");
+    createSimplePackagePrivateClasses(filesToCompile, "InEachSubcomponent");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -1794,7 +1795,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void mapMultibinding_requestedAsInstanceInLeaf_requestedAsFrameworkInstanceFromAncestor() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(
+    createSimplePackagePrivateClasses(
         filesToCompile, "Multibound", "MissingInLeaf_WillDependOnFrameworkInstance");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
@@ -1942,7 +1943,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void emptyMultibinds_set() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "Multibound");
+    createSimplePackagePrivateClasses(filesToCompile, "Multibound");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.LeafModule",
@@ -2056,7 +2057,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void emptyMultibinds_set_frameworkInstance() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "Multibound");
+    createSimplePackagePrivateClasses(filesToCompile, "Multibound");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.LeafModule",
@@ -2189,7 +2190,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void emptyMultibinds_map() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "Multibound");
+    createSimplePackagePrivateClasses(filesToCompile, "Multibound");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.LeafModule",
@@ -2305,7 +2306,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void emptyMultibinds_map_frameworkInstance() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "Multibound");
+    createSimplePackagePrivateClasses(filesToCompile, "Multibound");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.LeafModule",
@@ -2503,7 +2504,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   @Test
   public void multibindingsAndFastInit() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "PackagePrivate");
+    createSimplePackagePrivateClasses(filesToCompile, "PackagePrivate");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.MultibindingModule",
@@ -2629,7 +2630,7 @@ public final class AheadOfTimeSubcomponentsMultibindingsTest {
   }
 
   // TODO(ronshapiro): remove copies from AheadOfTimeSubcomponents*Test classes
-  private void createAncillaryClasses(
+  private void createSimplePackagePrivateClasses(
       ImmutableList.Builder<JavaFileObject> filesBuilder, String... ancillaryClasses) {
     for (String className : ancillaryClasses) {
       filesBuilder.add(

--- a/javatests/dagger/internal/codegen/AheadOfTimeSubcomponentsTest.java
+++ b/javatests/dagger/internal/codegen/AheadOfTimeSubcomponentsTest.java
@@ -42,7 +42,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void missingBindings_fromComponentMethod() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "MissingInLeaf");
+    createSimplePackagePrivateClasses(filesToCompile, "MissingInLeaf");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -128,7 +128,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void missingBindings_dependsOnBindingWithMatchingComponentMethod() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "MissingInLeaf");
+    createSimplePackagePrivateClasses(filesToCompile, "MissingInLeaf");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -178,7 +178,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void missingBindings_dependsOnMissingBinding() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "MissingInLeaf");
+    createSimplePackagePrivateClasses(filesToCompile, "MissingInLeaf");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -280,7 +280,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void missingBindings_satisfiedInGreatAncestor() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "MissingInLeaf");
+    createSimplePackagePrivateClasses(filesToCompile, "MissingInLeaf");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -987,7 +987,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void optionalBindings_boundAndSatisfiedInSameSubcomponent() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "SatisfiedInSub");
+    createSimplePackagePrivateClasses(filesToCompile, "SatisfiedInSub");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Sub",
@@ -1055,7 +1055,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void optionalBindings_satisfiedInAncestor() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "SatisfiedInAncestor");
+    createSimplePackagePrivateClasses(filesToCompile, "SatisfiedInAncestor");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -1164,7 +1164,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void optionalBindings_satisfiedInGrandAncestor() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "SatisfiedInGrandAncestor");
+    createSimplePackagePrivateClasses(filesToCompile, "SatisfiedInGrandAncestor");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -1312,7 +1312,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void optionalBindings_nonComponentMethodDependencySatisfiedInAncestor() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(
+    createSimplePackagePrivateClasses(
         filesToCompile, "SatisfiedInAncestor", "RequiresOptionalSatisfiedInAncestor");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
@@ -1436,7 +1436,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void optionalBindings_boundInAncestorAndSatisfiedInGrandAncestor() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "SatisfiedInGrandAncestor");
+    createSimplePackagePrivateClasses(filesToCompile, "SatisfiedInGrandAncestor");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -1951,7 +1951,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void provisionOverInjection_prunedIndirectDependency() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "PrunedDependency");
+    createSimplePackagePrivateClasses(filesToCompile, "PrunedDependency");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.InjectsPrunedDependency",
@@ -2429,7 +2429,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void productionSubcomponentAndModifiableFrameworkInstance() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "Response", "ResponseDependency");
+    createSimplePackagePrivateClasses(filesToCompile, "Response", "ResponseDependency");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -2742,7 +2742,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void lazyOfModifiableBinding() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "MissingInLeaf");
+    createSimplePackagePrivateClasses(filesToCompile, "MissingInLeaf");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Leaf",
@@ -2848,7 +2848,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void missingBindingAccessInLeafAndAncestor() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(
+    createSimplePackagePrivateClasses(
         filesToCompile, "Missing", "DependsOnMissing", "ProvidedInAncestor_InducesSetBinding");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
@@ -3061,7 +3061,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void subcomponentBuilders() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "InducesDependenciesOnBuilderFields");
+    createSimplePackagePrivateClasses(filesToCompile, "InducesDependenciesOnBuilderFields");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.LeafModule",
@@ -3357,7 +3357,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void subcomponentBuilders_moduleWithUnusedInstanceBindings() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "Used", "Unused");
+    createSimplePackagePrivateClasses(filesToCompile, "Used", "Unused");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.ModuleWithUsedBinding",
@@ -3706,7 +3706,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void bindsWithMissingDependency() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "MissingInLeaf");
+    createSimplePackagePrivateClasses(filesToCompile, "MissingInLeaf");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.LeafModule",
@@ -3824,7 +3824,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void bindsWithMissingDependency_pruned() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "MissingInLeaf");
+    createSimplePackagePrivateClasses(filesToCompile, "MissingInLeaf");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.LeafModule",
@@ -3964,7 +3964,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void modifiedProducerFromProvider() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "DependsOnModifiedProducerFromProvider");
+    createSimplePackagePrivateClasses(filesToCompile, "DependsOnModifiedProducerFromProvider");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.LeafModule",
@@ -4379,7 +4379,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void subcomponentInducedFromAncestor() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "Inducer");
+    createSimplePackagePrivateClasses(filesToCompile, "Inducer");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.InducedSubcomponent",
@@ -4523,7 +4523,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void rootScopedAtInjectConstructor_effectivelyMissingInSubcomponent() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "ProvidesMethodRootScoped");
+    createSimplePackagePrivateClasses(filesToCompile, "ProvidesMethodRootScoped");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.RootScope",
@@ -4612,7 +4612,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void prunedModuleWithInstanceState() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "Pruned");
+    createSimplePackagePrivateClasses(filesToCompile, "Pruned");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.Modified",
@@ -5218,7 +5218,7 @@ public final class AheadOfTimeSubcomponentsTest {
   @Test
   public void castModifiableMethodAccessedInFinalImplementation() {
     ImmutableList.Builder<JavaFileObject> filesToCompile = ImmutableList.builder();
-    createAncillaryClasses(filesToCompile, "PackagePrivate");
+    createSimplePackagePrivateClasses(filesToCompile, "PackagePrivate");
     filesToCompile.add(
         JavaFileObjects.forSourceLines(
             "test.PublicBaseType",
@@ -5404,7 +5404,7 @@ public final class AheadOfTimeSubcomponentsTest {
   }
 
   // TODO(ronshapiro): remove copies from AheadOfTimeSubcomponents*Test classes
-  private void createAncillaryClasses(
+  private void createSimplePackagePrivateClasses(
       ImmutableList.Builder<JavaFileObject> filesBuilder, String... ancillaryClasses) {
     for (String className : ancillaryClasses) {
       filesBuilder.add(


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Use a loop instead of a Stream to avoid calculating the size of an object for which we only need to check the existence of a single match

Profile of a large internal component with AOT off shows a savings of ~850ms.

RELNOTES=Build performance improvements for large components

56d70ae3907fe0f2d2ee06df991ca268c814f5e8

-------

<p> Rename createAncillaryClasses to make it clear that the classes are package private

4b7636f1ed64ce223cf698a901a6ac1f98062e23

-------

<p> Memoize the hashCode of BindingDeclaration implementations

This has a pretty big win: at least 11% for a large internal component (5s/build), but looking at the profile diffbase, it looks like certain areas got even faster, and some areas that remain unchanged could have been slower in the profiles that were run. Either way, it's a big win for little cost.

RELNOTES=Build performance improvements for large components

854a1c3d38a6ef99d9046324658cbe4b07c5c5a7