### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/BindsTypeChecker.java
+++ b/java/dagger/internal/codegen/BindsTypeChecker.java
@@ -17,7 +17,6 @@
 package dagger.internal.codegen;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static javax.lang.model.util.ElementFilter.methodsIn;
 
 import com.google.auto.common.MoreElements;
 import com.google.auto.common.MoreTypes;
@@ -77,7 +76,11 @@ final class BindsTypeChecker {
   private ImmutableList<TypeMirror> methodParameterTypes(DeclaredType type, String methodName) {
     ImmutableList.Builder<ExecutableElement> methodsForName = ImmutableList.builder();
     for (ExecutableElement method :
-        methodsIn(MoreElements.asType(type.asElement()).getEnclosedElements())) {
+        // type.asElement().getEnclosedElements() is not used because some non-standard JDKs (e.g.
+        // J2CL) don't redefine Set.add() (whose only purpose of being redefined in the standard JDK
+        // is documentation, and J2CL's implementation doesn't declare docs for JDK types).
+        // MoreElements.getLocalAndInheritedMethods ensures that the method will always be present.
+        MoreElements.getLocalAndInheritedMethods(MoreTypes.asTypeElement(type), types, elements)) {
       if (method.getSimpleName().contentEquals(methodName)) {
         methodsForName.add(method);
       }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make BindsTypeChecker more resilient on the way Java Standard Library APIs are declared.

For example, Set#add inherited from Collection#add so doesn't need to be redeclared but current logic will fail if it is not. The fix makes sure the inherited methods are correctly accounted for.

7f221e2e8ed5c9aa834252767b6ca6c5d50fa56e