### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/ComponentImplementation.java
+++ b/java/dagger/internal/codegen/ComponentImplementation.java
@@ -33,10 +33,10 @@ import static javax.lang.model.element.Modifier.PUBLIC;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Supplier;
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.MultimapBuilder;
@@ -202,7 +202,7 @@ final class ComponentImplementation {
   private final List<Supplier<TypeSpec>> switchingProviderSupplier = new ArrayList<>();
   private final ModifiableBindingMethods modifiableBindingMethods = new ModifiableBindingMethods();
   private final SetMultimap<BindingRequest, Key> multibindingContributionsMade =
-      HashMultimap.create();
+      LinkedHashMultimap.create();
   private Optional<ConfigureInitializationMethod> configureInitializationMethod = Optional.empty();
   private final Map<ComponentRequirement, String> modifiableModuleMethods = new LinkedHashMap<>();
 

--- a/java/dagger/model/testing/BindingGraphSubject.java
+++ b/java/dagger/model/testing/BindingGraphSubject.java
@@ -36,8 +36,11 @@ public final class BindingGraphSubject extends Subject<BindingGraphSubject, Bind
     return assertAbout(BindingGraphSubject::new).that(bindingGraph);
   }
 
+  private final BindingGraph actual;
+
   private BindingGraphSubject(FailureMetadata metadata, @NullableDecl BindingGraph actual) {
     super(metadata, actual);
+    this.actual = actual;
   }
 
   /**
@@ -90,7 +93,7 @@ public final class BindingGraphSubject extends Subject<BindingGraphSubject, Bind
   }
 
   private ImmutableSet<Binding> getBindingNodes(String keyString) {
-    return actual().bindings().stream()
+    return actual.bindings().stream()
         .filter(binding -> binding.key().toString().equals(keyString))
         .collect(toImmutableSet());
   }
@@ -106,8 +109,11 @@ public final class BindingGraphSubject extends Subject<BindingGraphSubject, Bind
   /** A Truth subject for a {@link Binding}. */
   public final class BindingSubject extends Subject<BindingSubject, Binding> {
 
+    private final Binding actual;
+
     BindingSubject(FailureMetadata metadata, @NullableDecl Binding actual) {
       super(metadata, actual);
+      this.actual = actual;
     }
 
     /**
@@ -131,14 +137,14 @@ public final class BindingGraphSubject extends Subject<BindingGraphSubject, Bind
     }
 
     private void dependsOnBindingWithKeyString(String keyString) {
-      if (actualBindingGraph().requestedBindings(actual()).stream()
+      if (actualBindingGraph().requestedBindings(actual).stream()
           .noneMatch(binding -> binding.key().toString().equals(keyString))) {
         failWithActual("expected to depend on binding with key", keyString);
       }
     }
 
     private BindingGraph actualBindingGraph() {
-      return BindingGraphSubject.this.actual();
+      return BindingGraphSubject.this.actual;
     }
   }
 }

--- a/javatests/dagger/internal/codegen/DaggerModuleMethodSubject.java
+++ b/javatests/dagger/internal/codegen/DaggerModuleMethodSubject.java
@@ -74,6 +74,7 @@ final class DaggerModuleMethodSubject extends Subject<DaggerModuleMethodSubject,
     }
   }
 
+  private final String actual;
   private final ImmutableList.Builder<String> imports =
       new ImmutableList.Builder<String>()
           .add(
@@ -89,6 +90,7 @@ final class DaggerModuleMethodSubject extends Subject<DaggerModuleMethodSubject,
 
   private DaggerModuleMethodSubject(FailureMetadata failureMetadata, String subject) {
     super(failureMetadata, subject);
+    this.actual = subject;
   }
 
   /**
@@ -155,7 +157,7 @@ final class DaggerModuleMethodSubject extends Subject<DaggerModuleMethodSubject,
   }
 
   private int methodLine(String source) {
-    String beforeMethod = source.substring(0, source.indexOf(actual()));
+    String beforeMethod = source.substring(0, source.indexOf(actual));
     int methodLine = 1;
     for (int nextNewlineIndex = beforeMethod.indexOf('\n');
         nextNewlineIndex >= 0;
@@ -174,7 +176,7 @@ final class DaggerModuleMethodSubject extends Subject<DaggerModuleMethodSubject,
       writer.println(importLine);
     }
     writer.println();
-    writer.printf(declaration, "TestModule", "\n" + actual() + "\n");
+    writer.printf(declaration, "TestModule", "\n" + actual + "\n");
     writer.println();
     return stringWriter.toString();
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make generated code deterministic

RELNOTES=N/A

056f242b14da52521d89a0cb4daa14cf4595728b

-------

<p> Instead of calling Subject.actual(), store the actual value in a field, and read that.

actual() is being removed.

cea96d777b39ba22aaef563a8bbf0bccf3c48cbf