### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -168,6 +168,7 @@ java_library(
         "FrameworkType.java",
         "FrameworkTypeMapper.java",
         "InjectBindingRegistry.java",
+        "InjectionSiteFactory.java",
         "KeyFactory.java",
         "KeyVariableNamer.java",  # needs ConfigurationAnnotations, SourceFiles
         "MapKeys.java",

--- a/java/dagger/internal/codegen/Binding.java
+++ b/java/dagger/internal/codegen/Binding.java
@@ -118,7 +118,7 @@ abstract class Binding extends BindingDeclaration {
    * union of {@link #explicitDependencies()} and {@link #implicitDependencies()}. This returns an
    * unmodifiable set.
    */
-  ImmutableSet<DependencyRequest> dependencies() {
+  final ImmutableSet<DependencyRequest> dependencies() {
     return dependencies.get();
   }
 
@@ -164,7 +164,7 @@ abstract class Binding extends BindingDeclaration {
   /* TODO(dpb): The stable-order postcondition is actually hard to verify in code for two equal
    * instances of Binding, because it really depends on the order of the binding's dependencies,
    * and two equal instances of Binding may have the same dependencies in a different order. */
-  ImmutableList<FrameworkDependency> frameworkDependencies() {
+  final ImmutableList<FrameworkDependency> frameworkDependencies() {
     return frameworkDependencies.get();
   }
 
@@ -212,7 +212,7 @@ abstract class Binding extends BindingDeclaration {
    * multiple times if the {@linkplain Binding#unresolved() unresolved} binding requires it. If that
    * distinction is not important, the entries can be merged into a single mapping.
    */
-  ImmutableList<DependencyAssociation> dependencyAssociations() {
+  final ImmutableList<DependencyAssociation> dependencyAssociations() {
     return dependencyAssociations.get();
   }
 
@@ -236,7 +236,8 @@ abstract class Binding extends BindingDeclaration {
    * Returns the mapping from each {@linkplain #dependencies dependency} to its associated {@link
    * FrameworkDependency}.
    */
-  ImmutableMap<DependencyRequest, FrameworkDependency> dependenciesToFrameworkDependenciesMap() {
+  final ImmutableMap<DependencyRequest, FrameworkDependency>
+      dependenciesToFrameworkDependenciesMap() {
     return frameworkDependenciesMap.get();
   }
 

--- a/java/dagger/internal/codegen/BindingDeclaration.java
+++ b/java/dagger/internal/codegen/BindingDeclaration.java
@@ -49,7 +49,7 @@ abstract class BindingDeclaration {
    * The type enclosing the {@link #bindingElement()}, or {@link Optional#empty()} if {@link
    * #bindingElement()} is empty.
    */
-  Optional<TypeElement> bindingTypeElement() {
+  final Optional<TypeElement> bindingTypeElement() {
     return bindingElement().map(DaggerElements::closestEnclosingTypeElement);
   }
   

--- a/java/dagger/internal/codegen/BindingElementValidator.java
+++ b/java/dagger/internal/codegen/BindingElementValidator.java
@@ -72,7 +72,7 @@ abstract class BindingElementValidator<E extends Element> {
   }
 
   /**
-   * Returns an error message of the form "<{@link #bindingElements()}> <i>rule</i>", where
+   * Returns an error message of the form "&lt;{@link #bindingElements()}&gt; <i>rule</i>", where
    * <i>rule</i> comes from calling {@link String#format(String, Object...)} on {@code ruleFormat}
    * and the other arguments.
    */
@@ -114,7 +114,7 @@ abstract class BindingElementValidator<E extends Element> {
   /**
    * The type declared by this binding element. This may differ from a binding's {@link Key#type()},
    * for example in multibindings. An {@link Optional#empty()} return value indicates that the
-   * contributed type is ambiguous or missing, i.e. a {@link @BindsInstance} method with zero or
+   * contributed type is ambiguous or missing, i.e. a {@code @BindsInstance} method with zero or
    * many parameters.
    */
   // TODO(dpb): should this be an ImmutableList<TypeMirror>, with this class checking the size?

--- a/java/dagger/internal/codegen/BindingElementValidator.java
+++ b/java/dagger/internal/codegen/BindingElementValidator.java
@@ -29,10 +29,8 @@ import static javax.lang.model.type.TypeKind.VOID;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.FormatMethod;
-import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import dagger.MapKey;
 import dagger.Provides;
-import dagger.internal.codegen.ValidationReport.Builder;
 import dagger.model.Key;
 import dagger.model.Scope;
 import dagger.multibindings.ElementsIntoSet;
@@ -71,6 +69,15 @@ abstract class BindingElementValidator<E extends Element> {
     this.allowsScoping = allowsScoping;
   }
 
+  /** Returns a {@link ValidationReport} for {@code element}. */
+  final ValidationReport<E> validate(E element) {
+    return reentrantComputeIfAbsent(cache, element, this::validateUncached);
+  }
+
+  private ValidationReport<E> validateUncached(E element) {
+    return elementValidator(element).validate();
+  }
+
   /**
    * Returns an error message of the form "&lt;{@link #bindingElements()}&gt; <i>rule</i>", where
    * <i>rule</i> comes from calling {@link String#format(String, Object...)} on {@code ruleFormat}
@@ -86,114 +93,15 @@ abstract class BindingElementValidator<E extends Element> {
    */
   protected abstract String bindingElements();
 
-  /** The verb describing the {@link #bindingElementType(Builder)} in error messages. */
+  /** The verb describing the {@link ElementValidator#bindingElementType()} in error messages. */
   // TODO(ronshapiro,dpb): improve the name of this method and it's documentation.
   protected abstract String bindingElementTypeVerb();
-
-  /** Returns a {@link ValidationReport} for {@code element}. */
-  final ValidationReport<E> validate(E element) {
-    return reentrantComputeIfAbsent(cache, element, this::validateUncached);
-  }
-
-  private ValidationReport<E> validateUncached(E element) {
-    ValidationReport.Builder<E> report = ValidationReport.about(element);
-    checkElement(report);
-    return report.build();
-  }
-
-  /** Checks the element for validity. Adds errors to {@code builder}. */
-  @OverridingMethodsMustInvokeSuper
-  protected void checkElement(ValidationReport.Builder<E> builder) {
-    checkType(builder);
-    checkQualifiers(builder);
-    checkMapKeys(builder);
-    checkMultibindings(builder);
-    checkScopes(builder);
-  }
-
-  /**
-   * The type declared by this binding element. This may differ from a binding's {@link Key#type()},
-   * for example in multibindings. An {@link Optional#empty()} return value indicates that the
-   * contributed type is ambiguous or missing, i.e. a {@code @BindsInstance} method with zero or
-   * many parameters.
-   */
-  // TODO(dpb): should this be an ImmutableList<TypeMirror>, with this class checking the size?
-  protected abstract Optional<TypeMirror> bindingElementType(ValidationReport.Builder<E> report);
-
-  /**
-   * Adds an error if the {@link #bindingElementType(ValidationReport.Builder) binding element type}
-   * is not appropriate.
-   *
-   * <p>Adds an error if the type is not a primitive, array, declared type, or type variable.
-   *
-   * <p>If the binding is not a multibinding contribution, adds an error if the type is a framework
-   * type.
-   *
-   * <p>If the element has {@link ElementsIntoSet @ElementsIntoSet} or {@code SET_VALUES}, adds an
-   * error if the type is not a {@code Set<T>} for some {@code T}
-   */
-  protected void checkType(ValidationReport.Builder<E> builder) {
-    switch (ContributionType.fromBindingElement(builder.getSubject())) {
-      case UNIQUE:
-        /* Validate that a unique binding is not attempting to bind a framework type. This
-         * validation is only appropriate for unique bindings because multibindings may collect
-         * framework types.  E.g. Set<Provider<Foo>> is perfectly reasonable. */
-        checkFrameworkType(builder);
-        // fall through
-
-      case SET:
-      case MAP:
-        bindingElementType(builder).ifPresent(type -> checkKeyType(builder, type));
-        break;
-
-      case SET_VALUES:
-        checkSetValuesType(builder);
-    }
-  }
-
-  /**
-   * Adds an error if {@code keyType} is not a primitive, declared type, array, or type variable.
-   */
-  protected void checkKeyType(ValidationReport.Builder<E> builder, TypeMirror keyType) {
-    TypeKind kind = keyType.getKind();
-    if (kind.equals(VOID)) {
-      builder.addError(bindingElements("must %s a value (not void)", bindingElementTypeVerb()));
-    } else if (!(kind.isPrimitive()
-        || kind.equals(DECLARED)
-        || kind.equals(ARRAY)
-        || kind.equals(TYPEVAR))) {
-      builder.addError(badTypeMessage());
-    }
-  }
 
   /** The error message when a binding element has a bad type. */
   protected String badTypeMessage() {
     return bindingElements(
         "must %s a primitive, an array, a type variable, or a declared type",
         bindingElementTypeVerb());
-  }
-
-  /**
-   * Adds an error if the type for an element with {@link ElementsIntoSet @ElementsIntoSet} or
-   * {@code SET_VALUES} is not a a {@code Set<T>} for a reasonable {@code T}.
-   */
-  // TODO(gak): should we allow "covariant return" for set values?
-  protected void checkSetValuesType(ValidationReport.Builder<E> builder) {
-    bindingElementType(builder).ifPresent(keyType -> checkSetValuesType(builder, keyType));
-  }
-
-  /** Adds an error if {@code type} is not a {@code Set<T>} for a reasonable {@code T}. */
-  protected final void checkSetValuesType(ValidationReport.Builder<E> builder, TypeMirror type) {
-    if (!SetType.isSet(type)) {
-      builder.addError(elementsIntoSetNotASetMessage());
-    } else {
-      SetType setType = SetType.from(type);
-      if (setType.isRawType()) {
-        builder.addError(elementsIntoSetRawSetMessage());
-      } else {
-        checkKeyType(builder, setType.elementType());
-      }
-    }
   }
 
   /**
@@ -214,127 +122,234 @@ abstract class BindingElementValidator<E extends Element> {
         "annotated with @ElementsIntoSet cannot %s a raw Set", bindingElementTypeVerb());
   }
 
-  /** Adds an error if the element has more than one {@linkplain Qualifier qualifier} annotation. */
-  private void checkQualifiers(ValidationReport.Builder<E> builder) {
-    ImmutableSet<? extends AnnotationMirror> qualifiers = getQualifiers(builder.getSubject());
-    if (qualifiers.size() > 1) {
-      for (AnnotationMirror qualifier : qualifiers) {
-        builder.addError(
-            bindingElements("may not use more than one @Qualifier"),
-            builder.getSubject(),
-            qualifier);
+  /*** Returns an {@link ElementValidator} for validating the given {@code element}. */
+  protected abstract ElementValidator elementValidator(E element);
+
+  /** Validator for a single binding element. */
+  protected abstract class ElementValidator {
+    protected final E element;
+    protected final ValidationReport.Builder<E> report;
+
+    protected ElementValidator(E element) {
+      this.element = element;
+      this.report = ValidationReport.about(element);
+    }
+
+    /** Checks the element for validity. */
+    private ValidationReport<E> validate() {
+      checkType();
+      checkQualifiers();
+      checkMapKeys();
+      checkMultibindings();
+      checkScopes();
+      checkAdditionalProperties();
+      return report.build();
+    }
+
+    /** Check any additional properties of the element. Does nothing by default. */
+    protected void checkAdditionalProperties() {}
+
+    /**
+     * The type declared by this binding element. This may differ from a binding's {@link
+     * Key#type()}, for example in multibindings. An {@link Optional#empty()} return value indicates
+     * that the contributed type is ambiguous or missing, i.e. a {@code @BindsInstance} method with
+     * zero or many parameters.
+     */
+    // TODO(dpb): should this be an ImmutableList<TypeMirror>, with this class checking the size?
+    protected abstract Optional<TypeMirror> bindingElementType();
+
+    /**
+     * Adds an error if the {@link #bindingElementType() binding element type} is not appropriate.
+     *
+     * <p>Adds an error if the type is not a primitive, array, declared type, or type variable.
+     *
+     * <p>If the binding is not a multibinding contribution, adds an error if the type is a
+     * framework type.
+     *
+     * <p>If the element has {@link ElementsIntoSet @ElementsIntoSet} or {@code SET_VALUES}, adds an
+     * error if the type is not a {@code Set<T>} for some {@code T}
+     */
+    protected void checkType() {
+      switch (ContributionType.fromBindingElement(element)) {
+        case UNIQUE:
+          /* Validate that a unique binding is not attempting to bind a framework type. This
+           * validation is only appropriate for unique bindings because multibindings may collect
+           * framework types.  E.g. Set<Provider<Foo>> is perfectly reasonable. */
+          checkFrameworkType();
+          // fall through
+
+        case SET:
+        case MAP:
+          bindingElementType().ifPresent(type -> checkKeyType(type));
+          break;
+
+        case SET_VALUES:
+          checkSetValuesType();
       }
     }
-  }
 
-  /**
-   * Adds an error if an {@link IntoMap @IntoMap} element doesn't have exactly one {@link
-   * MapKey @MapKey} annotation, or if an element that is {@link IntoMap @IntoMap} has any.
-   */
-  private void checkMapKeys(ValidationReport.Builder<E> builder) {
-    if (!allowsMultibindings.allowsMultibindings()) {
-      return;
-    }
-    ImmutableSet<? extends AnnotationMirror> mapKeys = getMapKeys(builder.getSubject());
-    if (ContributionType.fromBindingElement(builder.getSubject()).equals(ContributionType.MAP)) {
-      switch (mapKeys.size()) {
-        case 0:
-          builder.addError(bindingElements("of type map must declare a map key"));
-          break;
-        case 1:
-          break;
-        default:
-          builder.addError(bindingElements("may not have more than one map key"));
-          break;
+    /**
+     * Adds an error if {@code keyType} is not a primitive, declared type, array, or type variable.
+     */
+    protected void checkKeyType(TypeMirror keyType) {
+      TypeKind kind = keyType.getKind();
+      if (kind.equals(VOID)) {
+        report.addError(bindingElements("must %s a value (not void)", bindingElementTypeVerb()));
+      } else if (!(kind.isPrimitive()
+          || kind.equals(DECLARED)
+          || kind.equals(ARRAY)
+          || kind.equals(TYPEVAR))) {
+        report.addError(badTypeMessage());
       }
-    } else if (!mapKeys.isEmpty()) {
-      builder.addError(bindingElements("of non map type cannot declare a map key"));
     }
-  }
 
-  /**
-   * Adds errors if:
-   *
-   * <ul>
-   *   <li>the element doesn't allow {@linkplain MultibindingAnnotations multibinding annotations}
-   *       and has any
-   *   <li>the element does allow them but has more than one
-   *   <li>the element has a multibinding annotation and its {@link Provides} or {@link Produces}
-   *       annotation has a {@code type} parameter.
-   * </ul>
-   */
-  private void checkMultibindings(ValidationReport.Builder<E> builder) {
-    ImmutableSet<AnnotationMirror> multibindingAnnotations =
-        MultibindingAnnotations.forElement(builder.getSubject());
+    /**
+     * Adds an error if the type for an element with {@link ElementsIntoSet @ElementsIntoSet} or
+     * {@code SET_VALUES} is not a a {@code Set<T>} for a reasonable {@code T}.
+     */
+    // TODO(gak): should we allow "covariant return" for set values?
+    protected void checkSetValuesType() {
+      bindingElementType().ifPresent(keyType -> checkSetValuesType(keyType));
+    }
 
-    switch (allowsMultibindings) {
-      case NO_MULTIBINDINGS:
-        for (AnnotationMirror annotation : multibindingAnnotations) {
-          builder.addError(
-              bindingElements("cannot have multibinding annotations"),
-              builder.getSubject(),
-              annotation);
+    /** Adds an error if {@code type} is not a {@code Set<T>} for a reasonable {@code T}. */
+    protected final void checkSetValuesType(TypeMirror type) {
+      if (!SetType.isSet(type)) {
+        report.addError(elementsIntoSetNotASetMessage());
+      } else {
+        SetType setType = SetType.from(type);
+        if (setType.isRawType()) {
+          report.addError(elementsIntoSetRawSetMessage());
+        } else {
+          checkKeyType(setType.elementType());
         }
-        break;
+      }
+    }
 
-      case ALLOWS_MULTIBINDINGS:
-        if (multibindingAnnotations.size() > 1) {
+    /**
+     * Adds an error if the element has more than one {@linkplain Qualifier qualifier} annotation.
+     */
+    private void checkQualifiers() {
+      ImmutableSet<? extends AnnotationMirror> qualifiers = getQualifiers(element);
+      if (qualifiers.size() > 1) {
+        for (AnnotationMirror qualifier : qualifiers) {
+          report.addError(
+              bindingElements("may not use more than one @Qualifier"),
+              element,
+              qualifier);
+        }
+      }
+    }
+
+    /**
+     * Adds an error if an {@link IntoMap @IntoMap} element doesn't have exactly one {@link
+     * MapKey @MapKey} annotation, or if an element that is {@link IntoMap @IntoMap} has any.
+     */
+    private void checkMapKeys() {
+      if (!allowsMultibindings.allowsMultibindings()) {
+        return;
+      }
+      ImmutableSet<? extends AnnotationMirror> mapKeys = getMapKeys(element);
+      if (ContributionType.fromBindingElement(element).equals(ContributionType.MAP)) {
+        switch (mapKeys.size()) {
+          case 0:
+            report.addError(bindingElements("of type map must declare a map key"));
+            break;
+          case 1:
+            break;
+          default:
+            report.addError(bindingElements("may not have more than one map key"));
+            break;
+        }
+      } else if (!mapKeys.isEmpty()) {
+        report.addError(bindingElements("of non map type cannot declare a map key"));
+      }
+    }
+
+    /**
+     * Adds errors if:
+     *
+     * <ul>
+     *   <li>the element doesn't allow {@linkplain MultibindingAnnotations multibinding annotations}
+     *       and has any
+     *   <li>the element does allow them but has more than one
+     *   <li>the element has a multibinding annotation and its {@link Provides} or {@link Produces}
+     *       annotation has a {@code type} parameter.
+     * </ul>
+     */
+    private void checkMultibindings() {
+      ImmutableSet<AnnotationMirror> multibindingAnnotations =
+          MultibindingAnnotations.forElement(element);
+
+      switch (allowsMultibindings) {
+        case NO_MULTIBINDINGS:
           for (AnnotationMirror annotation : multibindingAnnotations) {
-            builder.addError(
-                bindingElements("cannot have more than one multibinding annotation"),
-                builder.getSubject(),
+            report.addError(
+                bindingElements("cannot have multibinding annotations"),
+                element,
                 annotation);
           }
-        }
-        break;
-    }
+          break;
 
-    // TODO(ronshapiro): move this into ProvidesMethodValidator
-    if (bindingAnnotation.equals(Provides.class)) {
-      AnnotationMirror bindingAnnotationMirror =
-          getAnnotationMirror(builder.getSubject(), bindingAnnotation).get();
-      boolean usesProvidesType = false;
-      for (ExecutableElement member : bindingAnnotationMirror.getElementValues().keySet()) {
-        usesProvidesType |= member.getSimpleName().contentEquals("type");
+        case ALLOWS_MULTIBINDINGS:
+          if (multibindingAnnotations.size() > 1) {
+            for (AnnotationMirror annotation : multibindingAnnotations) {
+              report.addError(
+                  bindingElements("cannot have more than one multibinding annotation"),
+                  element,
+                  annotation);
+            }
+          }
+          break;
       }
-      if (usesProvidesType && !multibindingAnnotations.isEmpty()) {
-        builder.addError(
-            "@Provides.type cannot be used with multibinding annotations", builder.getSubject());
+
+      // TODO(ronshapiro): move this into ProvidesMethodValidator
+      if (bindingAnnotation.equals(Provides.class)) {
+        AnnotationMirror bindingAnnotationMirror =
+            getAnnotationMirror(element, bindingAnnotation).get();
+        boolean usesProvidesType = false;
+        for (ExecutableElement member : bindingAnnotationMirror.getElementValues().keySet()) {
+          usesProvidesType |= member.getSimpleName().contentEquals("type");
+        }
+        if (usesProvidesType && !multibindingAnnotations.isEmpty()) {
+          report.addError(
+              "@Provides.type cannot be used with multibinding annotations", element);
+        }
       }
     }
-  }
 
-  /**
-   * Adds an error if the element has a scope but doesn't allow scoping, or if it has more than one
-   * {@linkplain Scope scope} annotation.
-   */
-  private void checkScopes(ValidationReport.Builder<E> builder) {
-    ImmutableSet<Scope> scopes = scopesOf(builder.getSubject());
-    String error = null;
-    switch (allowsScoping) {
-      case ALLOWS_SCOPING:
-        if (scopes.size() <= 1) {
-          return;
-        }
-        error = bindingElements("cannot use more than one @Scope");
-        break;
-      case NO_SCOPING:
-        error = bindingElements("cannot be scoped");
-        break;
+    /**
+     * Adds an error if the element has a scope but doesn't allow scoping, or if it has more than
+     * one {@linkplain Scope scope} annotation.
+     */
+    private void checkScopes() {
+      ImmutableSet<Scope> scopes = scopesOf(element);
+      String error = null;
+      switch (allowsScoping) {
+        case ALLOWS_SCOPING:
+          if (scopes.size() <= 1) {
+            return;
+          }
+          error = bindingElements("cannot use more than one @Scope");
+          break;
+        case NO_SCOPING:
+          error = bindingElements("cannot be scoped");
+          break;
+      }
+      verifyNotNull(error);
+      for (Scope scope : scopes) {
+        report.addError(error, element, scope.scopeAnnotation());
+      }
     }
-    verifyNotNull(error);
-    for (Scope scope : scopes) {
-      builder.addError(error, builder.getSubject(), scope.scopeAnnotation());
-    }
-  }
 
-  /**
-   * Adds an error if the {@link #bindingElementType(Builder) type} is a {@linkplain FrameworkTypes
-   * framework type}.
-   */
-  private void checkFrameworkType(ValidationReport.Builder<E> builder) {
-    if (bindingElementType(builder).filter(FrameworkTypes::isFrameworkType).isPresent()) {
-      builder.addError(bindingElements("must not %s framework types", bindingElementTypeVerb()));
+    /**
+     * Adds an error if the {@link #bindingElementType() type} is a {@linkplain FrameworkTypes
+     * framework type}.
+     */
+    private void checkFrameworkType() {
+      if (bindingElementType().filter(FrameworkTypes::isFrameworkType).isPresent()) {
+        report.addError(bindingElements("must not %s framework types", bindingElementTypeVerb()));
+      }
     }
   }
 

--- a/java/dagger/internal/codegen/BindsInstanceParameterValidator.java
+++ b/java/dagger/internal/codegen/BindsInstanceParameterValidator.java
@@ -35,32 +35,40 @@ final class BindsInstanceParameterValidator extends BindsInstanceElementValidato
   BindsInstanceParameterValidator() {}
 
   @Override
-  protected void checkElement(ValidationReport.Builder<VariableElement> report) {
-    super.checkElement(report);
-
-    VariableElement parameter = report.getSubject();
-    Element enclosing = parameter.getEnclosingElement();
-    if (!enclosing.getKind().equals(METHOD)) {
-      report.addError("@BindsInstance should only be applied to methods or parameters of methods");
-      return;
-    }
-
-    ExecutableElement method = MoreElements.asExecutable(enclosing);
-    if (!method.getModifiers().contains(ABSTRACT)) {
-      report.addError("@BindsInstance parameters may only be used in abstract methods");
-    }
-
-    TypeKind returnKind = method.getReturnType().getKind();
-    if (!(returnKind.equals(DECLARED) || returnKind.equals(TYPEVAR))) {
-      report.addError(
-          "@BindsInstance parameters may not be used in methods with a void, array or primitive "
-              + "return type");
-    }
+  protected ElementValidator elementValidator(VariableElement element) {
+    return new Validator(element);
   }
 
-  @Override
-  protected Optional<TypeMirror> bindingElementType(
-      ValidationReport.Builder<VariableElement> report) {
-    return Optional.of(report.getSubject().asType());
+  private class Validator extends ElementValidator {
+    Validator(VariableElement element) {
+      super(element);
+    }
+
+    @Override
+    protected void checkAdditionalProperties() {
+      Element enclosing = element.getEnclosingElement();
+      if (!enclosing.getKind().equals(METHOD)) {
+        report.addError(
+            "@BindsInstance should only be applied to methods or parameters of methods");
+        return;
+      }
+
+      ExecutableElement method = MoreElements.asExecutable(enclosing);
+      if (!method.getModifiers().contains(ABSTRACT)) {
+        report.addError("@BindsInstance parameters may only be used in abstract methods");
+      }
+
+      TypeKind returnKind = method.getReturnType().getKind();
+      if (!(returnKind.equals(DECLARED) || returnKind.equals(TYPEVAR))) {
+        report.addError(
+            "@BindsInstance parameters may not be used in methods with a void, array or primitive "
+                + "return type");
+      }
+    }
+
+    @Override
+    protected Optional<TypeMirror> bindingElementType() {
+      return Optional.of(element.asType());
+    }
   }
 }

--- a/java/dagger/internal/codegen/BindsOptionalOfMethodValidator.java
+++ b/java/dagger/internal/codegen/BindsOptionalOfMethodValidator.java
@@ -60,29 +60,33 @@ final class BindsOptionalOfMethodValidator extends BindingMethodValidator {
   }
 
   @Override
-  protected void checkElement(ValidationReport.Builder<ExecutableElement> builder) {
-    super.checkElement(builder);
-    checkParameters(builder);
+  protected ElementValidator elementValidator(ExecutableElement element) {
+    return new Validator(element);
   }
 
-  @Override
-  protected void checkKeyType(
-      ValidationReport.Builder<ExecutableElement> builder, TypeMirror keyType) {
-    super.checkKeyType(builder, keyType);
-    if (isValidImplicitProvisionKey(
-            getQualifiers(builder.getSubject()).stream().findFirst(), keyType, types)
-        && !injectedConstructors(MoreElements.asType(MoreTypes.asDeclared(keyType).asElement()))
-            .isEmpty()) {
-      builder.addError(
-          "@BindsOptionalOf methods cannot return unqualified types that have an @Inject-"
-              + "annotated constructor because those are always present");
+  private class Validator extends MethodValidator {
+    Validator(ExecutableElement element) {
+      super(element);
     }
-  }
 
-  @Override
-  protected void checkParameters(ValidationReport.Builder<ExecutableElement> builder) {
-    if (!builder.getSubject().getParameters().isEmpty()) {
-      builder.addError("@BindsOptionalOf methods cannot have parameters");
+    @Override
+    protected void checkKeyType(TypeMirror keyType) {
+      super.checkKeyType(keyType);
+      if (isValidImplicitProvisionKey(
+              getQualifiers(element).stream().findFirst(), keyType, types)
+          && !injectedConstructors(MoreElements.asType(MoreTypes.asDeclared(keyType).asElement()))
+              .isEmpty()) {
+        report.addError(
+            "@BindsOptionalOf methods cannot return unqualified types that have an @Inject-"
+                + "annotated constructor because those are always present");
+      }
+    }
+
+    @Override
+    protected void checkParameters() {
+      if (!element.getParameters().isEmpty()) {
+        report.addError("@BindsOptionalOf methods cannot have parameters");
+      }
     }
   }
 }

--- a/java/dagger/internal/codegen/ContributionBinding.java
+++ b/java/dagger/internal/codegen/ContributionBinding.java
@@ -68,7 +68,7 @@ abstract class ContributionBinding extends Binding implements HasContributionTyp
   }
 
   /** If {@link #bindingElement()} is a method that returns a primitive type, returns that type. */
-  Optional<TypeMirror> contributedPrimitiveType() {
+  final Optional<TypeMirror> contributedPrimitiveType() {
     return bindingElement()
         .filter(bindingElement -> bindingElement instanceof ExecutableElement)
         .map(bindingElement -> MoreElements.asExecutable(bindingElement).getReturnType())
@@ -102,7 +102,7 @@ abstract class ContributionBinding extends Binding implements HasContributionTyp
    *
    * <p>All other bindings use the {@link FactoryCreationStrategy#CLASS_CONSTRUCTOR} strategy.
    */
-  FactoryCreationStrategy factoryCreationStrategy() {
+  final FactoryCreationStrategy factoryCreationStrategy() {
     switch (kind()) {
       case DELEGATE:
         return DELEGATE;

--- a/java/dagger/internal/codegen/InjectionSiteFactory.java
+++ b/java/dagger/internal/codegen/InjectionSiteFactory.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2017 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen;
+
+import static com.google.auto.common.MoreElements.isAnnotationPresent;
+import static dagger.internal.codegen.MembersInjectionBinding.InjectionSite.Kind.METHOD;
+import static dagger.internal.codegen.langmodel.DaggerElements.DECLARATION_ORDER;
+import static javax.lang.model.element.Modifier.PRIVATE;
+import static javax.lang.model.element.Modifier.STATIC;
+
+import com.google.auto.common.MoreElements;
+import com.google.auto.common.MoreTypes;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.SetMultimap;
+import dagger.internal.codegen.MembersInjectionBinding.InjectionSite;
+import dagger.internal.codegen.langmodel.DaggerElements;
+import dagger.internal.codegen.langmodel.DaggerTypes;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementVisitor;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementKindVisitor8;
+
+/** A factory for {@link Binding} objects. */
+final class InjectionSiteFactory {
+  private final ElementVisitor<Optional<InjectionSite>, DeclaredType> injectionSiteVisitor =
+      new ElementKindVisitor8<Optional<InjectionSite>, DeclaredType>(Optional.empty()) {
+        @Override
+        public Optional<InjectionSite> visitExecutableAsMethod(
+            ExecutableElement method, DeclaredType type) {
+          ExecutableType resolved = MoreTypes.asExecutable(types.asMemberOf(type, method));
+          return Optional.of(
+              InjectionSite.method(
+                  method,
+                  dependencyRequestFactory.forRequiredResolvedVariables(
+                      method.getParameters(), resolved.getParameterTypes())));
+        }
+
+        @Override
+        public Optional<InjectionSite> visitVariableAsField(
+            VariableElement field, DeclaredType type) {
+          if (!isAnnotationPresent(field, Inject.class)
+              || field.getModifiers().contains(PRIVATE)
+              || field.getModifiers().contains(STATIC)) {
+            return Optional.empty();
+          }
+          TypeMirror resolved = types.asMemberOf(type, field);
+          return Optional.of(
+              InjectionSite.field(
+                  field, dependencyRequestFactory.forRequiredResolvedVariable(field, resolved)));
+        }
+      };
+
+  private final DaggerTypes types;
+  private final DaggerElements elements;
+  private final DependencyRequestFactory dependencyRequestFactory;
+
+  @Inject
+  InjectionSiteFactory(
+      DaggerTypes types,
+      DaggerElements elements,
+      DependencyRequestFactory dependencyRequestFactory) {
+    this.types = types;
+    this.elements = elements;
+    this.dependencyRequestFactory = dependencyRequestFactory;
+  }
+
+  /** Returns the injection sites for a type. */
+  ImmutableSortedSet<InjectionSite> getInjectionSites(DeclaredType declaredType) {
+    Set<InjectionSite> injectionSites = new HashSet<>();
+    List<TypeElement> ancestors = new ArrayList<>();
+    SetMultimap<String, ExecutableElement> overriddenMethodMap = LinkedHashMultimap.create();
+    for (Optional<DeclaredType> currentType = Optional.of(declaredType);
+        currentType.isPresent();
+        currentType = types.nonObjectSuperclass(currentType.get())) {
+      DeclaredType type = currentType.get();
+      ancestors.add(MoreElements.asType(type.asElement()));
+      for (Element enclosedElement : type.asElement().getEnclosedElements()) {
+        Optional<InjectionSite> maybeInjectionSite =
+            injectionSiteVisitor.visit(enclosedElement, type);
+        if (maybeInjectionSite.isPresent()) {
+          InjectionSite injectionSite = maybeInjectionSite.get();
+          if (shouldBeInjected(injectionSite.element(), overriddenMethodMap)) {
+            injectionSites.add(injectionSite);
+          }
+          if (injectionSite.kind().equals(METHOD)) {
+            ExecutableElement injectionSiteMethod =
+                MoreElements.asExecutable(injectionSite.element());
+            overriddenMethodMap.put(
+                injectionSiteMethod.getSimpleName().toString(), injectionSiteMethod);
+          }
+        }
+      }
+    }
+    return ImmutableSortedSet.copyOf(
+        // supertypes before subtypes
+        Comparator.comparing(
+                (InjectionSite injectionSite) ->
+                    ancestors.indexOf(injectionSite.element().getEnclosingElement()))
+            .reversed()
+            // fields before methods
+            .thenComparing(injectionSite -> injectionSite.element().getKind())
+            // then sort by whichever element comes first in the parent
+            // this isn't necessary, but makes the processor nice and predictable
+            .thenComparing(InjectionSite::element, DECLARATION_ORDER),
+        injectionSites);
+  }
+
+  private boolean shouldBeInjected(
+      Element injectionSite, SetMultimap<String, ExecutableElement> overriddenMethodMap) {
+    if (!isAnnotationPresent(injectionSite, Inject.class)
+        || injectionSite.getModifiers().contains(PRIVATE)
+        || injectionSite.getModifiers().contains(STATIC)) {
+      return false;
+    }
+
+    if (injectionSite.getKind().isField()) { // Inject all fields (self and ancestors)
+      return true;
+    }
+
+    // For each method with the same name belonging to any descendant class, return false if any
+    // method has already overridden the injectionSite method. To decrease the number of methods
+    // that are checked, we store the already injected methods in a SetMultimap and only
+    // check the methods with the same name.
+    ExecutableElement injectionSiteMethod = MoreElements.asExecutable(injectionSite);
+    TypeElement injectionSiteType = MoreElements.asType(injectionSite.getEnclosingElement());
+    for (ExecutableElement method :
+        overriddenMethodMap.get(injectionSiteMethod.getSimpleName().toString())) {
+      if (elements.overrides(method, injectionSiteMethod, injectionSiteType)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/java/dagger/internal/codegen/MembersInjectionBinding.java
+++ b/java/dagger/internal/codegen/MembersInjectionBinding.java
@@ -28,8 +28,10 @@ import dagger.model.DependencyRequest;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 
 /**
  * Represents the full members injection of a particular type.
@@ -122,6 +124,17 @@ abstract class MembersInjectionBinding extends Binding {
           .filter(element -> element.getSimpleName().equals(this.element().getSimpleName()))
           .collect(toList())
           .indexOf(element());
+    }
+
+    static InjectionSite field(VariableElement element, DependencyRequest dependency) {
+      return new AutoValue_MembersInjectionBinding_InjectionSite(
+          Kind.FIELD, element, ImmutableSet.of(dependency));
+    }
+
+    static InjectionSite method(
+        ExecutableElement element, Iterable<DependencyRequest> dependencies) {
+      return new AutoValue_MembersInjectionBinding_InjectionSite(
+          Kind.METHOD, element, ImmutableSet.copyOf(dependencies));
     }
   }
 }

--- a/java/dagger/internal/codegen/ProvidesMethodValidator.java
+++ b/java/dagger/internal/codegen/ProvidesMethodValidator.java
@@ -55,15 +55,24 @@ final class ProvidesMethodValidator extends BindingMethodValidator {
   }
 
   @Override
-  protected void checkElement(ValidationReport.Builder<ExecutableElement> builder) {
-    super.checkElement(builder);
+  protected ElementValidator elementValidator(ExecutableElement element) {
+    return new Validator(element);
   }
 
-  /** Adds an error if a {@link Provides @Provides} method depends on a producer type. */
-  @Override
-  protected void checkParameter(
-      ValidationReport.Builder<ExecutableElement> builder, VariableElement parameter) {
-    super.checkParameter(builder, parameter);
-    dependencyRequestValidator.checkNotProducer(builder, parameter);
+  private class Validator extends MethodValidator {
+    Validator(ExecutableElement element) {
+      super(element);
+    }
+
+    @Override
+    protected void checkAdditionalMethodProperties() {
+    }
+
+    /** Adds an error if a {@link Provides @Provides} method depends on a producer type. */
+    @Override
+    protected void checkParameter(VariableElement parameter) {
+      super.checkParameter(parameter);
+      dependencyRequestValidator.checkNotProducer(report, parameter);
+    }
   }
 }

--- a/java/dagger/model/BindingGraph.java
+++ b/java/dagger/model/BindingGraph.java
@@ -426,6 +426,13 @@ public abstract class BindingGraph {
     public final String toString() {
       return String.format("missing binding for %s in %s", key(), componentPath());
     }
+
+    @Memoized
+    @Override
+    public abstract int hashCode();
+
+    @Override
+    public abstract boolean equals(Object o);
   }
 
   /**


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix malformed javadoc links. These won't build with javac11.

8bb5d7a0a07080c521e81924461976f2af08c0a4

-------

<p> Memoize MissingBinding's hashCode()

efc566cb08f83e6db124a054cd766c4a581a93b8

-------

<p> Refactor BindingMethodValidator to avoid the need to pass around the ValidationReport.Builder or call getSubject() on it.

2e950af1b6dfd6c58276d139711358555698a2a6

-------

<p> Make methods that aren't overridden final.

93b1ce4f36235f1dc992eac15f62fc3c728d48d0

-------

<p> Use one missing binding node per-key in AOT.

From a purely practical perspective, we don't need multiple categories of missing binding nodes because we don't report missing bindings on AOT subcomponents. This creates many fewer nodes and avoids some performance regressions in common.graph for Networks with parallels edges.

Even if we did, it seems that we don't currently use the component path in error reporting.

3bfbe5c39e4a9f55ff6b7293e52ade1dadc36582

-------

<p> Refactoring: Extract InjectionSiteFactory from BindingFactory.

0776a505ce329128d8a56cb102761c47c28ab442