### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/BindingGraph.java
+++ b/java/dagger/internal/codegen/BindingGraph.java
@@ -25,6 +25,7 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimaps;
 import com.google.common.graph.Traverser;
@@ -73,12 +74,12 @@ abstract class BindingGraph {
         : contributionBindings().get(request.key());
   }
 
-  @Memoized
-  ImmutableSet<ResolvedBindings> resolvedBindings() {
-    return ImmutableSet.<ResolvedBindings>builder()
-        .addAll(membersInjectionBindings().values())
-        .addAll(contributionBindings().values())
-        .build();
+  final Iterable<ResolvedBindings> resolvedBindings() {
+    // Don't return an immutable collection - this is only ever used for looping over all bindings
+    // in the graph. Copying is wasteful, especially if is a hashing collection, since the values
+    // should all, by definition, be distinct.
+    // TODO(dpb): consider inlining this to callers and removing this.
+    return Iterables.concat(membersInjectionBindings().values(), contributionBindings().values());
   }
 
   abstract ImmutableList<BindingGraph> subgraphs();

--- a/java/dagger/internal/codegen/BindingGraphConverter.java
+++ b/java/dagger/internal/codegen/BindingGraphConverter.java
@@ -212,16 +212,10 @@ final class BindingGraphConverter {
       return BindingNode.create(
           pathFromRootToAncestor(owningComponent),
           binding,
-          associatedDeclaringElements(resolvedBindings),
-          () -> bindingDeclarationFormatter.format(binding));
-    }
-
-    private Iterable<BindingDeclaration> associatedDeclaringElements(
-        ResolvedBindings resolvedBindings) {
-      return Iterables.concat(
           resolvedBindings.multibindingDeclarations(),
           resolvedBindings.optionalBindingDeclarations(),
-          resolvedBindings.subcomponentDeclarations());
+          resolvedBindings.subcomponentDeclarations(),
+          bindingDeclarationFormatter);
     }
 
     private MissingBinding missingBindingNode(ResolvedBindings dependencies) {

--- a/java/dagger/internal/codegen/BindingGraphConverter.java
+++ b/java/dagger/internal/codegen/BindingGraphConverter.java
@@ -98,9 +98,7 @@ final class BindingGraphConverter {
     protected void visitComponent(BindingGraph graph) {
       ComponentNode grandparentComponent = parentComponent;
       parentComponent = currentComponent;
-      currentComponent =
-          ComponentNodeImpl.create(
-              componentTreePath().toComponentPath(), graph.componentDescriptor());
+      currentComponent = ComponentNodeImpl.create(componentPath(), graph.componentDescriptor());
 
       network.addNode(currentComponent);
 
@@ -183,9 +181,7 @@ final class BindingGraphConverter {
 
     private ResolvedBindings resolvedDependencies(
         Node source, DependencyRequest dependencyRequest) {
-      return componentTreePath()
-          .pathFromRootToAncestor(source.componentPath().currentComponent())
-          .currentGraph()
+      return graphForAncestor(source.componentPath().currentComponent())
           .resolvedBindings(bindingRequest(dependencyRequest));
     }
 
@@ -214,7 +210,7 @@ final class BindingGraphConverter {
     private BindingNode bindingNode(
         ResolvedBindings resolvedBindings, Binding binding, TypeElement owningComponent) {
       return BindingNode.create(
-          componentTreePath().pathFromRootToAncestor(owningComponent).toComponentPath(),
+          pathFromRootToAncestor(owningComponent),
           binding,
           associatedDeclaringElements(resolvedBindings),
           () -> bindingDeclarationFormatter.format(binding));
@@ -230,10 +226,7 @@ final class BindingGraphConverter {
 
     private MissingBinding missingBindingNode(ResolvedBindings dependencies) {
       return BindingGraphProxies.missingBindingNode(
-          componentTreePath()
-              .pathFromRootToAncestor(dependencies.resolvingComponent())
-              .toComponentPath(),
-          dependencies.key());
+          pathFromRootToAncestor(dependencies.resolvingComponent()), dependencies.key());
     }
 
     private ComponentNode subcomponentNode(TypeMirror subcomponentBuilderType, BindingGraph graph) {
@@ -241,8 +234,7 @@ final class BindingGraphConverter {
       ComponentDescriptor subcomponent =
           graph.componentDescriptor().getChildComponentWithBuilderType(subcomponentBuilderElement);
       return ComponentNodeImpl.create(
-          componentTreePath().childPath(subcomponent.typeElement()).toComponentPath(),
-          subcomponent);
+          componentPath().childPath(subcomponent.typeElement()), subcomponent);
     }
 
     private ImmutableSet<TypeElement> subcomponentDeclaringModules(

--- a/java/dagger/internal/codegen/ComponentTreeTraverser.java
+++ b/java/dagger/internal/codegen/ComponentTreeTraverser.java
@@ -17,23 +17,16 @@
 package dagger.internal.codegen;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import dagger.internal.codegen.ComponentDescriptor.ComponentMethodDescriptor;
 import dagger.model.ComponentPath;
 import dagger.model.DependencyRequest;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.function.Predicate;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 
@@ -146,126 +139,41 @@ public class ComponentTreeTraverser {
    * Returns an immutable snapshot of the path from the root component to the currently visited
    * component.
    */
-  protected final ComponentTreePath componentTreePath() {
-    return ComponentTreePath.create(bindingGraphPath);
+  protected final ComponentPath componentPath() {
+    ImmutableList.Builder<TypeElement> path = ImmutableList.builder();
+    for (BindingGraph graph : bindingGraphPath) {
+      path.add(graph.componentTypeElement());
+    }
+    return ComponentPath.create(path.build());
   }
 
   /**
-   * A path from the root component to a component within the component tree during a {@linkplain
-   * ComponentTreeTraverser traversal}.
+   * Returns the subpath from the root component to the matching {@code ancestor} of the current
+   * component.
    */
-  @AutoValue
-  public abstract static class ComponentTreePath {
-
-    private static ComponentTreePath create(Iterable<BindingGraph> path) {
-      return new AutoValue_ComponentTreeTraverser_ComponentTreePath(ImmutableList.copyOf(path));
-    }
-
-    /**
-     * Returns the binding graphs in the path, starting from the {@linkplain #rootGraph() root
-     * graph} and ending with the {@linkplain #currentGraph() current graph}.
-     */
-    public abstract ImmutableList<BindingGraph> graphsInPath();
-
-    /** Returns the binding graph for the component at the end of the path. */
-    public BindingGraph currentGraph() {
-      return Iterables.getLast(graphsInPath());
-    }
-
-    /** Returns the type of the component at the end of the path. */
-    public TypeElement currentComponent() {
-      return currentGraph().componentTypeElement();
-    }
-
-    /**
-     * Returns the binding graph for the parent of the {@linkplain #currentGraph() current
-     * component}.
-     *
-     * @throws IllegalStateException if the current graph is the {@linkplain #atRoot() root graph}
-     */
-    public BindingGraph parentGraph() {
-      checkState(!atRoot());
-      return graphsInPath().reverse().get(1);
-    }
-
-    /** Returns the binding graph for the root component. */
-    public BindingGraph rootGraph() {
-      return graphsInPath().get(0);
-    }
-
-    /**
-     * Returns {@code true} if the {@linkplain #currentGraph() current graph} is the {@linkplain
-     * #rootGraph() root graph}.
-     */
-    public boolean atRoot() {
-      return graphsInPath().size() == 1;
-    }
-
-    /** Returns the rootmost binding graph in the component path among the given components. */
-    public BindingGraph rootmostGraph(Iterable<ComponentDescriptor> components) {
-      ImmutableSet<ComponentDescriptor> set = ImmutableSet.copyOf(components);
-      return rootmostGraph(graph -> set.contains(graph.componentDescriptor()));
-    }
-
-    /** Returns the binding graph within this path that represents the given component. */
-    public BindingGraph graphForComponent(ComponentDescriptor component) {
-      checkNotNull(component);
-      return rootmostGraph(graph -> graph.componentDescriptor().equals(component));
-    }
-
-    /**
-     * Returns the subpath from the root component to the matching {@code ancestor} of the current
-     * component.
-     */
-    ComponentTreePath pathFromRootToAncestor(TypeElement ancestor) {
-      ImmutableList.Builder<BindingGraph> path = ImmutableList.builder();
-      for (BindingGraph graph : graphsInPath()) {
-        path.add(graph);
-        if (graph.componentTypeElement().equals(ancestor)) {
-          return create(path.build());
-        }
+  protected final ComponentPath pathFromRootToAncestor(TypeElement ancestor) {
+    ImmutableList.Builder<TypeElement> path = ImmutableList.builder();
+    for (TypeElement component : componentPath().components()) {
+      path.add(component);
+      if (component.equals(ancestor)) {
+        return ComponentPath.create(path.build());
       }
-      throw new IllegalArgumentException(
-          String.format("%s is not in the current path: %s", ancestor.getQualifiedName(), this));
     }
+    throw new IllegalArgumentException(
+        String.format("%s is not in the current path: %s", ancestor.getQualifiedName(), this));
+  }
 
-    /**
-     * Returns the path from the root component to the child of the current component for a {@code
-     * subcomponent}.
-     *
-     * @throws IllegalArgumentException if {@code subcomponent} is not a child of the current
-     *     component
-     */
-    ComponentTreePath childPath(TypeElement subcomponent) {
-      for (BindingGraph child : currentGraph().subgraphs()) {
-        if (child.componentTypeElement().equals(subcomponent)) {
-          return create(
-              ImmutableList.<BindingGraph>builder().addAll(graphsInPath()).add(child).build());
-        }
+  /**
+   * Returns the BindingGraph for {@code ancestor}, where {@code ancestor} is in the component path
+   * of the current traversal.
+   */
+  protected final BindingGraph graphForAncestor(TypeElement ancestor) {
+    for (BindingGraph graph : bindingGraphPath) {
+      if (graph.componentTypeElement().equals(ancestor)) {
+        return graph;
       }
-      throw new IllegalArgumentException(
-          String.format(
-              "%s is not a child of %s",
-              subcomponent.getQualifiedName(),
-              currentGraph().componentTypeElement().getQualifiedName()));
     }
-
-    private BindingGraph rootmostGraph(Predicate<? super BindingGraph> predicate) {
-      return graphsInPath().stream().filter(predicate).findFirst().get();
-    }
-
-    /** Converts this {@link ComponentTreePath} into a {@link ComponentPath}. */
-    ComponentPath toComponentPath() {
-      return ComponentPath.create(
-          graphsInPath().stream().map(BindingGraph::componentTypeElement).collect(toList()));
-    }
-
-    @Override
-    public final String toString() {
-      return graphsInPath().stream()
-          .map(BindingGraph::componentTypeElement)
-          .map(TypeElement::getQualifiedName)
-          .collect(joining(" → "));
-    }
+    throw new IllegalArgumentException(
+        String.format("%s is not in the current path: %s", ancestor.getQualifiedName(), this));
   }
 }

--- a/java/dagger/model/ComponentPath.java
+++ b/java/dagger/model/ComponentPath.java
@@ -71,6 +71,11 @@ public abstract class ComponentPath {
     return create(components().subList(0, components().size() - 1));
   }
 
+  /** Returns the path from the root component to the {@code child} of the current component. */
+  public final ComponentPath childPath(TypeElement child) {
+    return create(ImmutableList.<TypeElement>builder().addAll(components()).add(child).build());
+  }
+
   /**
    * Returns {@code true} if the {@linkplain #currentComponent()} current component} is the
    * {@linkplain #rootComponent()} root component}.

--- a/java/dagger/model/ComponentPath.java
+++ b/java/dagger/model/ComponentPath.java
@@ -21,6 +21,7 @@ import static com.google.common.collect.Iterables.getLast;
 import static java.util.stream.Collectors.joining;
 
 import com.google.auto.value.AutoValue;
+import com.google.auto.value.extension.memoized.Memoized;
 import com.google.common.collect.ImmutableList;
 import javax.lang.model.element.TypeElement;
 
@@ -47,7 +48,8 @@ public abstract class ComponentPath {
   }
 
   /** Returns the component at the end of the path. */
-  public final TypeElement currentComponent() {
+  @Memoized
+  public TypeElement currentComponent() {
     return getLast(components());
   }
 
@@ -66,6 +68,7 @@ public abstract class ComponentPath {
    *
    * @throws IllegalStateException if the current graph is the {@linkplain #atRoot() root component}
    */
+  // TODO(ronshapiro): consider memoizing this
   public final ComponentPath parent() {
     checkState(!atRoot());
     return create(components().subList(0, components().size() - 1));
@@ -88,4 +91,11 @@ public abstract class ComponentPath {
   public final String toString() {
     return components().stream().map(TypeElement::getQualifiedName).collect(joining(" → "));
   }
+
+  @Memoized
+  @Override
+  public abstract int hashCode();
+
+  @Override
+  public abstract boolean equals(Object obj);
 }

--- a/javatests/dagger/internal/codegen/MissingBindingValidationTest.java
+++ b/javatests/dagger/internal/codegen/MissingBindingValidationTest.java
@@ -663,4 +663,118 @@ public class MissingBindingValidationTest {
         .onLineContaining("interface TestComponent");
     assertThat(compilation).hadErrorCount(1);
   }
+
+  @Test
+  public void tooManyRequests() {
+    JavaFileObject foo =
+        JavaFileObjects.forSourceLines(
+            "test.Foo",
+            "package test;",
+            "",
+            "import javax.inject.Inject;",
+            "",
+            "final class Foo {",
+            "  @Inject Foo(",
+            "      String one,",
+            "      String two,",
+            "      String three,",
+            "      String four,",
+            "      String five,",
+            "      String six,",
+            "      String seven,",
+            "      String eight,",
+            "      String nine,",
+            "      String ten,",
+            "      String eleven,",
+            "      String twelve,",
+            "      String thirteen) {",
+            "  }",
+            "}");
+    JavaFileObject component =
+        JavaFileObjects.forSourceLines(
+            "test.TestComponent",
+            "package test;",
+            "",
+            "import dagger.Component;",
+            "",
+            "@Component",
+            "interface TestComponent {",
+            "  String string();",
+            "  Foo foo();",
+            "}");
+
+    Compilation compilation = daggerCompiler().compile(foo, component);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
+            message(
+                "[Dagger/MissingBinding] java.lang.String cannot be provided without an @Inject "
+                    + "constructor or an @Provides-annotated method.",
+                "    java.lang.String is provided at",
+                "        test.TestComponent.string()",
+                "It is also requested at:",
+                "    test.Foo(one, …)",
+                "    test.Foo(…, two, …)",
+                "    test.Foo(…, three, …)",
+                "    test.Foo(…, four, …)",
+                "    test.Foo(…, five, …)",
+                "    test.Foo(…, six, …)",
+                "    test.Foo(…, seven, …)",
+                "    test.Foo(…, eight, …)",
+                "    test.Foo(…, nine, …)",
+                "    test.Foo(…, ten, …)",
+                "    and 3 others"))
+        .inFile(component)
+        .onLineContaining("interface TestComponent");
+  }
+
+  @Test
+  public void tooManyEntryPoints() {
+    JavaFileObject component =
+        JavaFileObjects.forSourceLines(
+            "test.TestComponent",
+            "package test;",
+            "",
+            "import dagger.Component;",
+            "",
+            "@Component",
+            "interface TestComponent {",
+            "  String string1();",
+            "  String string2();",
+            "  String string3();",
+            "  String string4();",
+            "  String string5();",
+            "  String string6();",
+            "  String string7();",
+            "  String string8();",
+            "  String string9();",
+            "  String string10();",
+            "  String string11();",
+            "  String string12();",
+            "}");
+
+    Compilation compilation = daggerCompiler().compile(component);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
+            message(
+                "[Dagger/MissingBinding] java.lang.String cannot be provided without an @Inject "
+                    + "constructor or an @Provides-annotated method.",
+                "    java.lang.String is provided at",
+                "        test.TestComponent.string1()",
+                "The following other entry points also depend on it:",
+                "    test.TestComponent.string2()",
+                "    test.TestComponent.string3()",
+                "    test.TestComponent.string4()",
+                "    test.TestComponent.string5()",
+                "    test.TestComponent.string6()",
+                "    test.TestComponent.string7()",
+                "    test.TestComponent.string8()",
+                "    test.TestComponent.string9()",
+                "    test.TestComponent.string10()",
+                "    test.TestComponent.string11()",
+                "    and 1 other"))
+        .inFile(component)
+        .onLineContaining("interface TestComponent");
+  }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove ComponentTreePath

This itself doesn't do much besides merge two classes that were pretty much the same (Component{,Tree}Path), but it should prepare another CL that will allow ComponentPath to be interned, which could have better performance wins.

5200b101a90f3f4483a72deb95e1fc38dc77c167

-------

<p> Return an Iterable from BindingGraph.resolvedBindings() instead of an ImmutableSet.

The values are only ever used to iterate, and hashing all of the items ImmutableSet is needlessly expensive.

This isn't a huge savings (~.25s/build for a large internal component, and ~.5s with AOT turned on), but it is nonetheless unnecessary.

cc4c13e9f6ddf794b1a576e31d1c9a1b51b2a540

-------

<p> Reduce the cost of creating BindingNodes:
  - Build BindingNode.associatedDeclarations lazily instead of eagerly. It's an unnecessary cost and is only ever used when reporting duplicate bindings
  - Return an Iterable<BindingDeclaration> for the associated declarations instead of an ImmutableSet. The values are only used for iteration, and additionally the 3 contributing sets each have different equality semantics, and thus will never be have any overlapping values. (I *think* that at most one of them should ever have any values, and thus we can check for which one is non-empty, but that seems like an unnecessary optimization, though it would allow us to continue to return an ImmutableSet)
  - Instead of a capturing lambda for the toStringFunction for every binding node, extract a constant that accepts a binding as its input.

Cost savings for a large internal component is .3s/build (.5s/build with AOT)

abe872703c872723a64c45cdaeb7d5cfd66897c3

-------

<p> Limit the number of requests and entry points reported explicitly for errors.

RELNOTES=Limit the number of requests and entry points reported explicitly for errors.

fff0b6ffe78155c77c3e2eadb7a5c5d3b5bf5285

-------

<p> Ensure only one ComponentPath instance exists for each logical ComponentPath (per dagger.model.BindingGraph)

This ensures that ComponentPaths used in BindingGraph.Nodes are all based on instance equality instead of checking their composing lists.

This has a decrease of almost 3s/build for a large internal component, or ~11% of Dagger processing time. With AOT turned on, it saves 6s/build, or 14% of Dagger processing time.

RELNOTES=Build performance improvements for large components

d6f73250c00a6dcae13e1ac93bd0a93ea4bba7b9