### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/ComponentImplementationBuilder.java
+++ b/java/dagger/internal/codegen/ComponentImplementationBuilder.java
@@ -554,13 +554,8 @@ abstract class ComponentImplementationBuilder {
    * from the requirement the parameter fulfills to the spec for the parameter.
    */
   private final ImmutableMap<ComponentRequirement, ParameterSpec> initializationParameters() {
-    Optional<ComponentCreatorImplementation> creatorImplementation =
-        Optionals.firstPresent(
-            componentImplementation.creatorImplementation(),
-            componentImplementation.baseCreatorImplementation());
-
     Map<ComponentRequirement, ParameterSpec> parameters;
-    if (creatorImplementation.isPresent()) {
+    if (componentImplementation.componentDescriptor().hasCreator()) {
       parameters =
           Maps.toMap(componentImplementation.requirements(), ComponentRequirement::toParameterSpec);
     } else if (componentImplementation.isAbstract() && componentImplementation.isNested()) {

--- a/java/dagger/internal/codegen/ComponentImplementationBuilder.java
+++ b/java/dagger/internal/codegen/ComponentImplementationBuilder.java
@@ -757,7 +757,7 @@ abstract class ComponentImplementationBuilder {
         ComponentImplementation superclassImplementation =
             componentImplementation.superclassImplementation().get();
         for (ModifiableBindingMethod superclassModifiableBindingMethod :
-            superclassImplementation.getModifiableBindingMethods()) {
+            superclassImplementation.getModifiableBindingMethods().values()) {
           bindingExpressions
               .modifiableBindingExpressions()
               .possiblyReimplementedMethod(superclassModifiableBindingMethod)

--- a/java/dagger/internal/codegen/ComponentRequirementExpressions.java
+++ b/java/dagger/internal/codegen/ComponentRequirementExpressions.java
@@ -127,11 +127,7 @@ final class ComponentRequirementExpressions {
 
   /** Returns a field for a {@link ComponentRequirement}. */
   private ComponentRequirementExpression createField(ComponentRequirement requirement) {
-    Optional<ComponentCreatorImplementation> creatorImplementation =
-        Optionals.firstPresent(
-            componentImplementation.baseImplementation().flatMap(c -> c.creatorImplementation()),
-            componentImplementation.creatorImplementation());
-    if (creatorImplementation.isPresent()) {
+    if (componentImplementation.componentDescriptor().hasCreator()) {
       return new ComponentParameterField(requirement, componentImplementation, Optional.empty());
     } else if (graph.factoryMethod().isPresent()
         && graph.factoryMethodParameters().containsKey(requirement)) {

--- a/java/dagger/internal/codegen/ModifiableBindingExpressions.java
+++ b/java/dagger/internal/codegen/ModifiableBindingExpressions.java
@@ -111,6 +111,7 @@ final class ModifiableBindingExpressions {
           : Optional.of(
               reimplementedMethod(
                   modifiableBindingMethod,
+                  newModifiableBindingType,
                   new PrunedConcreteMethodBindingExpression(),
                   componentImplementation.isAbstract()));
     }
@@ -134,6 +135,7 @@ final class ModifiableBindingExpressions {
       return Optional.of(
           reimplementedMethod(
               modifiableBindingMethod,
+              newModifiableBindingType,
               bindingExpressions.getBindingExpression(request),
               markMethodFinal));
     }
@@ -146,11 +148,12 @@ final class ModifiableBindingExpressions {
    */
   private ModifiableBindingMethod reimplementedMethod(
       ModifiableBindingMethod supertypeMethod,
+      ModifiableBindingType newModifiableBindingType,
       BindingExpression bindingExpression,
       boolean markMethodFinal) {
     MethodSpec baseMethod = supertypeMethod.methodSpec();
-    return ModifiableBindingMethod.implement(
-        supertypeMethod,
+    return supertypeMethod.reimplement(
+        newModifiableBindingType,
         MethodSpec.methodBuilder(baseMethod.name)
             .addModifiers(baseMethod.modifiers.contains(PUBLIC) ? PUBLIC : PROTECTED)
             .addModifiers(markMethodFinal ? ImmutableSet.of(FINAL) : ImmutableSet.of())

--- a/java/dagger/internal/codegen/ModifiableBindingExpressions.java
+++ b/java/dagger/internal/codegen/ModifiableBindingExpressions.java
@@ -19,6 +19,7 @@ package dagger.internal.codegen;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static dagger.internal.codegen.BindingRequest.bindingRequest;
+import static java.util.stream.Collectors.toList;
 import static javax.lang.model.element.Modifier.FINAL;
 import static javax.lang.model.element.Modifier.PROTECTED;
 import static javax.lang.model.element.Modifier.PUBLIC;
@@ -440,7 +441,10 @@ final class ModifiableBindingExpressions {
         // Only modify a multibinding if there are new contributions.
         return !componentImplementation
             .superclassContributionsMade(request)
-            .containsAll(resolvedBindings.contributionBinding().dependencies());
+            .containsAll(
+                resolvedBindings.contributionBinding().dependencies().stream()
+                    .map(DependencyRequest::key)
+                    .collect(toList()));
 
       case INJECTION:
         return !resolvedBindings.contributionBinding().kind().equals(BindingKind.INJECTION);

--- a/java/dagger/internal/codegen/MultibindingExpression.java
+++ b/java/dagger/internal/codegen/MultibindingExpression.java
@@ -16,17 +16,16 @@
 
 package dagger.internal.codegen;
 
-import static dagger.internal.codegen.BindingRequest.bindingRequest;
-
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import com.google.common.collect.Sets.SetView;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import dagger.internal.codegen.ModifiableBindingMethods.ModifiableBindingMethod;
 import dagger.model.DependencyRequest;
+import dagger.model.Key;
 import dagger.model.RequestKind;
 import java.util.Optional;
+import java.util.Set;
 
 /** An abstract base class for multibinding {@link BindingExpression}s. */
 abstract class MultibindingExpression extends SimpleInvocationBindingExpression {
@@ -60,9 +59,11 @@ abstract class MultibindingExpression extends SimpleInvocationBindingExpression 
    * one implementation of a multibinding expression and all {@link DependencyRequest}s from the
    * argment are returned.
    */
-  protected SetView<DependencyRequest> getNewContributions(
+  protected Set<DependencyRequest> getNewContributions(
       ImmutableSet<DependencyRequest> dependencies) {
-    return Sets.difference(dependencies, superclassContributions());
+    ImmutableSet<Key> superclassContributions = superclassContributions();
+    return Sets.filter(
+        dependencies, dependency -> !superclassContributions.contains(dependency.key()));
   }
 
   /**
@@ -87,7 +88,7 @@ abstract class MultibindingExpression extends SimpleInvocationBindingExpression 
     return BindingRequest.bindingRequest(binding.key(), RequestKind.INSTANCE);
   }
 
-  private ImmutableSet<DependencyRequest> superclassContributions() {
+  private ImmutableSet<Key> superclassContributions() {
     return componentImplementation.superclassContributionsMade(bindingRequest());
   }
 }

--- a/java/dagger/internal/codegen/MultibindingFactoryCreationExpression.java
+++ b/java/dagger/internal/codegen/MultibindingFactoryCreationExpression.java
@@ -57,9 +57,7 @@ abstract class MultibindingFactoryCreationExpression
 
   protected final ImmutableSet<FrameworkDependency> frameworkDependenciesToImplement() {
     ImmutableSet<Key> alreadyImplementedKeys =
-        componentImplementation.superclassContributionsMade(bindingRequest()).stream()
-            .map(dependency -> dependency.key())
-            .collect(toImmutableSet());
+        componentImplementation.superclassContributionsMade(bindingRequest());
     return binding.frameworkDependencies().stream()
         .filter(frameworkDependency -> !alreadyImplementedKeys.contains(frameworkDependency.key()))
         .collect(toImmutableSet());

--- a/javatests/dagger/functional/factory/AbstractModule.java
+++ b/javatests/dagger/functional/factory/AbstractModule.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.factory;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+abstract class AbstractModule {
+  @Provides
+  static String provideString() {
+    return "foo";
+  }
+}

--- a/javatests/dagger/functional/factory/ConcreteModuleThatCouldBeAbstract.java
+++ b/javatests/dagger/functional/factory/ConcreteModuleThatCouldBeAbstract.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.factory;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+final class ConcreteModuleThatCouldBeAbstract {
+  @Provides
+  static double provideDouble() {
+    return 42.0;
+  }
+}

--- a/javatests/dagger/functional/factory/Dependency.java
+++ b/javatests/dagger/functional/factory/Dependency.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.factory;
+
+final class Dependency {
+  Object object() {
+    return "bar";
+  }
+}

--- a/javatests/dagger/functional/factory/FactoryBindsInstanceTest.java
+++ b/javatests/dagger/functional/factory/FactoryBindsInstanceTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.factory;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.Assert.fail;
+
+import dagger.BindsInstance;
+import dagger.Component;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for component factories with {@link BindsInstance} parameters. */
+@RunWith(JUnit4.class)
+public final class FactoryBindsInstanceTest {
+
+  @Component
+  interface BindsInstanceComponent {
+    String string();
+
+    @Component.Factory
+    interface Factory {
+      BindsInstanceComponent create(@BindsInstance String string);
+    }
+  }
+
+  @Test
+  public void bindsInstance() {
+    BindsInstanceComponent component =
+        DaggerFactoryBindsInstanceTest_BindsInstanceComponent.factory().create("baz");
+    assertThat(component.string()).isEqualTo("baz");
+  }
+
+  @Test
+  public void nonNullableBindsInstance_failsOnNull() {
+    try {
+      DaggerFactoryBindsInstanceTest_BindsInstanceComponent.factory().create(null);
+      fail();
+    } catch (NullPointerException expected) {
+    }
+  }
+
+  @Target({METHOD, PARAMETER})
+  @Retention(RUNTIME)
+  @interface Nullable {}
+
+  @Component
+  interface NullableBindsInstanceComponent {
+    @Nullable
+    String string();
+
+    @Component.Factory
+    interface Factory {
+      NullableBindsInstanceComponent create(@BindsInstance @Nullable String string);
+    }
+  }
+
+  @Test
+  public void nullableBindsInstance_doesNotFailOnNull() {
+    NullableBindsInstanceComponent component =
+        DaggerFactoryBindsInstanceTest_NullableBindsInstanceComponent.factory().create(null);
+    assertThat(component.string()).isEqualTo(null);
+  }
+
+  @Component
+  interface PrimitiveBindsInstanceComponent {
+    int getInt();
+
+    @Component.Factory
+    interface Factory {
+      PrimitiveBindsInstanceComponent create(@BindsInstance int i);
+    }
+  }
+
+  @Test
+  public void primitiveBindsInstance() {
+    PrimitiveBindsInstanceComponent component =
+        DaggerFactoryBindsInstanceTest_PrimitiveBindsInstanceComponent.factory().create(1);
+    assertThat(component.getInt()).isEqualTo(1);
+  }
+}

--- a/javatests/dagger/functional/factory/FactoryDependenciesTest.java
+++ b/javatests/dagger/functional/factory/FactoryDependenciesTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.factory;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import dagger.Component;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for factories for components with a dependency. */
+@RunWith(JUnit4.class)
+public final class FactoryDependenciesTest {
+
+  @Component(dependencies = Dependency.class)
+  interface DependencyComponent {
+    Object object();
+
+    @Component.Factory
+    interface Factory {
+      DependencyComponent create(Dependency dependency);
+    }
+  }
+
+  @Test
+  public void dependency() {
+    DependencyComponent component =
+        DaggerFactoryDependenciesTest_DependencyComponent.factory().create(new Dependency());
+    assertThat(component.object()).isEqualTo("bar");
+  }
+
+  @Test
+  public void dependency_failsOnNull() {
+    try {
+      DaggerFactoryDependenciesTest_DependencyComponent.factory().create(null);
+      fail();
+    } catch (NullPointerException expected) {
+    }
+  }
+}

--- a/javatests/dagger/functional/factory/FactoryImplicitModulesTest.java
+++ b/javatests/dagger/functional/factory/FactoryImplicitModulesTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.factory;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import dagger.Component;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for factories for components with modules that do not require an instance to be passed to
+ * the factory. Includes both tests where the module does not have a corresponding parameter in the
+ * factory method and where it does have a parameter, for cases where that's allowed.
+ */
+@RunWith(JUnit4.class)
+public final class FactoryImplicitModulesTest {
+
+  @Component(modules = AbstractModule.class)
+  interface AbstractModuleComponent {
+    String string();
+
+    @Component.Factory
+    interface Factory {
+      AbstractModuleComponent create();
+    }
+  }
+
+  @Test
+  public void abstractModule() {
+    AbstractModuleComponent component =
+        DaggerFactoryImplicitModulesTest_AbstractModuleComponent.factory().create();
+    assertThat(component.string()).isEqualTo("foo");
+  }
+
+  @Component(modules = InstantiableConcreteModule.class)
+  interface InstantiableConcreteModuleComponent {
+    int getInt();
+
+    @Component.Factory
+    interface Factory {
+      InstantiableConcreteModuleComponent create();
+    }
+  }
+
+  @Test
+  public void instantiableConcreteModule() {
+    InstantiableConcreteModuleComponent component =
+        DaggerFactoryImplicitModulesTest_InstantiableConcreteModuleComponent.factory().create();
+    assertThat(component.getInt()).isEqualTo(42);
+  }
+
+  @Component(modules = InstantiableConcreteModule.class)
+  interface InstantiableConcreteModuleWithFactoryParameterComponent {
+    int getInt();
+
+    @Component.Factory
+    interface Factory {
+      InstantiableConcreteModuleWithFactoryParameterComponent create(
+          InstantiableConcreteModule module);
+    }
+  }
+
+  @Test
+  public void instantiableConcreteModule_withFactoryParameter() {
+    InstantiableConcreteModuleWithFactoryParameterComponent component =
+        DaggerFactoryImplicitModulesTest_InstantiableConcreteModuleWithFactoryParameterComponent
+            .factory()
+            .create(new InstantiableConcreteModule());
+    assertThat(component.getInt()).isEqualTo(42);
+  }
+
+  @Test
+  public void instantiableConcreteModule_withFactoryParameter_failsOnNull() {
+    try {
+      DaggerFactoryImplicitModulesTest_InstantiableConcreteModuleWithFactoryParameterComponent
+          .factory()
+          .create(null);
+      fail();
+    } catch (NullPointerException expected) {
+    }
+  }
+
+  @Component(modules = ConcreteModuleThatCouldBeAbstract.class)
+  interface ConcreteModuleThatCouldBeAbstractComponent {
+    double getDouble();
+
+    @Component.Factory
+    interface Factory {
+      ConcreteModuleThatCouldBeAbstractComponent create();
+    }
+  }
+
+  @Test
+  public void concreteModuleThatCouldBeAbstract() {
+    ConcreteModuleThatCouldBeAbstractComponent component =
+        DaggerFactoryImplicitModulesTest_ConcreteModuleThatCouldBeAbstractComponent.factory()
+            .create();
+    assertThat(component.getDouble()).isEqualTo(42.0);
+  }
+
+  @Component(modules = ConcreteModuleThatCouldBeAbstract.class)
+  interface ConcreteModuleThatCouldBeAbstractWithFactoryParameterComponent {
+    double getDouble();
+
+    @Component.Factory
+    interface Factory {
+      ConcreteModuleThatCouldBeAbstractWithFactoryParameterComponent create(
+          ConcreteModuleThatCouldBeAbstract module);
+    }
+  }
+
+  @Test
+  public void concreteModuleThatCouldBeAbstract_withFactoryParameter() {
+    ConcreteModuleThatCouldBeAbstractWithFactoryParameterComponent component =
+        DaggerFactoryImplicitModulesTest_ConcreteModuleThatCouldBeAbstractWithFactoryParameterComponent
+            .factory()
+            .create(new ConcreteModuleThatCouldBeAbstract());
+    assertThat(component.getDouble()).isEqualTo(42.0);
+  }
+
+  @Test
+  public void concreteModuleThatCouldBeAbstract_withFactoryParameter_doesNotFailOnNull() {
+    // TODO(cgdecker): Is this really what we want to happen?
+    // Builders allow there to be a setter for such a module; the setter checks that the argument
+    // is not null but otherwise ignores it. If nothing else, we should probably throw if the arg
+    // is null. But it's not clear to me that we should even allow such a parameter for a factory,
+    // since unlike a builder, where the setter can just not be called, a factory doesn't give the
+    // option of not passing *something* for the unused parameter.
+    ConcreteModuleThatCouldBeAbstractWithFactoryParameterComponent component =
+        DaggerFactoryImplicitModulesTest_ConcreteModuleThatCouldBeAbstractWithFactoryParameterComponent
+            .factory()
+            .create(null); // the parameter is unused and therefore not checked
+    assertThat(component.getDouble()).isEqualTo(42.0);
+  }
+}

--- a/javatests/dagger/functional/factory/FactoryImplicitModulesTest.java
+++ b/javatests/dagger/functional/factory/FactoryImplicitModulesTest.java
@@ -136,17 +136,19 @@ public final class FactoryImplicitModulesTest {
   }
 
   @Test
-  public void concreteModuleThatCouldBeAbstract_withFactoryParameter_doesNotFailOnNull() {
-    // TODO(cgdecker): Is this really what we want to happen?
-    // Builders allow there to be a setter for such a module; the setter checks that the argument
-    // is not null but otherwise ignores it. If nothing else, we should probably throw if the arg
-    // is null. But it's not clear to me that we should even allow such a parameter for a factory,
-    // since unlike a builder, where the setter can just not be called, a factory doesn't give the
-    // option of not passing *something* for the unused parameter.
-    ConcreteModuleThatCouldBeAbstractWithFactoryParameterComponent component =
-        DaggerFactoryImplicitModulesTest_ConcreteModuleThatCouldBeAbstractWithFactoryParameterComponent
-            .factory()
-            .create(null); // the parameter is unused and therefore not checked
-    assertThat(component.getDouble()).isEqualTo(42.0);
+  public void concreteModuleThatCouldBeAbstract_withFactoryParameter_failsOnNull() {
+    // This matches what builders do when there's a setter for such a module; the setter checks that
+    // the argument is not null but otherwise ignores it.
+    // It's possible that we shouldn't even allow such a parameter for a factory, since unlike a
+    // builder, where the setter can just not be called, a factory doesn't give the option of not
+    // passing *something* for the unused parameter.
+    try {
+      ConcreteModuleThatCouldBeAbstractWithFactoryParameterComponent component =
+          DaggerFactoryImplicitModulesTest_ConcreteModuleThatCouldBeAbstractWithFactoryParameterComponent
+              .factory()
+              .create(null);
+      fail();
+    } catch (NullPointerException expected) {
+    }
   }
 }

--- a/javatests/dagger/functional/factory/FactoryMixedParametersTest.java
+++ b/javatests/dagger/functional/factory/FactoryMixedParametersTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.factory;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import dagger.BindsInstance;
+import dagger.Component;
+import java.util.Random;
+import javax.inject.Provider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for component factories with multiple parameters. */
+@RunWith(JUnit4.class)
+public final class FactoryMixedParametersTest {
+
+  @Component(
+      modules = {
+        AbstractModule.class,
+        UninstantiableConcreteModule.class,
+        InstantiableConcreteModule.class
+      },
+      dependencies = Dependency.class)
+  interface MixedArgComponent {
+    String string();
+    int getInt();
+    long getLong();
+    Object object();
+    double getDouble();
+    Provider<Random> randomProvider();
+
+    @Component.Factory
+    interface Factory {
+      MixedArgComponent create(
+          @BindsInstance double d,
+          Dependency dependency,
+          UninstantiableConcreteModule module,
+          @BindsInstance Random random);
+    }
+  }
+
+  @Test
+  public void mixedArgComponent() {
+    Random random = new Random();
+    MixedArgComponent component =
+        DaggerFactoryMixedParametersTest_MixedArgComponent.factory()
+            .create(3.0, new Dependency(), new UninstantiableConcreteModule(2L), random);
+    assertThat(component.string()).isEqualTo("foo");
+    assertThat(component.getInt()).isEqualTo(42);
+    assertThat(component.getDouble()).isEqualTo(3.0);
+    assertThat(component.object()).isEqualTo("bar");
+    assertThat(component.getLong()).isEqualTo(2L);
+    assertThat(component.randomProvider().get()).isSameAs(random);
+    assertThat(component.randomProvider().get()).isSameAs(random);
+  }
+}

--- a/javatests/dagger/functional/factory/FactoryRequiredModulesTest.java
+++ b/javatests/dagger/functional/factory/FactoryRequiredModulesTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.factory;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import dagger.Component;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for factories for components that have a module that must have an instance provided by the
+ * user.
+ */
+@RunWith(JUnit4.class)
+public final class FactoryRequiredModulesTest {
+
+  @Component(modules = UninstantiableConcreteModule.class)
+  interface UninstantiableConcreteModuleComponent {
+    long getLong();
+
+    @Component.Factory
+    interface Factory {
+      UninstantiableConcreteModuleComponent create(UninstantiableConcreteModule module);
+    }
+  }
+
+  @Test
+  public void uninstantiableConcreteModule() {
+    UninstantiableConcreteModuleComponent component =
+        DaggerFactoryRequiredModulesTest_UninstantiableConcreteModuleComponent.factory()
+            .create(new UninstantiableConcreteModule(42L));
+    assertThat(component.getLong()).isEqualTo(42L);
+  }
+
+  @Test
+  public void uninstantiableConcreteModule_failsOnNull() {
+    try {
+      DaggerFactoryRequiredModulesTest_UninstantiableConcreteModuleComponent.factory().create(null);
+      fail();
+    } catch (NullPointerException expected) {
+    }
+  }
+}

--- a/javatests/dagger/functional/factory/InstantiableConcreteModule.java
+++ b/javatests/dagger/functional/factory/InstantiableConcreteModule.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.factory;
+
+import dagger.Module;
+import dagger.Provides;
+
+@SuppressWarnings("StaticModuleMethods") // intentionally non-static
+@Module
+final class InstantiableConcreteModule {
+  @Provides
+  int provideInt() {
+    return 42;
+  }
+}

--- a/javatests/dagger/functional/factory/SubcomponentFactoryTest.java
+++ b/javatests/dagger/functional/factory/SubcomponentFactoryTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.factory;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import dagger.BindsInstance;
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+import dagger.Subcomponent;
+import javax.inject.Inject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@linkplain Subcomponent.Factory subcomponent factories}.
+ *
+ * <p>Most things are tested in {@code FactoryTest}; this is just intended to test some things like
+ * injecting subcomponent factories and returning them from component methods.
+ */
+@RunWith(JUnit4.class)
+public final class SubcomponentFactoryTest {
+
+  @Component
+  interface ParentWithSubcomponentFactory {
+    Sub.Factory subcomponentFactory();
+
+    @Component.Factory
+    interface Factory {
+      ParentWithSubcomponentFactory create(@BindsInstance int i);
+    }
+  }
+
+  @Subcomponent
+  interface Sub {
+    int i();
+    String s();
+
+    @Subcomponent.Factory
+    interface Factory {
+      Sub create(@BindsInstance String s);
+    }
+  }
+
+  @Test
+  public void parentComponentWithSubcomponentFactoryEntryPoint() {
+    ParentWithSubcomponentFactory parent =
+        DaggerSubcomponentFactoryTest_ParentWithSubcomponentFactory.factory().create(3);
+    Sub subcomponent = parent.subcomponentFactory().create("foo");
+    assertThat(subcomponent.i()).isEqualTo(3);
+    assertThat(subcomponent.s()).isEqualTo("foo");
+  }
+
+  @Module(subcomponents = Sub.class)
+  abstract static class ModuleWithSubcomponent {
+    @Provides
+    static int provideInt() {
+      return 42;
+    }
+  }
+
+  static class UsesSubcomponentFactory {
+    private final Sub.Factory subFactory;
+
+    @Inject
+    UsesSubcomponentFactory(Sub.Factory subFactory) {
+      this.subFactory = subFactory;
+    }
+
+    Sub getSubcomponent(String s) {
+      return subFactory.create(s);
+    }
+  }
+
+  @Component(modules = ModuleWithSubcomponent.class)
+  interface ParentWithModuleWithSubcomponent {
+    UsesSubcomponentFactory usesSubcomponentFactory();
+  }
+
+  @Test
+  public void parentComponentWithModuleWithSubcomponent() {
+    ParentWithModuleWithSubcomponent parent =
+        DaggerSubcomponentFactoryTest_ParentWithModuleWithSubcomponent.create();
+    UsesSubcomponentFactory usesSubcomponentFactory = parent.usesSubcomponentFactory();
+
+    Sub subcomponent1 = usesSubcomponentFactory.getSubcomponent("foo");
+    assertThat(subcomponent1.i()).isEqualTo(42);
+    assertThat(subcomponent1.s()).isEqualTo("foo");
+
+    Sub subcomponent2 = usesSubcomponentFactory.getSubcomponent("bar");
+    assertThat(subcomponent2.i()).isEqualTo(42);
+    assertThat(subcomponent2.s()).isEqualTo("bar");
+  }
+}

--- a/javatests/dagger/functional/factory/UninstantiableConcreteModule.java
+++ b/javatests/dagger/functional/factory/UninstantiableConcreteModule.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.factory;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+final class UninstantiableConcreteModule {
+  private final long l;
+
+  UninstantiableConcreteModule(long l) {
+    this.l = l;
+  }
+
+  @Provides
+  long provideLong() {
+    return l;
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make the values of ComponentImplementation.multibindingContributionsMade Keys instead of DependencyRequests. This will help a later CL that attempts to serialize aspects of the ComponentImplementation, as it's easier to (de)serialize a Key than a full DependencyRequest.

ef9ca5191c868b6370ee94601cd33f5bda8e62f2

-------

<p> Add some functional tests for factories and fix a few issues:

- Don't use presence of a creator implementation or base creator implementation as a proxy for "has a creator", because factories and builders with no fields no longer have a base creator implementation. Use whether the descriptor says it has a creator or not instead.
- Add handling for factory parameters for framework field naming.

a553efce735080f24438933aae592d7080eb2e37

-------

<p> Track reimplemented methods in ModifiableBindingMethods too

This fixes a bug whereby we never recorded modifiable binding type state changes, and we'd continue reimplementing methods based on their initial type

In the process, simplify ModifiableBindingMethods a bit

28afaddfd6c9569541e556fbc2799fb7ea84ccde

-------

<p> Separate out the AOT logic from addInterfaceMethods so that it's clear what happens when AOT is not on. It wasn't clear to me what happened in that case, and you have to parse AOT logic to understand it.

d2a33c29143e1641a0597d16a8b8753e52299815

-------

<p> Ensure that all parameters to a factory method (other than nullable @BindsInstance parameters) are required to be non-null, even if the parameter is for a module that isn't required/used when constructing the component.

1c3d9935dffcae4bcda683a06be370501a7af8d0