### PR TITLE
Removed obsolete field (Android)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ dependencies {
 ```groovy
 // Add Dagger dependencies
 dependencies {
-  compile 'com.google.dagger:dagger:2.x'
+  implementation 'com.google.dagger:dagger:2.x'
   annotationProcessor 'com.google.dagger:dagger-compiler:2.x'
 }
 ```


### PR DESCRIPTION
'compile' is obsolete and must be replaced by 'implementation'.