### PR TITLE
Moe Sync

### DIFF
--- a/compiler-options.md
+++ b/compiler-options.md
@@ -51,21 +51,23 @@ we can enable this broadly.
 
 
 
-## Module binding validation {#module-binding-validation}
+## Full binding graph validation {#full-binding-graph-validation}
 
-By default, Dagger validates modules only for syntax problems, like having the
-wrong annotations on a binding method. But problems among the bindings in a
-module don't get reported until the module is installed in a root component _and
-the bindings are used in that component._ If you pass
-`-Adagger.moduleBindingValidation=ERROR` or
-`-Adagger.moduleBindingValidation=WARNING` to javac, then each module will be
-checked as if it were a component in which every one of its bindings (and those
-of the modules it includes) is used. Any binding graph errors, such as duplicate
-bindings, will be reported at the module, even if no component uses those
-bindings.
+By default, problems among the bindings in a module or subcomponent or component
+don't get reported unless they are used as part of a whole component tree rooted
+at a root `@Component` or `@ProductionComponent`. However, if you pass
+`-Adagger.fullBindingGraphValidation=ERROR` or
+`-Adagger.fullBindingGraphValidation=WARNING` to javac, then _all_ the bindings
+of each module, subcomponent, and component will be checked, including those
+that aren't used. Any binding graph errors, such as duplicate bindings, will be
+reported at the module, subcomponent, or component. (Note that missing bindings
+will not be reported for full binding graphs unless they're also found when
+analyzing the binding graph that's actually used to generate the root
+component.)
 
-If module binding validation is turned on, [SPI](spi.md) implementations will
-see a `BindingGraph` representing the bindings for each module as well.
+If full binding graph validation is turned on, [SPI](spi.md) implementations
+will see a `BindingGraph` representing the bindings for each module, component,
+and subcomponent as well.
 
 <!-- References -->
 

--- a/spi.md
+++ b/spi.md
@@ -37,9 +37,11 @@ done with a [`java_plugin`]; in Gradle declare a dependency with
 
 When Dagger detects an SPI plugin on the classpath, it will call its
 [`visitGraph(BindingGraph, DiagnosticReporter)`][`visitGraph()`] method for each
-valid `@Component` that Dagger compiles. If [module binding validation] is
-turned on, Dagger will also call [`visitGraph()`] for each module that has no
-errors. In that case, the `BindingGraph` may contain `MissingBinding` nodes.
+valid `@Component` that Dagger compiles. If [full binding graph validation] is
+turned on, Dagger will also call [`visitGraph()`] for each module, component,
+and subcomponent that has no errors when considering their full binding graph.
+(See [`isFullBindingGraph()`].)In that case, the `BindingGraph` may contain
+`MissingBinding` nodes.
 
 The `BindingGraph` is implemented as a [`Network`] that has nodes for
 [components][component nodes], [bindings][binding nodes], and
@@ -97,15 +99,16 @@ will forward the values to the [`initOptions()`] method.
 [dependency edges]: https://google.github.io/dagger/api/latest/dagger/model/DependencyEdge.html
 [`DiagnosticReporter`]: https://google.github.io/dagger/api/latest/dagger/spi/DiagnosticReporter.html
 [`Filer`]: https://docs.oracle.com/javase/9/docs/api/javax/annotation/processing/Filer.html
+[full binding graph validation]: compiler-options.md#full-binding-graph-validation
 [GitHub releases]: https://github.com/google/dagger/releases
 [`initElements()`]: https://google.github.io/dagger/api/latest/dagger/spi/BindingGraphPlugin.html#initElements-javax.lang.model.util.Elements-
 [`initFiler()`]: https://google.github.io/dagger/api/latest/dagger/spi/BindingGraphPlugin.html#initFiler-javax.annotation.processing.Filer-
 [`initOptions()`]: https://google.github.io/dagger/api/latest/dagger/spi/BindingGraphPlugin.html#initOptions-java.util.Map-
 [`initTypes()`]: https://google.github.io/dagger/api/latest/dagger/spi/BindingGraphPlugin.html#initTypes-javax.lang.model.util.Types-
+[`isFullBindingGraph()`]: https://google.github.io/dagger/api/latest/dagger/model/BindingGraph.html#isFullBindingGraph--
 [`java_plugin`]: https://docs.bazel.build/versions/master/be/java.html#java_plugin
 [`Messager`]: https://docs.oracle.com/javase/9/docs/api/javax/annotation/processing/Messager.html
 [missing binding nodes]: https://google.github.io/dagger/api/latest/dagger/model/MissingBinding.html
-[module binding validation]: compiler-options.md#module-binding-validation
 [`Network`]: http://google.github.io/guava/releases/27.0-jre/api/docs/com/google/common/graph/Network.html
 [`pluginName()`]: https://google.github.io/dagger/api/latest/dagger/spi/BindingGraphPlugin.html#pluginName--
 [reach out]: https://github.com/google/dagger/issues/new


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Rename moduleBindingValidation to fullBindingGraphValidation. The old name continues to work as an alias.

RELNOTES=Rename `-Adagger.moduleBindingValidation` to `-Adagger.fullBindingGraphValidation`. The old name continues to work as an alias.

bb59446bd6b34cf5c9dcf80ff4dcd81b354c67ef