### PR TITLE
Moe Sync

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -18,4 +18,4 @@ DOCLINT_HTML_AND_SYNTAX = ["-Xdoclint:html,syntax"]
 
 DOCLINT_REFERENCES = ["-Xdoclint:reference"]
 
-SOURCE_7_TARGET_7 = ["-source 1.7 -target 1.7"]
+SOURCE_7_TARGET_7 = ["-source", "1.7", "-target", "1.7"]

--- a/java/dagger/Module.java
+++ b/java/dagger/Module.java
@@ -17,6 +17,7 @@
 package dagger;
 
 import dagger.internal.Beta;
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -25,6 +26,7 @@ import java.lang.annotation.Target;
 /**
  * Annotates a class that contributes to the object graph.
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface Module {

--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -84,6 +84,8 @@ java_library(
         "ContributionType.java",
         "DaggerElements.java",
         "DaggerStatistics.java",
+        "DaggerStatisticsCollector.java",
+        "DaggerStatisticsRecorder.java",
         "DaggerTypes.java",
         "DiagnosticFormatting.java",
         "Expression.java",

--- a/java/dagger/internal/codegen/BindingRequest.java
+++ b/java/dagger/internal/codegen/BindingRequest.java
@@ -97,4 +97,12 @@ abstract class BindingRequest {
             : frameworkType().get().frameworkClass().getSimpleName();
     return requestKindObject.toString();
   }
+
+  /** Returns {@code true} if this request can be satisfied by a production binding. */
+  final boolean canBeSatisfiedByProductionBinding() {
+    if (requestKind().isPresent()) {
+      return RequestKinds.canBeSatisfiedByProductionBinding(requestKind().get());
+    }
+    return frameworkType().get().equals(FrameworkType.PRODUCER_NODE);
+  }
 }

--- a/java/dagger/internal/codegen/ComponentImplementationBuilder.java
+++ b/java/dagger/internal/codegen/ComponentImplementationBuilder.java
@@ -765,7 +765,7 @@ abstract class ComponentImplementationBuilder {
             superclassImplementation.getModifiableBindingMethods()) {
           bindingExpressions
               .modifiableBindingExpressions()
-              .reimplementedModifiableBindingMethod(superclassModifiableBindingMethod)
+              .possiblyReimplementedMethod(superclassModifiableBindingMethod)
               .ifPresent(componentImplementation::addImplementedModifiableBindingMethod);
         }
       } else {

--- a/java/dagger/internal/codegen/ComponentProcessor.java
+++ b/java/dagger/internal/codegen/ComponentProcessor.java
@@ -54,7 +54,7 @@ public class ComponentProcessor extends BasicAnnotationProcessor {
   @Inject ImmutableList<ProcessingStep> processingSteps;
   @Inject BindingGraphPlugins bindingGraphPlugins;
   @Inject CompilerOptions compilerOptions;
-  @Inject DaggerStatistics daggerStatistics;
+  @Inject DaggerStatisticsCollector statisticsCollector;
 
   // TODO(ronshapiro): inject a multibinding for all instances that retain caches?
   @Inject ModuleDescriptor.Factory moduleDescriptorFactory;
@@ -110,7 +110,7 @@ public class ComponentProcessor extends BasicAnnotationProcessor {
         .build()
         .inject(this);
 
-    daggerStatistics.processingStarted();
+    statisticsCollector.processingStarted();
     bindingGraphPlugins.initializePlugins();
     return processingSteps;
   }
@@ -183,7 +183,7 @@ public class ComponentProcessor extends BasicAnnotationProcessor {
   @Override
   protected void postRound(RoundEnvironment roundEnv) {
     if (roundEnv.processingOver()) {
-      daggerStatistics.processingStopped();
+      statisticsCollector.processingStopped();
     } else {
       try {
         injectBindingRegistry.generateSourcesForRequiredBindings(

--- a/java/dagger/internal/codegen/DaggerStatisticsCollector.java
+++ b/java/dagger/internal/codegen/DaggerStatisticsCollector.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2018 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Ticker;
+import java.time.Duration;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/** Collects {@link DaggerStatistics} over the course of Dagger annotation processing. */
+@Singleton // for state sharing
+final class DaggerStatisticsCollector {
+
+  private final Stopwatch totalRuntimeStopwatch;
+  private final Optional<DaggerStatisticsRecorder> statisticsRecorder;
+
+  @Inject
+  DaggerStatisticsCollector(Ticker ticker, Optional<DaggerStatisticsRecorder> statisticsRecorder) {
+    this.totalRuntimeStopwatch = Stopwatch.createUnstarted(ticker);
+    this.statisticsRecorder = statisticsRecorder;
+  }
+
+  /** Called when Dagger annotation processing starts. */
+  void processingStarted() {
+    checkState(!totalRuntimeStopwatch.isRunning());
+    totalRuntimeStopwatch.start();
+  }
+
+  /** Called when Dagger annotation processing completes. */
+  void processingStopped() {
+    checkState(totalRuntimeStopwatch.isRunning());
+    totalRuntimeStopwatch.stop();
+
+    statisticsRecorder.ifPresent(
+        recorder -> {
+          DaggerStatistics statistics = DaggerStatistics.create(elapsedTime(totalRuntimeStopwatch));
+          recorder.recordStatistics(statistics);
+        });
+  }
+
+  @SuppressWarnings("StopwatchNanosToDuration") // intentional
+  private Duration elapsedTime(Stopwatch stopwatch) {
+    // Using the java 7 method here as opposed to the Duration-returning version to avoid issues
+    // when other annotation processors rely on java 7's guava
+    return Duration.ofNanos(stopwatch.elapsed(NANOSECONDS));
+  }
+}

--- a/java/dagger/internal/codegen/DaggerStatisticsRecorder.java
+++ b/java/dagger/internal/codegen/DaggerStatisticsRecorder.java
@@ -16,17 +16,8 @@
 
 package dagger.internal.codegen;
 
-import com.google.auto.value.AutoValue;
-import java.time.Duration;
-
-/** Statistics collected over the course of Dagger annotation processing. */
-@AutoValue
-abstract class DaggerStatistics {
-  /** Creates a new {@link DaggerStatistics}. */
-  static DaggerStatistics create(Duration totalProcessingTime) {
-    return new AutoValue_DaggerStatistics(totalProcessingTime);
-  }
-
-  /** Total time spent in Dagger annotation processing. */
-  abstract Duration totalProcessingTime();
+/** Records collected {@link DaggerStatistics}. */
+interface DaggerStatisticsRecorder {
+  /** Records the given {@code statistics}. */
+  void recordStatistics(DaggerStatistics statistics);
 }

--- a/java/dagger/internal/codegen/MissingBindingValidator.java
+++ b/java/dagger/internal/codegen/MissingBindingValidator.java
@@ -20,7 +20,7 @@ import static com.google.common.base.Verify.verify;
 import static dagger.internal.codegen.DaggerStreams.instancesOf;
 import static dagger.internal.codegen.Keys.isValidImplicitProvisionKey;
 import static dagger.internal.codegen.Keys.isValidMembersInjectionKey;
-import static dagger.internal.codegen.RequestKinds.entryPointCanUseProduction;
+import static dagger.internal.codegen.RequestKinds.canBeSatisfiedByProductionBinding;
 import static javax.tools.Diagnostic.Kind.ERROR;
 
 import dagger.model.BindingGraph;
@@ -107,10 +107,12 @@ final class MissingBindingValidator implements BindingGraphPlugin {
         .allMatch(edge -> dependencyCanBeProduction(edge, graph));
   }
 
+  // TODO(ronshapiro): merge with
+  // ProvisionDependencyOnProduerBindingValidator.dependencyCanUseProduction
   private boolean dependencyCanBeProduction(DependencyEdge edge, BindingGraph graph) {
     Node source = graph.network().incidentNodes(edge).source();
     if (source instanceof ComponentNode) {
-      return entryPointCanUseProduction(edge.dependencyRequest().kind());
+      return canBeSatisfiedByProductionBinding(edge.dependencyRequest().kind());
     }
     if (source instanceof dagger.model.Binding) {
       return ((dagger.model.Binding) source).isProduction();

--- a/java/dagger/internal/codegen/ModifiableBindingExpressions.java
+++ b/java/dagger/internal/codegen/ModifiableBindingExpressions.java
@@ -84,14 +84,36 @@ final class ModifiableBindingExpressions {
    * implementation of this subcomponent. Returns {@link Optional#empty()} when the binding cannot
    * or should not be modified by the current binding graph.
    */
-  Optional<ModifiableBindingMethod> reimplementedModifiableBindingMethod(
+  Optional<ModifiableBindingMethod> possiblyReimplementedMethod(
       ModifiableBindingMethod modifiableBindingMethod) {
     checkState(componentImplementation.superclassImplementation().isPresent());
-    ModifiableBindingType newModifiableBindingType =
-        getModifiableBindingType(modifiableBindingMethod.request());
+    BindingRequest request = modifiableBindingMethod.request();
+    ModifiableBindingType newModifiableBindingType = getModifiableBindingType(request);
     ModifiableBindingType oldModifiableBindingType = modifiableBindingMethod.type();
     boolean modifiableBindingTypeChanged =
         !newModifiableBindingType.equals(oldModifiableBindingType);
+
+    ResolvedBindings resolvedBindings = graph.resolvedBindings(request);
+    // Don't reimplement modifiable bindings that were perceived to be provision bindings in a
+    // superclass implementation but are now production bindings.
+    if ((modifiableBindingTypeChanged
+            // Optional bindings don't need the same treatment since the only transition they can
+            // make is empty -> present. In that case, the Producer<Optional<T>> will be overridden
+            // and the absentOptionalProvider() will be a dangling reference that is never attempted
+            // to be overridden.
+            || newModifiableBindingType.equals(ModifiableBindingType.MULTIBINDING))
+        && resolvedBindings != null
+        && resolvedBindings.bindingType().equals(BindingType.PRODUCTION)
+        && !request.canBeSatisfiedByProductionBinding()) {
+      return oldModifiableBindingType.hasBaseClassImplementation()
+          ? Optional.empty()
+          : Optional.of(
+              reimplementedMethod(
+                  modifiableBindingMethod,
+                  new PrunedConcreteMethodBindingExpression(),
+                  componentImplementation.isAbstract()));
+    }
+
     if (modifiableBindingTypeChanged
         && !newModifiableBindingType.hasBaseClassImplementation()
         && (oldModifiableBindingType.hasBaseClassImplementation()
@@ -103,30 +125,41 @@ final class ModifiableBindingExpressions {
     }
 
     if (modifiableBindingTypeChanged
-        || shouldModifyImplementation(
-            newModifiableBindingType, modifiableBindingMethod.request())) {
-      MethodSpec baseMethod = modifiableBindingMethod.methodSpec();
+        || shouldModifyImplementation(newModifiableBindingType, request)) {
       boolean markMethodFinal =
           knownModifiableBindingWillBeFinalized(modifiableBindingMethod)
               // no need to mark the method final if the component implementation will be final
               && componentImplementation.isAbstract();
       return Optional.of(
-          ModifiableBindingMethod.implement(
+          reimplementedMethod(
               modifiableBindingMethod,
-              MethodSpec.methodBuilder(baseMethod.name)
-                  .addModifiers(baseMethod.modifiers.contains(PUBLIC) ? PUBLIC : PROTECTED)
-                  .addModifiers(markMethodFinal ? ImmutableSet.of(FINAL) : ImmutableSet.of())
-                  .returns(baseMethod.returnType)
-                  .addAnnotation(Override.class)
-                  .addCode(
-                      bindingExpressions
-                          .getBindingExpression(modifiableBindingMethod.request())
-                          .getModifiableBindingMethodImplementation(
-                              modifiableBindingMethod, componentImplementation, types))
-                  .build(),
+              bindingExpressions.getBindingExpression(request),
               markMethodFinal));
     }
     return Optional.empty();
+  }
+
+  /**
+   * Returns a new {@link ModifiableBindingMethod} that overrides {@code supertypeMethod} and is
+   * implemented with {@code bindingExpression}.
+   */
+  private ModifiableBindingMethod reimplementedMethod(
+      ModifiableBindingMethod supertypeMethod,
+      BindingExpression bindingExpression,
+      boolean markMethodFinal) {
+    MethodSpec baseMethod = supertypeMethod.methodSpec();
+    return ModifiableBindingMethod.implement(
+        supertypeMethod,
+        MethodSpec.methodBuilder(baseMethod.name)
+            .addModifiers(baseMethod.modifiers.contains(PUBLIC) ? PUBLIC : PROTECTED)
+            .addModifiers(markMethodFinal ? ImmutableSet.of(FINAL) : ImmutableSet.of())
+            .returns(baseMethod.returnType)
+            .addAnnotation(Override.class)
+            .addCode(
+                bindingExpression.getModifiableBindingMethodImplementation(
+                    supertypeMethod, componentImplementation, types))
+            .build(),
+        markMethodFinal);
   }
 
   /**
@@ -329,16 +362,29 @@ final class ModifiableBindingExpressions {
    */
   private boolean shouldModifyImplementation(
       ModifiableBindingType modifiableBindingType, BindingRequest request) {
+    ResolvedBindings resolvedBindings = graph.resolvedBindings(request);
     if (request.requestKind().isPresent()) {
       switch (request.requestKind().get()) {
         case FUTURE:
-          // Futures are always requested by a Producer.get() call, so if the binding is modifiable,
-          // the producer will be wrapped in a modifiable method and the future can refer to that
-          // method; even if the producer binding is modified, getModifiableProducer().get() will
-          // never need to be modified. Furthermore, because cancellation is treated by wrapped
-          // producers, and those producers point to the modifiable producer wrapper methods, we
-          // never need or want to change the access of these wrapped producers for entry
-          // methods
+          // Futures backed by production bindings are always requested by a Producer.get() call, so
+          // if the binding is modifiable, the producer will be wrapped in a modifiable method and
+          // the future can refer to that  method; even if the producer binding is modified,
+          // getModifiableProducer().get() will never need to be modified. Furthermore, because
+          // cancellation is treated by wrapped producers, and those producers point to the
+          // modifiable producer wrapper methods, we never need or want to change the access of
+          // these wrapped producers for entry methods
+          //
+          // Futures backed by provision bindings are inlined and contain no wrapping producer, so
+          // if the binding is modifiable and is resolved as a provision binding in a superclass
+          // but later resolved as a production binding, we can't take the same shortcut as before.
+          if (componentImplementation.superclassImplementation().isPresent()) {
+            BindingGraph superclassGraph =
+                componentImplementation.superclassImplementation().get().graph();
+            ResolvedBindings superclassBindings = superclassGraph.resolvedBindings(request);
+            return superclassBindings != null
+                && resolvedBindings != null
+                && !superclassBindings.bindingType().equals(resolvedBindings.bindingType());
+          }
           return false;
 
         case LAZY:
@@ -365,7 +411,6 @@ final class ModifiableBindingExpressions {
       }
     }
 
-    ResolvedBindings resolvedBindings = graph.resolvedBindings(request);
     switch (modifiableBindingType) {
       case GENERATED_INSTANCE:
         return !componentImplementation.isAbstract();

--- a/java/dagger/internal/codegen/ProcessingEnvironmentModule.java
+++ b/java/dagger/internal/codegen/ProcessingEnvironmentModule.java
@@ -23,6 +23,7 @@ import dagger.Module;
 import dagger.Provides;
 import dagger.Reusable;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -78,5 +79,10 @@ final class ProcessingEnvironmentModule {
   @Reusable // to avoid parsing options more than once
   CompilerOptions compilerOptions() {
     return CompilerOptions.create(processingEnvironment);
+  }
+
+  @Provides
+  Optional<DaggerStatisticsRecorder> daggerStatisticsRecorder() {
+    return Optional.empty();
   }
 }

--- a/java/dagger/internal/codegen/ProvisionDependencyOnProducerBindingValidator.java
+++ b/java/dagger/internal/codegen/ProvisionDependencyOnProducerBindingValidator.java
@@ -19,7 +19,7 @@ package dagger.internal.codegen;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static dagger.internal.codegen.DaggerStreams.instancesOf;
-import static dagger.internal.codegen.RequestKinds.entryPointCanUseProduction;
+import static dagger.internal.codegen.RequestKinds.canBeSatisfiedByProductionBinding;
 import static javax.tools.Diagnostic.Kind.ERROR;
 
 import dagger.model.BindingGraph;
@@ -74,9 +74,10 @@ final class ProvisionDependencyOnProducerBindingValidator implements BindingGrap
         .flatMap(instancesOf(DependencyEdge.class));
   }
 
+  // TODO(ronshapiro): merge with MissingBindingValidator.dependencyCanUseProduction
   private boolean dependencyCanUseProduction(DependencyEdge edge, BindingGraph bindingGraph) {
     return edge.isEntryPoint()
-        ? entryPointCanUseProduction(edge.dependencyRequest().kind())
+        ? canBeSatisfiedByProductionBinding(edge.dependencyRequest().kind())
         : bindingRequestingDependency(edge, bindingGraph).isProduction();
   }
 

--- a/java/dagger/internal/codegen/RequestKinds.java
+++ b/java/dagger/internal/codegen/RequestKinds.java
@@ -165,10 +165,10 @@ final class RequestKinds {
   }
 
   /**
-   * Returns {@code true} if entry points with the given request kind may be satisfied with a
-   * production binding.
+   * Returns {@code true} if requests for {@code requestKind} can be satisfied by a production
+   * binding.
    */
-  static boolean entryPointCanUseProduction(RequestKind requestKind) {
+  static boolean canBeSatisfiedByProductionBinding(RequestKind requestKind) {
     switch (requestKind) {
       case INSTANCE:
       case PROVIDER:

--- a/javatests/dagger/functional/producers/BUILD
+++ b/javatests/dagger/functional/producers/BUILD
@@ -38,6 +38,7 @@ GenJavaTests(
         "@google_bazel_common//third_party/java/junit",
         "@google_bazel_common//third_party/java/mockito",
         "@google_bazel_common//third_party/java/truth",
+        "@google_bazel_common//third_party/java/truth:truth8",
     ],
 )
 

--- a/javatests/dagger/functional/producers/aot/ProducesMethodShadowsInjectConstructorTest.java
+++ b/javatests/dagger/functional/producers/aot/ProducesMethodShadowsInjectConstructorTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.producers.aot;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import dagger.BindsOptionalOf;
+import dagger.Provides;
+import dagger.multibindings.IntoSet;
+import dagger.producers.ProducerModule;
+import dagger.producers.Produces;
+import dagger.producers.Production;
+import dagger.producers.ProductionComponent;
+import dagger.producers.ProductionSubcomponent;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import javax.inject.Inject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ProducesMethodShadowsInjectConstructorTest {
+  static class Multibound {}
+  static class Maybe {}
+
+  static class HasInjectConstructor {
+    @Inject HasInjectConstructor() {}
+  }
+
+  static class DependsOnShadowingProducer {}
+
+  @ProducerModule
+  abstract static class LeafModule {
+    @Produces
+    static DependsOnShadowingProducer dependsOnShadowingProducer(
+        // When viewed just within the leaf, this will resolve HasInjectConstructor to the @Inject
+        // constructor (and will receive a producerFromProvider), but when viewed within an ancestor
+        // that defines a @Produces method for HasInjectConstructor, the binding will be a regular
+        // Producer
+        HasInjectConstructor hasInjectConstructor,
+        Optional<Maybe> maybe) {
+      return new DependsOnShadowingProducer();
+    }
+
+    @Provides
+    @IntoSet
+    static Multibound provisionContribution() {
+      return new Multibound();
+    }
+
+    @BindsOptionalOf
+    abstract Maybe maybe();
+  }
+
+  @ProductionSubcomponent(modules = LeafModule.class)
+  interface Leaf {
+    ListenableFuture<DependsOnShadowingProducer> dependsOnShadowingProducer();
+    ListenableFuture<Set<Multibound>> shadowedProvisionMultibinding();
+    ListenableFuture<Optional<Maybe>> emptyProvisionBindingToPresentProductionBinding();
+  }
+
+  @ProducerModule
+  static class RootModule {
+    @Produces
+    static HasInjectConstructor shadowInjectConstructor() {
+      return new HasInjectConstructor();
+    }
+
+    @Produces
+    @IntoSet
+    static Multibound productionContribution() {
+      return new Multibound();
+    }
+
+    @Provides
+    @Production
+    static Executor executor() {
+      return MoreExecutors.directExecutor();
+    }
+
+    @Produces
+    static Maybe presentMaybeInParent() {
+      return new Maybe();
+    }
+  }
+
+  @ProductionComponent(modules = RootModule.class)
+  interface Root {
+    Leaf leaf();
+  }
+
+  @Test
+  public void shadowedInjectConstructorDoesNotCauseClassCast() throws Exception {
+    Leaf leaf = DaggerProducesMethodShadowsInjectConstructorTest_Root.create().leaf();
+    leaf.dependsOnShadowingProducer().get();
+    assertThat(leaf.shadowedProvisionMultibinding().get()).hasSize(2);
+    assertThat(leaf.emptyProvisionBindingToPresentProductionBinding().get()).isPresent();
+  }
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -19,5 +19,15 @@ package(default_visibility = ["//:src"])
 
 exports_files([
     "pom-template.xml",
-    "simple_jar.sh",
 ])
+
+sh_library(
+    name = "simple_jar",
+    srcs = ["simple_jar.sh"],
+)
+
+sh_test(
+    name = "simple_jar_test",
+    srcs = ["simple_jar_test.sh"],
+    deps = [":simple_jar"],
+)

--- a/tools/simple_jar.bzl
+++ b/tools/simple_jar.bzl
@@ -19,31 +19,13 @@ def simple_jar(name, srcs):
 
     # TODO(dpb): consider creating a Fileset() under the hood to support srcs from different
     # directories, or continually update the same zip file for each source file
-    # TODO(ronshapiro): extract a .sh file to make this easier to understand
     native.genrule(
         name = name,
         srcs = srcs,
         outs = ["%s.jar" % name],
-        cmd = 'package_name="{package_name}"'.format(package_name = native.package_name()) +
-              """
-        dirname=""
-        for src in $(SRCS); do
-          src_dirname="$$(echo "$${src}" | grep -o -P "(.*/)?$${package_name}" | head -n1)"
-          if [[ -z "$${dirname}" ]]; then
-            dirname="$${src_dirname}"
-          elif [[ "$${dirname}" != "$${src_dirname}" ]]; then
-            echo "Sources must all be in the same directory: $(SRCS)"
-            exit 1
-          fi
-        done
-
-        if [[ -z "$${dirname}" ]]; then
-          echo "No sources provided"
-          exit 1
-        fi
-
-        OUT="$$(pwd)/$@"
-        cd "$${dirname}"
-        zip "$$OUT" -r * &> /dev/null
-        """,
+        cmd = """
+            $(location //tools:simple_jar.sh) \
+              "{package_name}" "$@" $(SRCS)
+              """.format(package_name = native.package_name()),
+        tools = ["//tools:simple_jar.sh"],
     )

--- a/tools/simple_jar.sh
+++ b/tools/simple_jar.sh
@@ -1,4 +1,5 @@
-# Copyright (C) 2017 The Dagger Authors.
+#!/bin/bash
+# Copyright (C) 2018 The Dagger Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Description:
-#   Tools for Dagger
+readonly PACKAGE_NAME="$1"
+readonly OUT="${PWD}/$2"
+shift 2
 
-package(default_visibility = ["//:src"])
+dirname=""
+for src in "$@"; do
+  src_dirname="$(echo "${src}" | grep -o -P "(.*/)?${PACKAGE_NAME}" | head -n1)"
+  if [[ -z "${dirname}" ]]; then
+    dirname="${src_dirname}"
+  elif [[ "${dirname}" != "${src_dirname}" ]]; then
+    echo "Sources must all be in the same directory: $@"
+    exit 1
+  fi
+done
 
-exports_files([
-    "pom-template.xml",
-    "simple_jar.sh",
-])
+if [[ -z "${dirname}" ]]; then
+  echo "No sources provided"
+  exit 1
+fi
+
+cd "${dirname}"
+zip "${OUT}" -r * &> /dev/null

--- a/tools/simple_jar.sh
+++ b/tools/simple_jar.sh
@@ -13,29 +13,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-readonly PACKAGE_NAME="$1"
-readonly OUT="${PWD}/$2"
-shift 2
+set -e
 
-dirname=""
-for src in "$@"; do
-  if [[ ! "${src}" =~ ^((.*/)?"${PACKAGE_NAME}")/ ]]; then
-    echo "Sources must be in ${PACKAGE_NAME}: $@"
-    exit 1
-  fi
-  src_dirname="${BASH_REMATCH[1]}"
+find_dirname() {
+  local package_name="$1"
+  shift
+
+  local src src_dirname dirname=""
+  for src in "$@"; do
+    if [[ ! "${src}" =~ ^((.*/)?"${package_name}")/ ]]; then
+      echo "Sources must be in ${package_name}: $0" >&2
+      return 1
+    fi
+    src_dirname="${BASH_REMATCH[1]}"
+    if [[ -z "${dirname}" ]]; then
+      dirname="${src_dirname}"
+    elif [[ "${dirname}" != "${src_dirname}" ]]; then
+      echo "Sources must all be in the same directory: $@" >&2
+      return 1
+    fi
+  done
+
   if [[ -z "${dirname}" ]]; then
-    dirname="${src_dirname}"
-  elif [[ "${dirname}" != "${src_dirname}" ]]; then
-    echo "Sources must all be in the same directory: $@"
-    exit 1
+    echo "No sources provided" >&2
+    return 1
   fi
-done
 
-if [[ -z "${dirname}" ]]; then
-  echo "No sources provided"
-  exit 1
+  echo "${dirname}"
+}
+
+main() {
+  local package_name="$1"
+  local out="${PWD}/$2"
+  shift 2
+
+  local dirname
+  dirname="$(find_dirname "${package_name}" "$@")"
+  cd "${dirname}"
+  zip "${out}" -r * &> /dev/null
+}
+
+if [[ -z "$TEST_SRCDIR" ]]; then
+  main "$@"
 fi
-
-cd "${dirname}"
-zip "${OUT}" -r * &> /dev/null

--- a/tools/simple_jar.sh
+++ b/tools/simple_jar.sh
@@ -19,7 +19,11 @@ shift 2
 
 dirname=""
 for src in "$@"; do
-  src_dirname="$(echo "${src}" | grep -o -P "(.*/)?${PACKAGE_NAME}" | head -n1)"
+  if [[ ! "${src}" =~ ^((.*/)?"${PACKAGE_NAME}")/ ]]; then
+    echo "Sources must be in ${PACKAGE_NAME}: $@"
+    exit 1
+  fi
+  src_dirname="${BASH_REMATCH[1]}"
   if [[ -z "${dirname}" ]]; then
     dirname="${src_dirname}"
   elif [[ "${dirname}" != "${src_dirname}" ]]; then

--- a/tools/simple_jar.sh
+++ b/tools/simple_jar.sh
@@ -26,9 +26,7 @@ find_dirname() {
       return 1
     fi
     src_dirname="${BASH_REMATCH[1]}"
-    if [[ -z "${dirname}" ]]; then
-      dirname="${src_dirname}"
-    elif [[ "${dirname}" != "${src_dirname}" ]]; then
+    if [[ "${dirname:=${src_dirname}}" != "${src_dirname}" ]]; then
       echo "Sources must all be in the same directory: $@" >&2
       return 1
     fi

--- a/tools/simple_jar_test.sh
+++ b/tools/simple_jar_test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Copyright (C) 2019 The Dagger Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+fail() {
+  local message="${1:-failed}"
+  echo "${message} at $(caller)" >&2
+  return 1
+}
+
+. "tools/simple_jar.sh"
+
+[[ "$(find_dirname some/package some/package/a/b/c some/package/d/e/f)" \
+    == "some/package" ]] \
+  || fail "without prefix"
+
+[[ "$(find_dirname some/package prefix/some/package/a prefix/some/package/b)" \
+    == "prefix/some/package" ]] \
+  || fail "with prefix"
+
+! find_dirname some/package some/package/a other/package/b >/dev/null \
+  || fail "wrong package"
+
+! find_dirname some/package some/package/a prefix/some/package/b >/dev/null \
+  || fail "different prefixes"
+
+! find_dirname some/package >/dev/null || fail "no sources"
+
+true

--- a/tools/simple_jar_test.sh
+++ b/tools/simple_jar_test.sh
@@ -25,18 +25,22 @@ fail() {
 
 [[ "$(find_dirname some/package some/package/a/b/c some/package/d/e/f)" \
     == "some/package" ]] \
-  || fail "without prefix"
+  || fail "no prefix"
 
 [[ "$(find_dirname some/package prefix/some/package/a prefix/some/package/b)" \
     == "prefix/some/package" ]] \
   || fail "with prefix"
 
 ! find_dirname some/package some/package/a other/package/b >/dev/null \
-  || fail "wrong package"
+  || fail "expected failure if one file is in the wrong package"
+
+! find_dirname some/package other/package/a other/package/b >/dev/null \
+  || fail "expected failure if all files are in the wrong package"
 
 ! find_dirname some/package some/package/a prefix/some/package/b >/dev/null \
-  || fail "different prefixes"
+  || fail "expected failure if files have different prefixes"
 
-! find_dirname some/package >/dev/null || fail "no sources"
+! find_dirname some/package >/dev/null \
+  || fail "expected failure with no sources"
 
 true


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix `simple_jar` to work no matter what prefix the package_name has. This supports newer versions of bazel that prefix external/{dagger_repoistory_name}/{package_name}

ac584a47d95025104fa9fd5ee0f5edbd41b3dfc4

-------

<p> Make @Module @Documented

@ProducerModule is already @Documented

87eb3f6233048153cd35b7d30cf753d7c5272f68

-------

<p> Don't reimplement provision requests for production bindings that replace modifiable methods

Beforehand, in fastInit, we'd throw an exception for trying to translate a ProductionBinding into a provision request kind. In default mode, we'd just generate the wrong code (and have two Producer instances for the same binding).

a07ce4dbe40aebedfd470d23a3675036ae6958b2

-------

<p> Tokenize javacopts

f16c8c80bf2b357a098484e5be6a033546d68b34

-------

<p> Extract simple_jar.sh from simple_jar.bzl.

21cba0c05a776dc06e48649076141dafdee28dfe

-------

<p> Use Bash regular expression matching instead of grep -P.

30916e233c7f34a6e5541fe6eeada740dd651b57

-------

<p> Split up DaggerStatistics into a data class, a collector, and an interface for recording the collected data.

390f288fde633618205e88da4533d9a7ff9b60f3

-------

<p> Add unit test for simple_jar.sh.

Have to make functions to do so.

bccd72412841216283e93d9b9edfb65ec7c5e3fa

-------

<p> Add test for case where all files are in the wrong package.

Also improve failure messages.

b14d9bfd62e5a00c867d54008f25a36b7b6bfedd

-------

<p> Simplify simple_jar's bash code a bit.

abc2d8316b6a3e5fb812a1382a1703b565ac1b30