### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/android/processor/ContributesAndroidInjectorGenerator.java
+++ b/java/dagger/android/processor/ContributesAndroidInjectorGenerator.java
@@ -35,7 +35,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
-import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
@@ -171,7 +170,7 @@ final class ContributesAndroidInjectorGenerator implements ProcessingStep {
       ClassName subcomponentFactoryName) {
     AnnotationSpec.Builder subcomponentAnnotation = AnnotationSpec.builder(Subcomponent.class);
     for (ClassName module : descriptor.modules()) {
-      subcomponentAnnotation.addMember("modules", CodeBlock.of("$T.class", module));
+      subcomponentAnnotation.addMember("modules", "$T.class", module);
     }
 
     return interfaceBuilder(subcomponentName)

--- a/java/dagger/model/testing/BindingGraphSubject.java
+++ b/java/dagger/model/testing/BindingGraphSubject.java
@@ -82,14 +82,8 @@ public final class BindingGraphSubject extends Subject<BindingGraphSubject, Bind
 
   private BindingSubject bindingWithKeyString(String keyString) {
     ImmutableSet<Binding> bindings = getBindingNodes(keyString);
-    if (bindings.isEmpty()) {
-      failWithActual("expected to have binding with key", keyString);
-    }
     // TODO(dpb): Handle multiple bindings for the same key.
-    if (bindings.size() > 1) {
-      failWithBadResults(
-          "has only one binding with key", keyString, "has the following bindings:", bindings);
-    }
+    check("bindingsWithKey(%s)", keyString).that(bindings).hasSize(1);
     return check("bindingWithKey(%s)", keyString)
         .about(BindingSubject::new)
         .that(getOnlyElement(bindings));


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Simplify some JavaPoet code by running a new set of Refaster templates

9b9fd10e0952c9814623497780a117f0f8f19d91

-------

<p> Migrate users from the old, deprecated Subject.fail* methods to the new Subject.fail* methods or, in some cases, to Subject.check.

Most of the changes in this CL were made manually.

I've tried to preserve all information (and of course behavior!), but the format and grammar of the messages does change. For example before-and-after messages, see the LSC doc.

b381894c161599b9bcf89521d297aa6186a8ae46