### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/android/AndroidInjector.java
+++ b/java/dagger/android/AndroidInjector.java
@@ -25,11 +25,12 @@ import dagger.internal.Beta;
  * android.app.Activity} or {@link android.app.Fragment}).
  *
  * <p>Commonly implemented by {@link dagger.Subcomponent}-annotated types whose {@link
- * dagger.Subcomponent.Builder} extends {@link Builder}.
+ * dagger.Subcomponent.Factory} extends {@link Factory}.
  *
  * @param <T> a concrete subtype of a core Android type
  * @see AndroidInjection
  * @see DispatchingAndroidInjector
+ * @see ContributesAndroidInjector
  */
 @Beta
 public interface AndroidInjector<T> {
@@ -47,7 +48,7 @@ public interface AndroidInjector<T> {
      * Creates an {@link AndroidInjector} for {@code instance}. This should be the same instance
      * that will be passed to {@link #inject(Object)}.
      */
-    AndroidInjector<T> create(T instance);
+    AndroidInjector<T> create(@BindsInstance T instance);
   }
 
   /**
@@ -55,7 +56,10 @@ public interface AndroidInjector<T> {
    * Factory}.
    *
    * @param <T> the concrete type to be injected
+   * @deprecated Prefer {@link Factory} now that components can have {@link dagger.Component.Factory
+   *     factories} instead of builders
    */
+  @Deprecated
   abstract class Builder<T> implements AndroidInjector.Factory<T> {
     @Override
     public final AndroidInjector<T> create(T instance) {

--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -39,6 +39,7 @@ CODEGEN_SHARED_DEPS = [
     "@google_bazel_common//third_party/java/auto:service",
     "@google_bazel_common//third_party/java/auto:value",
     "@google_bazel_common//third_party/java/auto:common",
+    "@google_bazel_common//third_party/java/checker_framework_annotations",
     "@google_bazel_common//third_party/java/error_prone:annotations",
     "@google_bazel_common//third_party/java/google_java_format",
     "@google_bazel_common//third_party/java/javapoet",

--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -412,10 +412,10 @@ java_library(
     ],
 )
 
-# A _deploy.jar consisting of the java_librarys in https://github.com/google/kythe needed to build a
+# A _deploy.jar consisting of the java_librarys in https://github.com/kythe/kythe needed to build a
 # Kythe plugin
 # TODO(ronshapiro): replace this with a http_archive of the next release in
-# https://github.com/google/kythe/releases
+# https://github.com/kythe/kythe/releases
 java_import(
     name = "kythe_plugin",
     jars = ["kythe_plugin_deploy.jar"],

--- a/java/dagger/internal/codegen/BindsMethodValidator.java
+++ b/java/dagger/internal/codegen/BindsMethodValidator.java
@@ -18,6 +18,7 @@ package dagger.internal.codegen;
 
 import static dagger.internal.codegen.BindingMethodValidator.Abstractness.MUST_BE_ABSTRACT;
 import static dagger.internal.codegen.BindingMethodValidator.AllowsMultibindings.ALLOWS_MULTIBINDINGS;
+import static dagger.internal.codegen.BindingMethodValidator.AllowsScoping.ALLOWS_SCOPING;
 import static dagger.internal.codegen.BindingMethodValidator.ExceptionSuperclass.RUNTIME_EXCEPTION;
 
 import com.google.auto.common.MoreTypes;
@@ -50,7 +51,8 @@ final class BindsMethodValidator extends BindingMethodValidator {
         dependencyRequestValidator,
         MUST_BE_ABSTRACT,
         RUNTIME_EXCEPTION,
-        ALLOWS_MULTIBINDINGS);
+        ALLOWS_MULTIBINDINGS,
+        ALLOWS_SCOPING);
     this.types = types;
     this.bindsTypeChecker = new BindsTypeChecker(types, elements);
   }

--- a/java/dagger/internal/codegen/BindsOptionalOfMethodValidator.java
+++ b/java/dagger/internal/codegen/BindsOptionalOfMethodValidator.java
@@ -18,18 +18,17 @@ package dagger.internal.codegen;
 
 import static dagger.internal.codegen.BindingMethodValidator.Abstractness.MUST_BE_ABSTRACT;
 import static dagger.internal.codegen.BindingMethodValidator.AllowsMultibindings.NO_MULTIBINDINGS;
+import static dagger.internal.codegen.BindingMethodValidator.AllowsScoping.NO_SCOPING;
 import static dagger.internal.codegen.BindingMethodValidator.ExceptionSuperclass.NO_EXCEPTIONS;
 import static dagger.internal.codegen.InjectionAnnotations.getQualifiers;
 import static dagger.internal.codegen.InjectionAnnotations.injectedConstructors;
 import static dagger.internal.codegen.Keys.isValidImplicitProvisionKey;
-import static dagger.internal.codegen.Scopes.scopesOf;
 
 import com.google.auto.common.MoreElements;
 import com.google.auto.common.MoreTypes;
 import com.google.common.collect.ImmutableSet;
 import dagger.BindsOptionalOf;
 import dagger.Module;
-import dagger.model.Scope;
 import dagger.producers.ProducerModule;
 import javax.inject.Inject;
 import javax.lang.model.element.ExecutableElement;
@@ -53,7 +52,8 @@ final class BindsOptionalOfMethodValidator extends BindingMethodValidator {
         dependencyRequestValidator,
         MUST_BE_ABSTRACT,
         NO_EXCEPTIONS,
-        NO_MULTIBINDINGS);
+        NO_MULTIBINDINGS,
+        NO_SCOPING);
     this.types = types;
   }
 
@@ -81,16 +81,6 @@ final class BindsOptionalOfMethodValidator extends BindingMethodValidator {
   protected void checkParameters(ValidationReport.Builder<ExecutableElement> builder) {
     if (!builder.getSubject().getParameters().isEmpty()) {
       builder.addError("@BindsOptionalOf methods cannot have parameters");
-    }
-  }
-
-  @Override
-  protected void checkScopes(ValidationReport.Builder<ExecutableElement> builder) {
-    for (Scope scope : scopesOf(builder.getSubject())) {
-      builder.addError(
-          "@BindsOptionalOf methods cannot be scoped",
-          builder.getSubject(),
-          scope.scopeAnnotation());
     }
   }
 }

--- a/java/dagger/internal/codegen/ComponentCreatorDescriptor.java
+++ b/java/dagger/internal/codegen/ComponentCreatorDescriptor.java
@@ -208,10 +208,7 @@ abstract class ComponentCreatorDescriptor {
           dependencyRequestFactory.forRequiredResolvedVariable(parameter, type);
       // Validation already ensured that only setter methods have @BindsInstance, so name the
       // variable for the method in that case. Otherwise, name the variable for the parameter.
-      String variableName =
-          methodIsBindsInstance
-              ? method.getSimpleName().toString()
-              : parameter.getSimpleName().toString();
+      String variableName = (methodIsBindsInstance ? method : parameter).getSimpleName().toString();
       return ComponentRequirement.forBoundInstance(
           request.key(), request.isNullable(), variableName);
     }

--- a/java/dagger/internal/codegen/ComponentImplementation.java
+++ b/java/dagger/internal/codegen/ComponentImplementation.java
@@ -307,17 +307,20 @@ final class ComponentImplementation {
   }
 
   /**
-   * The possible requirements for creating an instance of this component implementation type.
+   * The requirements for creating an instance of this component implementation type.
    *
    * <p>If this component implementation is concrete, these requirements will be in the order that
    * the implementation's constructor takes them as parameters.
    */
   ImmutableSet<ComponentRequirement> requirements() {
     // If the base implementation's creator is being generated in ahead-of-time-subcomponents
-    // mode, this uses possiblyNecessaryRequirements() since Dagger doesn't know what modules may
-    // end up being unused. Otherwise, we use the necessary component requirements.
+    // mode, this uses the ComponentDescriptor's requirements() since Dagger doesn't know what
+    // modules may end being unused or owned by an ancestor component. Otherwise, we use the
+    // necessary component requirements.
+    // TODO(ronshapiro): can we remove the second condition here? Or, is it never going to be
+    // called, so we should enforce that invariant?
     return isAbstract() && !superclassImplementation().isPresent()
-        ? graph().possiblyNecessaryRequirements()
+        ? componentDescriptor().requirements()
         : graph().componentRequirements();
   }
 

--- a/java/dagger/internal/codegen/ComponentImplementation.java
+++ b/java/dagger/internal/codegen/ComponentImplementation.java
@@ -67,8 +67,6 @@ import javax.lang.model.type.TypeMirror;
 /** The implementation of a component type. */
 final class ComponentImplementation {
   /** A type of field that this component can contain. */
-  // TODO(user, dpb): Move component requirements and reference managers to top? The order should
-  // be component requirements, reference managers, framework fields, private method fields, ... etc
   enum FieldSpecKind {
 
     /** A field required by the component, e.g. module instances. */

--- a/java/dagger/internal/codegen/ComponentImplementationBuilder.java
+++ b/java/dagger/internal/codegen/ComponentImplementationBuilder.java
@@ -364,8 +364,7 @@ abstract class ComponentImplementationBuilder {
 
   /** Creates an inner abstract subcomponent implementation. */
   private ComponentImplementation abstractInnerSubcomponent(BindingGraph childGraph) {
-    return new ComponentImplementation(
-        componentImplementation,
+    return componentImplementation.childComponentImplementation(
         childGraph,
         Optional.of(
             componentImplementationFactory.findChildSuperclassImplementation(
@@ -376,8 +375,7 @@ abstract class ComponentImplementationBuilder {
 
   /** Creates a concrete inner subcomponent implementation. */
   private ComponentImplementation concreteSubcomponent(BindingGraph childGraph) {
-    return new ComponentImplementation(
-        componentImplementation,
+    return componentImplementation.childComponentImplementation(
         childGraph,
         Optional.empty(), // superclassImplementation
         PRIVATE,

--- a/java/dagger/internal/codegen/ComponentImplementationBuilder.java
+++ b/java/dagger/internal/codegen/ComponentImplementationBuilder.java
@@ -115,7 +115,8 @@ abstract class ComponentImplementationBuilder {
         componentImplementation.name());
     setSupertype();
     componentImplementation.setCreatorImplementation(
-        componentCreatorImplementationFactory.create(componentImplementation));
+        componentCreatorImplementationFactory.create(
+            componentImplementation, componentImplementation.graph()));
     componentImplementation
         .creatorImplementation()
         .map(ComponentCreatorImplementation::spec)

--- a/java/dagger/internal/codegen/ComponentImplementationFactory.java
+++ b/java/dagger/internal/codegen/ComponentImplementationFactory.java
@@ -19,17 +19,12 @@ package dagger.internal.codegen;
 import static com.google.common.base.Preconditions.checkState;
 import static dagger.internal.codegen.ComponentGenerator.componentName;
 import static dagger.internal.codegen.Util.reentrantComputeIfAbsent;
-import static javax.lang.model.element.Modifier.ABSTRACT;
-import static javax.lang.model.element.Modifier.FINAL;
-import static javax.lang.model.element.Modifier.PUBLIC;
 
-import com.squareup.javapoet.ClassName;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import javax.lang.model.element.NestingKind;
 import javax.lang.model.element.TypeElement;
 
 /** Factory for {@link ComponentImplementation}s. */
@@ -68,7 +63,10 @@ final class ComponentImplementationFactory implements ClearableCache {
 
   private ComponentImplementation createComponentImplementationUncached(BindingGraph bindingGraph) {
     ComponentImplementation componentImplementation =
-        topLevelImplementation(componentName(bindingGraph.componentTypeElement()), bindingGraph);
+        ComponentImplementation.topLevelComponentImplementation(
+            bindingGraph,
+            componentName(bindingGraph.componentTypeElement()),
+            new SubcomponentNames(bindingGraph, keyFactory));
     // TODO(dpb): explore using optional bindings for the "parent" bindings
     CurrentImplementationSubcomponent currentImplementationSubcomponent =
         topLevelImplementationComponentBuilder
@@ -92,18 +90,6 @@ final class ComponentImplementationFactory implements ClearableCache {
     } else {
       return currentImplementationSubcomponent.rootComponentBuilder().build();
     }
-  }
-
-  /** Creates a root component or top-level abstract subcomponent implementation. */
-  ComponentImplementation topLevelImplementation(ClassName name, BindingGraph graph) {
-    return new ComponentImplementation(
-        graph,
-        name,
-        NestingKind.TOP_LEVEL,
-        Optional.empty(), // superclassImplementation
-        new SubcomponentNames(graph, keyFactory),
-        PUBLIC,
-        graph.componentDescriptor().isSubcomponent() ? ABSTRACT : FINAL);
   }
 
   /** Returns the superclass of the child nested within a superclass of the parent component. */

--- a/java/dagger/internal/codegen/DiagnosticReporterFactory.java
+++ b/java/dagger/internal/codegen/DiagnosticReporterFactory.java
@@ -68,6 +68,7 @@ import javax.inject.Inject;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** A factory for {@link DiagnosticReporter}s. */
 // TODO(ronshapiro): If multiple plugins print errors on the same node/edge, should we condense the
@@ -229,7 +230,9 @@ final class DiagnosticReporterFactory {
     }
 
     void printMessage(
-        Diagnostic.Kind diagnosticKind, CharSequence message, Element elementToReport) {
+        Diagnostic.Kind diagnosticKind,
+        CharSequence message,
+        @NullableDecl Element elementToReport) {
       if (graph.isModuleBindingGraph()) {
         if (compilerOptions.moduleBindingValidationType().equals(NONE)) {
           return;
@@ -244,7 +247,7 @@ final class DiagnosticReporterFactory {
 
       // TODO(ronshapiro): should we create a HashSet out of elementEncloses() so we don't
       // need to do an O(n) contains() each time?
-      if (!elementEncloses(rootComponent, elementToReport)) {
+      if (elementToReport != null && !elementEncloses(rootComponent, elementToReport)) {
         appendBracketPrefix(fullMessage, elementToString(elementToReport));
         elementToReport = rootComponent;
       }

--- a/java/dagger/internal/codegen/ModifiableBindingExpressions.java
+++ b/java/dagger/internal/codegen/ModifiableBindingExpressions.java
@@ -382,12 +382,7 @@ final class ModifiableBindingExpressions {
           // if the binding is modifiable and is resolved as a provision binding in a superclass
           // but later resolved as a production binding, we can't take the same shortcut as before.
           if (componentImplementation.superclassImplementation().isPresent()) {
-            BindingGraph superclassGraph =
-                componentImplementation.superclassImplementation().get().graph();
-            ResolvedBindings superclassBindings = superclassGraph.resolvedBindings(request);
-            return superclassBindings != null
-                && resolvedBindings != null
-                && !superclassBindings.bindingType().equals(resolvedBindings.bindingType());
+            return bindingTypeChanged(request, resolvedBindings);
           }
           return false;
 
@@ -458,6 +453,19 @@ final class ModifiableBindingExpressions {
                 "Overriding modifiable binding method with unsupported ModifiableBindingType [%s].",
                 modifiableBindingType));
     }
+  }
+
+  /**
+   * Returns {@code true} if the {@link BindingType} for {@code request} is not the same in this
+   * implementation and it's superclass implementation.
+   */
+  private boolean bindingTypeChanged(BindingRequest request, ResolvedBindings resolvedBindings) {
+    BindingGraph superclassGraph =
+        componentImplementation.superclassImplementation().get().graph();
+    ResolvedBindings superclassBindings = superclassGraph.resolvedBindings(request);
+    return superclassBindings != null
+        && resolvedBindings != null
+        && !superclassBindings.bindingType().equals(resolvedBindings.bindingType());
   }
 
   /**

--- a/java/dagger/internal/codegen/ModuleKind.java
+++ b/java/dagger/internal/codegen/ModuleKind.java
@@ -99,13 +99,6 @@ enum ModuleKind {
     return moduleAnnotation;
   }
 
-  /** Returns the annotation for binding methods on this type of module. */
-  // TODO(cgdecker): Validate how this is used... is it really correct? Producer modules can also
-  // have @Provides methods.
-  Class<? extends Annotation> methodAnnotation() {
-    return methodAnnotation;
-  }
-
   /** Returns the kinds of modules that a module of this kind is allowed to include. */
   ImmutableSet<ModuleKind> legalIncludedModuleKinds() {
     switch (this) {

--- a/java/dagger/internal/codegen/MultibindsMethodValidator.java
+++ b/java/dagger/internal/codegen/MultibindsMethodValidator.java
@@ -18,6 +18,7 @@ package dagger.internal.codegen;
 
 import static dagger.internal.codegen.BindingMethodValidator.Abstractness.MUST_BE_ABSTRACT;
 import static dagger.internal.codegen.BindingMethodValidator.AllowsMultibindings.NO_MULTIBINDINGS;
+import static dagger.internal.codegen.BindingMethodValidator.AllowsScoping.NO_SCOPING;
 import static dagger.internal.codegen.BindingMethodValidator.ExceptionSuperclass.NO_EXCEPTIONS;
 import static dagger.internal.codegen.FrameworkTypes.isFrameworkType;
 
@@ -47,9 +48,10 @@ class MultibindsMethodValidator extends BindingMethodValidator {
         dependencyRequestValidator,
         MUST_BE_ABSTRACT,
         NO_EXCEPTIONS,
-        NO_MULTIBINDINGS);
+        NO_MULTIBINDINGS,
+        NO_SCOPING);
   }
-  
+
   @Override
   protected void checkMethod(ValidationReport.Builder<ExecutableElement> builder) {
     super.checkMethod(builder);

--- a/java/dagger/internal/codegen/ProducesMethodValidator.java
+++ b/java/dagger/internal/codegen/ProducesMethodValidator.java
@@ -19,8 +19,8 @@ package dagger.internal.codegen;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static dagger.internal.codegen.BindingMethodValidator.Abstractness.MUST_BE_CONCRETE;
 import static dagger.internal.codegen.BindingMethodValidator.AllowsMultibindings.ALLOWS_MULTIBINDINGS;
+import static dagger.internal.codegen.BindingMethodValidator.AllowsScoping.NO_SCOPING;
 import static dagger.internal.codegen.BindingMethodValidator.ExceptionSuperclass.EXCEPTION;
-import static dagger.internal.codegen.Scopes.scopesOf;
 
 import com.google.auto.common.MoreTypes;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -52,9 +52,10 @@ final class ProducesMethodValidator extends BindingMethodValidator {
         ProducerModule.class,
         MUST_BE_CONCRETE,
         EXCEPTION,
-        ALLOWS_MULTIBINDINGS);
+        ALLOWS_MULTIBINDINGS,
+        NO_SCOPING);
   }
-  
+
   @Override
   protected void checkMethod(ValidationReport.Builder<ExecutableElement> builder) {
     super.checkMethod(builder);
@@ -66,14 +67,6 @@ final class ProducesMethodValidator extends BindingMethodValidator {
   private void checkNullable(ValidationReport.Builder<ExecutableElement> builder) {
     if (ConfigurationAnnotations.getNullableType(builder.getSubject()).isPresent()) {
       builder.addWarning("@Nullable on @Produces methods does not do anything");
-    }
-  }
-
-  /** Adds an error if a {@link Produces @Produces} method has a scope annotation. */
-  @Override
-  protected void checkScopes(ValidationReport.Builder<ExecutableElement> builder) {
-    if (!scopesOf(builder.getSubject()).isEmpty()) {
-      builder.addError("@Produces methods may not have scope annotations");
     }
   }
 

--- a/java/dagger/internal/codegen/ProvidesMethodValidator.java
+++ b/java/dagger/internal/codegen/ProvidesMethodValidator.java
@@ -18,6 +18,7 @@ package dagger.internal.codegen;
 
 import static dagger.internal.codegen.BindingMethodValidator.Abstractness.MUST_BE_CONCRETE;
 import static dagger.internal.codegen.BindingMethodValidator.AllowsMultibindings.ALLOWS_MULTIBINDINGS;
+import static dagger.internal.codegen.BindingMethodValidator.AllowsScoping.ALLOWS_SCOPING;
 import static dagger.internal.codegen.BindingMethodValidator.ExceptionSuperclass.RUNTIME_EXCEPTION;
 
 import com.google.common.collect.ImmutableSet;
@@ -48,7 +49,8 @@ final class ProvidesMethodValidator extends BindingMethodValidator {
         dependencyRequestValidator,
         MUST_BE_CONCRETE,
         RUNTIME_EXCEPTION,
-        ALLOWS_MULTIBINDINGS);
+        ALLOWS_MULTIBINDINGS,
+        ALLOWS_SCOPING);
     this.dependencyRequestValidator = dependencyRequestValidator;
   }
 

--- a/java/dagger/spi/BUILD
+++ b/java/dagger/spi/BUILD
@@ -28,7 +28,7 @@ filegroup(
     srcs = glob(["*.java"]),
 )
 
-load("//tools:maven.bzl", "pom_file", "POM_VERSION")
+load("//tools:maven.bzl", "POM_VERSION", "pom_file")
 
 java_library(
     name = "spi",

--- a/javatests/dagger/functional/modules/ModuleIncludesTest.java
+++ b/javatests/dagger/functional/modules/ModuleIncludesTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.modules;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import dagger.Component;
+import dagger.functional.modules.subpackage.PublicModule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class ModuleIncludesTest {
+
+  @Component(modules = PublicModule.class)
+  interface TestComponent {
+    Object object();
+  }
+
+  @Test
+  public void publicModuleIncludingPackagePrivateModuleThatDoesNotRequireInstance() {
+    TestComponent component = DaggerModuleIncludesTest_TestComponent.create();
+    assertThat(component.object()).isEqualTo("foo42");
+  }
+}

--- a/javatests/dagger/functional/modules/subpackage/PackagePrivateModule.java
+++ b/javatests/dagger/functional/modules/subpackage/PackagePrivateModule.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.modules.subpackage;
+
+import dagger.Binds;
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+abstract class PackagePrivateModule {
+  @Binds
+  abstract Object bindObject(String string);
+
+  @Provides
+  static String provideString(int i) {
+    return "foo" + i;
+  }
+}

--- a/javatests/dagger/functional/modules/subpackage/PublicModule.java
+++ b/javatests/dagger/functional/modules/subpackage/PublicModule.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.modules.subpackage;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module(includes = PackagePrivateModule.class)
+public abstract class PublicModule {
+  @Provides
+  static int provideInt() {
+    return 42;
+  }
+}

--- a/javatests/dagger/internal/codegen/AheadOfTimeSubcomponentsTest.java
+++ b/javatests/dagger/internal/codegen/AheadOfTimeSubcomponentsTest.java
@@ -4812,11 +4812,11 @@ public final class AheadOfTimeSubcomponentsTest {
 
   /**
    * This tests a regression case where the component builder in the base implementation used one
-   * set of disambiguated names from all of the {@link
-   * BindingGraph#possiblyNecessaryRequirements()}, and the final implementation used a different
-   * set of disambiguated names from the resolved {@link BindingGraph#componentRequirements()}. This
-   * resulted in generated output that didn't compile, as the builder implementation attempted to
-   * use the new names in validation, which didn't line up with the old names.
+   * set of disambiguated names from all of the {@link ComponentDescriptor#requirements()}, and the
+   * final implementation used a different set of disambiguated names from the resolved {@link
+   * BindingGraph#componentRequirements()}. This resulted in generated output that didn't compile,
+   * as the builder implementation attempted to use the new names in validation, which didn't line
+   * up with the old names.
    */
   @Test
   public void componentBuilderFields_consistencyAcrossImplementations() {

--- a/javatests/dagger/internal/codegen/ModuleFactoryGeneratorTest.java
+++ b/javatests/dagger/internal/codegen/ModuleFactoryGeneratorTest.java
@@ -46,89 +46,77 @@ public class ModuleFactoryGeneratorTest {
   // TODO(gak): add tests for invalid combinations of scope and qualifier annotations like we have
   // for @Inject
 
-  private String formatErrorMessage(String msg) {
-    return String.format(msg, "Provides");
-  }
-
-  private String formatModuleErrorMessage(String msg) {
-    return String.format(msg, "Provides", "Module");
-  }
-
   @Test public void providesMethodNotInModule() {
     assertThatMethodInUnannotatedClass("@Provides String provideString() { return null; }")
-        .hasError(formatModuleErrorMessage("@%s methods can only be present within a @%s"));
+        .hasError("@Provides methods can only be present within a @Module or @ProducerModule");
   }
 
   @Test public void providesMethodAbstract() {
     assertThatModuleMethod("@Provides abstract String abstractMethod();")
-        .hasError(formatErrorMessage("@%s methods cannot be abstract"));
+        .hasError("@Provides methods cannot be abstract");
   }
 
   @Test public void providesMethodPrivate() {
     assertThatModuleMethod("@Provides private String privateMethod() { return null; }")
-        .hasError(formatErrorMessage("@%s methods cannot be private"));
+        .hasError("@Provides methods cannot be private");
   }
 
   @Test public void providesMethodReturnVoid() {
     assertThatModuleMethod("@Provides void voidMethod() {}")
-        .hasError(formatErrorMessage("@%s methods must return a value (not void)"));
+        .hasError("@Provides methods must return a value (not void)");
   }
 
   @Test
   public void providesMethodReturnsProvider() {
     assertThatModuleMethod("@Provides Provider<String> provideProvider() {}")
-        .hasError(formatErrorMessage("@%s methods must not return framework types"));
+        .hasError("@Provides methods must not return framework types");
   }
 
   @Test
   public void providesMethodReturnsLazy() {
     assertThatModuleMethod("@Provides Lazy<String> provideLazy() {}")
-        .hasError(formatErrorMessage("@%s methods must not return framework types"));
+        .hasError("@Provides methods must not return framework types");
   }
 
   @Test
   public void providesMethodReturnsMembersInjector() {
     assertThatModuleMethod("@Provides MembersInjector<String> provideMembersInjector() {}")
-        .hasError(formatErrorMessage("@%s methods must not return framework types"));
+        .hasError("@Provides methods must not return framework types");
   }
 
   @Test
   public void providesMethodReturnsProducer() {
     assertThatModuleMethod("@Provides Producer<String> provideProducer() {}")
-        .hasError(formatErrorMessage("@%s methods must not return framework types"));
+        .hasError("@Provides methods must not return framework types");
   }
 
   @Test
   public void providesMethodReturnsProduced() {
     assertThatModuleMethod("@Provides Produced<String> provideProduced() {}")
-        .hasError(formatErrorMessage("@%s methods must not return framework types"));
+        .hasError("@Provides methods must not return framework types");
   }
 
   @Test public void providesMethodWithTypeParameter() {
     assertThatModuleMethod("@Provides <T> String typeParameter() { return null; }")
-        .hasError(formatErrorMessage("@%s methods may not have type parameters"));
+        .hasError("@Provides methods may not have type parameters");
   }
 
   @Test public void providesMethodSetValuesWildcard() {
     assertThatModuleMethod("@Provides @ElementsIntoSet Set<?> provideWildcard() { return null; }")
         .hasError(
-            formatErrorMessage(
-                "@%s methods must return a primitive, an array, a type variable, "
-                    + "or a declared type"));
+            "@Provides methods must return a primitive, an array, a type variable, "
+                + "or a declared type");
   }
 
   @Test public void providesMethodSetValuesRawSet() {
     assertThatModuleMethod("@Provides @ElementsIntoSet Set provideSomething() { return null; }")
-        .hasError(
-            formatErrorMessage(
-                "@%s methods annotated with @ElementsIntoSet cannot return a raw Set"));
+        .hasError("@Provides methods annotated with @ElementsIntoSet cannot return a raw Set");
   }
 
   @Test public void providesMethodSetValuesNotASet() {
     assertThatModuleMethod(
             "@Provides @ElementsIntoSet List<String> provideStrings() { return null; }")
-        .hasError(
-            formatErrorMessage("@%s methods annotated with @ElementsIntoSet must return a Set"));
+        .hasError("@Provides methods annotated with @ElementsIntoSet must return a Set");
   }
 
   @Test public void modulesWithTypeParamsMustBeAbstract() {
@@ -668,11 +656,11 @@ public class ModuleFactoryGeneratorTest {
     Compilation compilation = daggerCompiler().compile(moduleFile);
     assertThat(compilation).failed();
     assertThat(compilation)
-        .hadErrorContaining(formatErrorMessage("@%s methods may only throw unchecked exceptions"))
+        .hadErrorContaining("@Provides methods may only throw unchecked exceptions")
         .inFile(moduleFile)
         .onLine(8);
     assertThat(compilation)
-        .hadErrorContaining(formatErrorMessage("@%s methods may only throw unchecked exceptions"))
+        .hadErrorContaining("@Provides methods may only throw unchecked exceptions")
         .inFile(moduleFile)
         .onLine(12);
   }

--- a/javatests/dagger/internal/codegen/ModuleFactoryGeneratorTest.java
+++ b/javatests/dagger/internal/codegen/ModuleFactoryGeneratorTest.java
@@ -1338,11 +1338,11 @@ public class ModuleFactoryGeneratorTest {
     Compilation compilation = daggerCompiler().compile(moduleFile, SCOPE_A, SCOPE_B);
     assertThat(compilation).failed();
     assertThat(compilation)
-        .hadErrorContaining("Cannot use more than one @Scope")
+        .hadErrorContaining("cannot use more than one @Scope")
         .inFile(moduleFile)
         .onLineContaining("@ScopeA");
     assertThat(compilation)
-        .hadErrorContaining("Cannot use more than one @Scope")
+        .hadErrorContaining("cannot use more than one @Scope")
         .inFile(moduleFile)
         .onLineContaining("@ScopeB");
   }

--- a/javatests/dagger/internal/codegen/ModuleFactoryGeneratorTest.java
+++ b/javatests/dagger/internal/codegen/ModuleFactoryGeneratorTest.java
@@ -162,9 +162,8 @@ public class ModuleFactoryGeneratorTest {
         .withDeclaration("@Module class %s extends Parent { %s }")
         .withAdditionalSources(parent)
         .hasError(
-            String.format(
-                "@%s methods may not be overridden in modules. Overrides: %s",
-                "Provides", "@Provides String test.Parent.foo()"));
+            "Binding methods may not be overridden in modules. Overrides: "
+                + "@Provides String test.Parent.foo()");
   }
 
   @Test public void provideOverriddenByProvide() {
@@ -182,9 +181,8 @@ public class ModuleFactoryGeneratorTest {
         .withDeclaration("@Module class %s extends Parent { %s }")
         .withAdditionalSources(parent)
         .hasError(
-            String.format(
-                "@%s methods may not override another method. Overrides: %s",
-                "Provides", "@Provides String test.Parent.foo()"));
+            "Binding methods may not override another method. Overrides: "
+                + "@Provides String test.Parent.foo()");
   }
 
   @Test public void providesOverridesNonProvides() {
@@ -201,9 +199,8 @@ public class ModuleFactoryGeneratorTest {
         .withDeclaration("@Module class %s extends Parent { %s }")
         .withAdditionalSources(parent)
         .hasError(
-            String.format(
-                "@%s methods may not override another method. Overrides: %s",
-                "Provides", "String test.Parent.foo()"));
+            "Binding methods may not override another method. Overrides: "
+                + "String test.Parent.foo()");
   }
 
   @Test public void validatesIncludedModules() {
@@ -638,14 +635,12 @@ public class ModuleFactoryGeneratorTest {
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
-            formatErrorMessage(
-                "Cannot have more than one @%s method with the same name in a single module"))
+            "Cannot have more than one binding method with the same name in a single module")
         .inFile(moduleFile)
         .onLine(8);
     assertThat(compilation)
         .hadErrorContaining(
-            formatErrorMessage(
-                "Cannot have more than one @%s method with the same name in a single module"))
+            "Cannot have more than one binding method with the same name in a single module")
         .inFile(moduleFile)
         .onLine(12);
   }
@@ -1469,8 +1464,7 @@ public class ModuleFactoryGeneratorTest {
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
-            "A @Module may not contain both non-static @Provides methods and "
-                + "abstract @Binds or @Multibinds declarations");
+            "A @Module may not contain both non-static and abstract binding methods");
   }
 
   @Test
@@ -1479,8 +1473,7 @@ public class ModuleFactoryGeneratorTest {
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
-            "A @Module may not contain both non-static @Provides methods and "
-                + "abstract @Binds or @Multibinds declarations");
+            "A @Module may not contain both non-static and abstract binding methods");
   }
 
   @Test

--- a/javatests/dagger/internal/codegen/ProducerModuleFactoryGeneratorTest.java
+++ b/javatests/dagger/internal/codegen/ProducerModuleFactoryGeneratorTest.java
@@ -204,7 +204,7 @@ public class ProducerModuleFactoryGeneratorTest {
 
   @Test public void producesMethodWithScope() {
     assertThatProductionModuleMethod("@Produces @Singleton String str() { return \"\"; }")
-        .hasError("@Produces methods may not have scope annotations");
+        .hasError("@Produces methods cannot be scoped");
   }
 
   @Test

--- a/javatests/dagger/internal/codegen/ProducerModuleFactoryGeneratorTest.java
+++ b/javatests/dagger/internal/codegen/ProducerModuleFactoryGeneratorTest.java
@@ -40,63 +40,55 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ProducerModuleFactoryGeneratorTest {
 
-  private String formatErrorMessage(String msg) {
-    return String.format(msg, "Produces");
-  }
-
-  private String formatModuleErrorMessage(String msg) {
-    return String.format(msg, "Produces", "ProducerModule");
-  }
-
   @Test public void producesMethodNotInModule() {
     assertThatMethodInUnannotatedClass("@Produces String produceString() { return null; }")
-        .hasError(formatModuleErrorMessage("@%s methods can only be present within a @%s"));
+        .hasError("@Produces methods can only be present within a @ProducerModule");
   }
 
   @Test public void producesMethodAbstract() {
     assertThatProductionModuleMethod("@Produces abstract String produceString();")
-        .hasError(formatErrorMessage("@%s methods cannot be abstract"));
+        .hasError("@Produces methods cannot be abstract");
   }
 
   @Test public void producesMethodPrivate() {
     assertThatProductionModuleMethod("@Produces private String produceString() { return null; }")
-        .hasError(formatErrorMessage("@%s methods cannot be private"));
+        .hasError("@Produces methods cannot be private");
   }
 
   @Test public void producesMethodReturnVoid() {
     assertThatProductionModuleMethod("@Produces void produceNothing() {}")
-        .hasError(formatErrorMessage("@%s methods must return a value (not void)"));
+        .hasError("@Produces methods must return a value (not void)");
   }
 
   @Test
   public void producesProvider() {
     assertThatProductionModuleMethod("@Produces Provider<String> produceProvider() {}")
-        .hasError(formatErrorMessage("@%s methods must not return framework types"));
+        .hasError("@Produces methods must not return framework types");
   }
 
   @Test
   public void producesLazy() {
     assertThatProductionModuleMethod("@Produces Lazy<String> produceLazy() {}")
-        .hasError(formatErrorMessage("@%s methods must not return framework types"));
+        .hasError("@Produces methods must not return framework types");
   }
 
   @Test
   public void producesMembersInjector() {
     assertThatProductionModuleMethod(
             "@Produces MembersInjector<String> produceMembersInjector() {}")
-        .hasError(formatErrorMessage("@%s methods must not return framework types"));
+        .hasError("@Produces methods must not return framework types");
   }
 
   @Test
   public void producesProducer() {
     assertThatProductionModuleMethod("@Produces Producer<String> produceProducer() {}")
-        .hasError(formatErrorMessage("@%s methods must not return framework types"));
+        .hasError("@Produces methods must not return framework types");
   }
 
   @Test
   public void producesProduced() {
     assertThatProductionModuleMethod("@Produces Produced<String> produceProduced() {}")
-        .hasError(formatErrorMessage("@%s methods must not return framework types"));
+        .hasError("@Produces methods must not return framework types");
   }
 
   @Test public void producesMethodReturnRawFuture() {
@@ -115,7 +107,7 @@ public class ProducerModuleFactoryGeneratorTest {
 
   @Test public void producesMethodWithTypeParameter() {
     assertThatProductionModuleMethod("@Produces <T> String produceString() { return null; }")
-        .hasError(formatErrorMessage("@%s methods may not have type parameters"));
+        .hasError("@Produces methods may not have type parameters");
   }
 
   @Test public void producesMethodSetValuesWildcard() {
@@ -129,9 +121,7 @@ public class ProducerModuleFactoryGeneratorTest {
   @Test public void producesMethodSetValuesRawSet() {
     assertThatProductionModuleMethod(
             "@Produces @ElementsIntoSet Set produceSomething() { return null; }")
-        .hasError(
-            formatErrorMessage(
-                "@%s methods annotated with @ElementsIntoSet cannot return a raw Set"));
+        .hasError("@Produces methods annotated with @ElementsIntoSet cannot return a raw Set");
   }
 
   @Test public void producesMethodSetValuesNotASet() {
@@ -155,9 +145,7 @@ public class ProducerModuleFactoryGeneratorTest {
     assertThatProductionModuleMethod(
             "@Produces @ElementsIntoSet ListenableFuture<Set> produceSomething() { return null; }")
         .importing(ListenableFuture.class)
-        .hasError(
-            formatErrorMessage(
-                "@%s methods annotated with @ElementsIntoSet cannot return a raw Set"));
+        .hasError("@Produces methods annotated with @ElementsIntoSet cannot return a raw Set");
   }
 
   @Test public void producesMethodSetValuesFutureNotASet() {

--- a/javatests/dagger/internal/codegen/ProducerModuleFactoryGeneratorTest.java
+++ b/javatests/dagger/internal/codegen/ProducerModuleFactoryGeneratorTest.java
@@ -187,7 +187,7 @@ public class ProducerModuleFactoryGeneratorTest {
         "  }",
         "}");
     String errorMessage =
-        "Cannot have more than one @Produces method with the same name in a single module";
+        "Cannot have more than one binding method with the same name in a single module";
     Compilation compilation = daggerCompiler().compile(moduleFile);
     assertThat(compilation).failed();
     assertThat(compilation).hadErrorContaining(errorMessage).inFile(moduleFile).onLine(8);

--- a/javatests/dagger/spi/FailingPlugin.java
+++ b/javatests/dagger/spi/FailingPlugin.java
@@ -31,7 +31,10 @@ public final class FailingPlugin implements BindingGraphPlugin {
   @Override
   public Set<String> supportedOptions() {
     return ImmutableSet.of(
-        "error_on_binding", "error_on_dependency", "error_on_component", "error_on_subcomponents");
+        "error_on_binding",
+        "error_on_dependency",
+        "error_on_component",
+        "error_on_subcomponents");
   }
 
   @Override
@@ -80,6 +83,7 @@ public final class FailingPlugin implements BindingGraphPlugin {
           .forEach(
               edge -> diagnosticReporter.reportDependency(ERROR, edge, "Bad Dependency: %s", edge));
     }
+
   }
 
   @Override


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove stale comment

c20aa45cc742fa2551e280ae4bd556cef93a8cc4

-------

<p> Report an error for scopes on @Multibinds methods. We may at some point want to allow this, but until we have an implementation, we should report an error so that users don't have mismatched expectations.

See https://github.com/google/dagger/issues/1408

RELNOTES=Report an error for scopes on `@Multibinds` methods. This was never supported, but the scope was previously ignored.

5c3a58bd6da5b8f7ba65f2bcd28abbe62cdf32e7

-------

<p> Add a method to DiagnosticReporter to allow plugins to report elementless diagnostics

850e803da285ffca73e5388a77673acf18708b83

-------

<p> Move possiblyNecessaryComponentRequirements from BindingGraph to ComponentDescriptor.

This will simplify an upcoming change where we need to determine the possibly necessary requirements in situations where we don't have a BindingGraph instance.

9d1bdb1a7c8279ff3d59dcf583b27793b835f8d0

-------

<p> Fix some weird logic in ModuleValidator.

It wasn't considering all kinds of binding methods when doing some validations and was going out of its way to use "@Provides" or "@Produces" in error messages when what it meant was "any binding method".

RELNOTES=Fix `@BindsOptionalOf` methods to require that they have a different name than any other binding method in the module; this was already true for all other types of binding methods (`@Provides`, `@Binds` etc.) but `@BindsOptionalOf` wasn't being included.

9df9ad0db1598cc2a27b984e3b4a5519436aef19

-------

<p> Extract a method to make a future refactoring simpler

68c43efc05d960e11215db2ffbc87c1a67f95b1c

-------

<p> Remove usage of weird formatErrorMessage() in (Producer)ModuleFactoryGeneratorTest. It added more characters than it saved and didn't seem to serve any purpose.

c5aea747fa3f425550c2aba4bd5e86881f79d914

-------

<p> Don't create MethodSpecs with bodies for methods that are modifiable and do not have a base class implementation.

This currently doesn't make any difference since the methods don't get added to the component implementation since they're already abstract. But they will in an upcoming CL that adds metadata annotations to modifiable binding methods, and it's easier to emit abstract method even though it functionally serves no purpose. Without this change, the added methods would infinitely recurse:

@Override
public Foo getModifiableFoo() {
  return getModifiableFoo();
}

e7ac9df896004be277cf05f651334a2e61e17bfb

-------

<p> Create a factory methods for ComponentImplementations instead of calling constructors directly.

Also extract a ComponentDescriptor variable, as that will simplify a later CL where ComponentImplementations are created without BindingGraphs

80974fcead50d79489cdf5c028723ec10cdaa368

-------

<p> Small change to logic for ComponentRequirement.requiresAPassedInstance.

Previously, it would decide that a module instance must be passed if the module had any abstract method that was not a binding method. But this isn't quite true: if the module's binding methods are all abstract and/or static, then the abstract non-binding method doesn't matter at all; instance state does not affect the module.

5ba7d5a655e790ea9b913781d439d5bce571cd08

-------

<p> Allow public modules to include non-public modules when those included modules do not require an instance: that is, they only have abstract and/or static binding methods.

RELNOTES=Public modules are now allowed to include non-public modules when those included modules do not require an instance: that is, they only have abstract and/or static binding methods.

32e3a2b6ac6c1b3717bab8c749599cb85091fa33

-------

<p> github.com/google/kythe -> github.com/kythe/kythe

880f1e99fbb98bbd1ef39795f47f4226c77274f4

-------

<p> Use the ComponentDescriptor directly instead of going through the BindingGraph.

This will make upcoming changes simpler in cases where the ComponentImplementation does not always have a BindingGraph

459c4d861bffd94d712a684c68ff7abe3e5992aa

-------

<p> Small ternary simplification

493f693eca772915c9eef372c5035a739f07dcb7

-------

<p> Begin to use @Subcomponent.Factory in dagger.android

30321cb98acc68028b340fd22e95ca807eba57f7