### PR TITLE
Moe Sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: android
 
 os: linux
-dist: precise
+dist: trusty
 sudo: required
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ env:
     # permission to push to the repo.
     - secure: "UpTUhCQzAGbr5JetRg2GZxp/dPDep/7Il3yGeyDECopciWdx41OPk/QNqAXBhNtKuEaMVsmASyoteuhgaTryQdV4qUIGVOMhES6kbOlYy3nwK44VdsNeeepwVospyDyZbxMtXq5LuHWuTADmAl1mdjNPNoziXc523zjnUzUx/EQ="
     - JDK_FOR_PUBLISHING: *jdk_for_publishing
-    - BAZEL_VERSION="0.19.2"
+    - BAZEL_VERSION="0.24.1"
 
 after_success:
   - util/generate-latest-docs.sh

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,10 +16,19 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "google_bazel_common",
-    strip_prefix = "bazel-common-1c225e62390566a9e88916471948ddd56e5f111c",
-    urls = ["https://github.com/google/bazel-common/archive/1c225e62390566a9e88916471948ddd56e5f111c.zip"],
+    strip_prefix = "bazel-common-29d6ca04ea34e4facd599f36e97135212a16e570",
+    urls = ["https://github.com/google/bazel-common/archive/29d6ca04ea34e4facd599f36e97135212a16e570.zip"],
 )
 
 load("@google_bazel_common//:workspace_defs.bzl", "google_common_workspace_rules")
 
 google_common_workspace_rules()
+
+# This fixes an issue with protobuf starting to use zlib by default in 3.7.0.
+# TODO(ronshapiro): Figure out if this is in fact necessary, or if proto can depend on the
+# @bazel_tools library directly. See discussion in
+# https://github.com/protocolbuffers/protobuf/pull/5389#issuecomment-481785716
+bind(
+    name = "zlib",
+    actual = "@bazel_tools//third_party/zlib",
+)

--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -411,9 +411,9 @@ java_library(
     deps = [
         ":base",
         ":binding",
+        ":javac",
         ":processor",
         "//java/dagger:core",
-        "@bazel_tools//third_party/java/jdk/langtools:javac",
     ],
 )
 
@@ -424,17 +424,23 @@ java_library(
     deps = [
         ":base",
         ":binding",
+        ":javac",
         ":javac-plugin-module",
         ":kythe_plugin",
         ":processor",
         "//java/dagger:core",
         "//java/dagger/model",
         "//java/dagger/producers",
-        "@bazel_tools//third_party/java/jdk/langtools:javac",
         "@google_bazel_common//third_party/java/auto:common",
         "@google_bazel_common//third_party/java/auto:service",
         "@google_bazel_common//third_party/java/guava",
     ],
+)
+
+# Replacement for @bazel_tools//third_party/java/jdk/langtools:javac, which seems to have gone away?
+java_import(
+    name = "javac",
+    jars = ["@bazel_tools//third_party/java/jdk/langtools:javac_jar"],
 )
 
 # A _deploy.jar consisting of the java_librarys in https://github.com/kythe/kythe needed to build a
@@ -500,11 +506,11 @@ java_library(
     deps = [
         ":base",
         ":binding",
+        ":javac",
         ":javac-plugin-module",
         ":processor",
         "//java/dagger:core",
         "//java/dagger/model",
-        "@bazel_tools//third_party/java/jdk/langtools:javac",
         "@google_bazel_common//third_party/java/error_prone:check_api",
     ],
 )

--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -23,14 +23,16 @@ load("//tools:simple_jar.bzl", "simple_jar")
 
 EXPERIMENTAL_VISUALIZER_SRCS = ["BindingNetworkVisualizer.java"]
 
-KYTHE_SRCS = [
-    "DaggerKythePlugin.java",
-    "JavacPluginModule.java",
-]
+JAVAC_PLUGIN_MODULE_SRCS = ["JavacPluginModule.java"]
+
+KYTHE_SRCS = ["DaggerKythePlugin.java"]
+
+STATISTICS_COLLECTOR_SRCS = ["BindingGraphStatisticsCollector.java"]
 
 CODEGEN_SRCS = glob(
     ["*.java"],
-    exclude = EXPERIMENTAL_VISUALIZER_SRCS + KYTHE_SRCS,
+    exclude = EXPERIMENTAL_VISUALIZER_SRCS + KYTHE_SRCS + STATISTICS_COLLECTOR_SRCS +
+              JAVAC_PLUGIN_MODULE_SRCS,
 )
 
 CODEGEN_PLUGINS = [":bootstrap_compiler_plugin"]
@@ -402,12 +404,27 @@ pom_file(
 )
 
 java_library(
+    name = "javac-plugin-module",
+    srcs = JAVAC_PLUGIN_MODULE_SRCS,
+    plugins = [":component-codegen"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":base",
+        ":binding",
+        ":processor",
+        "//java/dagger:core",
+        "@bazel_tools//third_party/java/jdk/langtools:javac",
+    ],
+)
+
+java_library(
     name = "kythe",
     srcs = KYTHE_SRCS,
     plugins = [":component-codegen"],
     deps = [
         ":base",
         ":binding",
+        ":javac-plugin-module",
         ":kythe_plugin",
         ":processor",
         "//java/dagger:core",
@@ -474,4 +491,20 @@ java_plugin(
         "genclass=${package}.Dagger${outerclasses}${classname}",
     ],
     deps = [":processor"],
+)
+
+java_library(
+    name = "statistics",
+    srcs = STATISTICS_COLLECTOR_SRCS,
+    plugins = [":component-codegen"],
+    deps = [
+        ":base",
+        ":binding",
+        ":javac-plugin-module",
+        ":processor",
+        "//java/dagger:core",
+        "//java/dagger/model",
+        "@bazel_tools//third_party/java/jdk/langtools:javac",
+        "@google_bazel_common//third_party/java/error_prone:check_api",
+    ],
 )

--- a/java/dagger/internal/codegen/BindingGraphStatisticsCollector.java
+++ b/java/dagger/internal/codegen/BindingGraphStatisticsCollector.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen;
+
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+import static dagger.internal.codegen.ComponentAnnotation.rootComponentAnnotation;
+
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.ClassTree;
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.tools.javac.util.Context;
+import dagger.BindsInstance;
+import dagger.Component;
+import dagger.model.BindingGraph;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/** A {@link BugChecker} that collects statistics derived from a {@link BindingGraph}. */
+public abstract class BindingGraphStatisticsCollector extends BugChecker
+    implements ClassTreeMatcher {
+  private BindingGraphConverter bindingGraphConverter;
+  private BindingGraphFactory bindingGraphFactory;
+  private ComponentDescriptorFactory componentDescriptorFactory;
+  private boolean isInjected;
+
+  @Singleton
+  @Component(modules = JavacPluginModule.class)
+  interface Injector {
+    void inject(BindingGraphStatisticsCollector collector);
+
+    @Component.Factory
+    interface Factory {
+      Injector create(@BindsInstance Context context);
+    }
+  }
+
+  // BugCheckers must have no-arg constructors, so we'll use method injection instead.
+  @Inject
+  void inject(
+      BindingGraphConverter bindingGraphConverter,
+      BindingGraphFactory bindingGraphFactory,
+      ComponentDescriptorFactory componentDescriptorFactory) {
+    this.bindingGraphConverter = bindingGraphConverter;
+    this.bindingGraphFactory = bindingGraphFactory;
+    this.componentDescriptorFactory = componentDescriptorFactory;
+  }
+
+  @Override
+  public final Description matchClass(ClassTree tree, VisitorState state) {
+    injectIfNecessary(state.context);
+
+    ClassSymbol symbol = getSymbol(tree);
+    rootComponentAnnotation(symbol)
+        .map(annotation -> createBindingGraph(symbol))
+        .ifPresent(graph -> visitBindingGraph(graph, state));
+
+    return Description.NO_MATCH;
+  }
+
+  private BindingGraph createBindingGraph(ClassSymbol component) {
+    return bindingGraphConverter.convert(
+        bindingGraphFactory.create(
+            componentDescriptorFactory.rootComponentDescriptor(component), false));
+  }
+
+  /** Visits a {@link BindingGraph} and emits stats to a {@link VisitorState}. */
+  protected abstract void visitBindingGraph(BindingGraph graph, VisitorState state);
+
+  private void injectIfNecessary(Context context) {
+    if (isInjected) {
+      return;
+    }
+    DaggerBindingGraphStatisticsCollector_Injector.factory().create(context).inject(this);
+    isInjected = true;
+  }
+}

--- a/javatests/dagger/android/support/functional/BUILD
+++ b/javatests/dagger/android/support/functional/BUILD
@@ -27,12 +27,14 @@ android_library(
     manifest = "AndroidManifest.xml",
     resource_files = glob(["res/**"]),
     deps = [
+        "@androidsdk//com.android.support:support-fragment-25.0.0",
+        "@androidsdk//com.android.support:appcompat-v7-25.0.0",
+        "@google_bazel_common//third_party/java/guava",
+        "//:dagger_with_compiler",
         "//:android",
         "//:android-support",
-        "//:dagger_with_compiler",
-        "@androidsdk//com.android.support:appcompat-v7-25.0.0",
-        "@androidsdk//com.android.support:support-fragment-25.0.0",
-        "@google_bazel_common//third_party/java/guava",
+        # TODO(ronshapiro): figure out why strict deps is failing without this
+        "@google_bazel_common//third_party/java/jsr250_annotations",
     ],
 )
 

--- a/javatests/dagger/internal/codegen/TestUtils.java
+++ b/javatests/dagger/internal/codegen/TestUtils.java
@@ -25,7 +25,7 @@ final class TestUtils {
   private static final Joiner MESSAGE_JOINER = Joiner.on("\n  ");
 
   /**
-   * Returns the lines joined by {@code "\n "}. Useful for passing to {@link
+   * Returns the lines joined by {@code "\n  "}. Useful for passing to {@link
    * com.google.testing.compile.CompilationSubject#hadErrorContaining(String)}, etc.
    */
   static String message(String... lines) {
@@ -33,7 +33,7 @@ final class TestUtils {
   }
 
   /**
-   * Returns a pattern that matches strings that end with the lines joined by {@code "\n "}. Useful
+   * Returns a pattern that matches strings that end with the lines joined by {@code "\n  "}. Useful
    * for passing to {@link
    * com.google.testing.compile.CompilationSubject#hadErrorContainingMatch(Pattern)}, etc.
    */


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Refactor ModuleBindingValidationTest some more to prepare for applying full binding graph validation to components and subcomponents.

Move tests/constants around and rename so it's clearer which files/messages go with which tests.

Add back the case where a module includes another module with errors/warnings to demonstrate that we don't repeat the error (but we do repeat the warning: see b/130284666).

Add a similar case where a module declares a subcomponent with errors/warnings to demonstrate that we DO repeat the error/warning (see b/130284677).

d8fbc4c410b3e16490604ff6cbb7703c3dba000b

-------

<p> Fix typo in Javadoc.

67a266068aed9eb99fd65efbb6084a654eb047bb

-------

<p> Add a simple framework to collect Dagger codebase stats using ErrorProne

Add a simple implementation that collects frequencies of each request kind.

8201b005a9ee624561426a797d5960013d711efb

-------

<p> Make parseOption methods non-static so they can cache their results, so we don't report an error more than once per option.

9ce8fc8891408056f94208aba05433a119ec2450

-------

<p> Update to Bazel 0.24.1 and fix a few things that came up during upgrading

9c31fa7dc52d13a8be4d2a37977b585f6fec276b