### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/ComponentInstanceBindingExpression.java
+++ b/java/dagger/internal/codegen/ComponentInstanceBindingExpression.java
@@ -25,10 +25,10 @@ final class ComponentInstanceBindingExpression extends SimpleInvocationBindingEx
   private final ClassName componentName;
   private final ContributionBinding binding;
 
-  ComponentInstanceBindingExpression(ResolvedBindings resolvedBindings, ClassName componentName) {
-    super(resolvedBindings);
+  ComponentInstanceBindingExpression(ContributionBinding binding, ClassName componentName) {
+    super(binding);
+    this.binding = binding;
     this.componentName = componentName;
-    this.binding = resolvedBindings.contributionBinding();
   }
 
   @Override

--- a/java/dagger/internal/codegen/ComponentProvisionBindingExpression.java
+++ b/java/dagger/internal/codegen/ComponentProvisionBindingExpression.java
@@ -31,12 +31,12 @@ final class ComponentProvisionBindingExpression extends SimpleInvocationBindingE
   private final CompilerOptions compilerOptions;
 
   ComponentProvisionBindingExpression(
-      ResolvedBindings resolvedBindings,
+      ProvisionBinding binding,
       BindingGraph bindingGraph,
       ComponentRequirementExpressions componentRequirementExpressions,
       CompilerOptions compilerOptions) {
-    super(resolvedBindings);
-    this.binding = (ProvisionBinding) resolvedBindings.contributionBinding();
+    super(binding);
+    this.binding = binding;
     this.bindingGraph = checkNotNull(bindingGraph);
     this.componentRequirementExpressions = checkNotNull(componentRequirementExpressions);
     this.compilerOptions = checkNotNull(compilerOptions);

--- a/java/dagger/internal/codegen/ComponentRequirementBindingExpression.java
+++ b/java/dagger/internal/codegen/ComponentRequirementBindingExpression.java
@@ -29,10 +29,10 @@ final class ComponentRequirementBindingExpression extends SimpleInvocationBindin
   private final ComponentRequirementExpressions componentRequirementExpressions;
 
   ComponentRequirementBindingExpression(
-      ResolvedBindings resolvedBindings,
+      ContributionBinding binding,
       ComponentRequirement componentRequirement,
       ComponentRequirementExpressions componentRequirementExpressions) {
-    super(resolvedBindings);
+    super(binding);
     this.componentRequirement = componentRequirement;
     this.componentRequirementExpressions = componentRequirementExpressions;
   }

--- a/java/dagger/internal/codegen/DelegateBindingExpression.java
+++ b/java/dagger/internal/codegen/DelegateBindingExpression.java
@@ -65,8 +65,8 @@ final class DelegateBindingExpression extends BindingExpression {
             .contributionBindings()
             .get(getOnlyElement(bindsBinding.dependencies()).key())
             .binding();
-    ScopeKind bindsScope = ScopeKind.get(bindsBinding, graph);
-    ScopeKind dependencyScope = ScopeKind.get(dependencyBinding, graph);
+    ScopeKind bindsScope = ScopeKind.get(bindsBinding);
+    ScopeKind dependencyScope = ScopeKind.get(dependencyBinding);
     return bindsScope.isStrongerScopeThan(dependencyScope);
   }
 
@@ -119,7 +119,7 @@ final class DelegateBindingExpression extends BindingExpression {
     DOUBLE_CHECK,
     ;
 
-    static ScopeKind get(Binding binding, BindingGraph graph) {
+    static ScopeKind get(Binding binding) {
       return binding
           .scope()
           .map(scope -> scope.isReusable() ? SINGLE_CHECK : DOUBLE_CHECK)

--- a/java/dagger/internal/codegen/DelegateBindingExpression.java
+++ b/java/dagger/internal/codegen/DelegateBindingExpression.java
@@ -40,12 +40,12 @@ final class DelegateBindingExpression extends BindingExpression {
   private final BindsTypeChecker bindsTypeChecker;
 
   DelegateBindingExpression(
-      ResolvedBindings resolvedBindings,
+      ContributionBinding binding,
       RequestKind requestKind,
       ComponentBindingExpressions componentBindingExpressions,
       DaggerTypes types,
       DaggerElements elements) {
-    this.binding = checkNotNull(resolvedBindings.contributionBinding());
+    this.binding = checkNotNull(binding);
     this.requestKind = checkNotNull(requestKind);
     this.componentBindingExpressions = checkNotNull(componentBindingExpressions);
     this.types = checkNotNull(types);
@@ -57,8 +57,7 @@ final class DelegateBindingExpression extends BindingExpression {
    * binding it depends on.
    */
   static boolean isBindsScopeStrongerThanDependencyScope(
-      ResolvedBindings resolvedBindings, BindingGraph graph) {
-    ContributionBinding bindsBinding = resolvedBindings.contributionBinding();
+      ContributionBinding bindsBinding, BindingGraph graph) {
     checkArgument(bindsBinding.kind().equals(DELEGATE));
     Binding dependencyBinding =
         graph

--- a/java/dagger/internal/codegen/FrameworkInstanceBindingExpression.java
+++ b/java/dagger/internal/codegen/FrameworkInstanceBindingExpression.java
@@ -30,17 +30,17 @@ import javax.lang.model.type.TypeMirror;
 
 /** A binding expression that uses a {@link FrameworkType} field. */
 abstract class FrameworkInstanceBindingExpression extends BindingExpression {
-  private final ResolvedBindings resolvedBindings;
+  private final ContributionBinding binding;
   private final FrameworkInstanceSupplier frameworkInstanceSupplier;
   private final DaggerTypes types;
   private final DaggerElements elements;
 
   FrameworkInstanceBindingExpression(
-      ResolvedBindings resolvedBindings,
+      ContributionBinding binding,
       FrameworkInstanceSupplier frameworkInstanceSupplier,
       DaggerTypes types,
       DaggerElements elements) {
-    this.resolvedBindings = checkNotNull(resolvedBindings);
+    this.binding = checkNotNull(binding);
     this.frameworkInstanceSupplier = checkNotNull(frameworkInstanceSupplier);
     this.types = checkNotNull(types);
     this.elements = checkNotNull(elements);
@@ -55,11 +55,10 @@ abstract class FrameworkInstanceBindingExpression extends BindingExpression {
   @Override
   Expression getDependencyExpression(ClassName requestingClass) {
     MemberSelect memberSelect = frameworkInstanceSupplier.memberSelect();
-    TypeMirror contributedType = resolvedBindings.contributionBinding().contributedType();
     TypeMirror expressionType =
-        isTypeAccessibleFrom(contributedType, requestingClass.packageName())
+        isTypeAccessibleFrom(binding.contributedType(), requestingClass.packageName())
                 || isInlinedFactoryCreation(memberSelect)
-            ? types.wrapType(contributedType, frameworkType().frameworkClass())
+            ? types.wrapType(binding.contributedType(), frameworkType().frameworkClass())
             : rawFrameworkType();
     return Expression.create(expressionType, memberSelect.getExpressionFor(requestingClass));
   }

--- a/java/dagger/internal/codegen/ImmediateFutureBindingExpression.java
+++ b/java/dagger/internal/codegen/ImmediateFutureBindingExpression.java
@@ -30,21 +30,20 @@ import dagger.model.RequestKind;
 import javax.lang.model.SourceVersion;
 
 final class ImmediateFutureBindingExpression extends BindingExpression {
-
+  private final Key key;
   private final ComponentBindingExpressions componentBindingExpressions;
   private final DaggerTypes types;
   private final SourceVersion sourceVersion;
-  private final Key key;
 
   ImmediateFutureBindingExpression(
-      ResolvedBindings resolvedBindings,
+      Key key,
       ComponentBindingExpressions componentBindingExpressions,
       DaggerTypes types,
       SourceVersion sourceVersion) {
+    this.key = key;
     this.componentBindingExpressions = checkNotNull(componentBindingExpressions);
     this.types = checkNotNull(types);
     this.sourceVersion = checkNotNull(sourceVersion);
-    this.key = resolvedBindings.key();
   }
 
   @Override

--- a/java/dagger/internal/codegen/MapBindingExpression.java
+++ b/java/dagger/internal/codegen/MapBindingExpression.java
@@ -52,14 +52,14 @@ final class MapBindingExpression extends MultibindingExpression {
   private final DaggerElements elements;
 
   MapBindingExpression(
-      ResolvedBindings resolvedBindings,
+      ProvisionBinding binding,
       ComponentImplementation componentImplementation,
       BindingGraph graph,
       ComponentBindingExpressions componentBindingExpressions,
       DaggerTypes types,
       DaggerElements elements) {
-    super(resolvedBindings, componentImplementation);
-    this.binding = (ProvisionBinding) resolvedBindings.contributionBinding();
+    super(binding, componentImplementation);
+    this.binding = binding;
     BindingKind bindingKind = this.binding.kind();
     checkArgument(bindingKind.equals(MULTIBOUND_MAP), bindingKind);
     this.componentBindingExpressions = componentBindingExpressions;

--- a/java/dagger/internal/codegen/MemberSelect.java
+++ b/java/dagger/internal/codegen/MemberSelect.java
@@ -106,21 +106,7 @@ abstract class MemberSelect {
    * this method returns the static member select that returns the factory or no-op members
    * injector.
    */
-  static Optional<MemberSelect> staticFactoryCreation(ResolvedBindings resolvedBindings) {
-    if (resolvedBindings.contributionBindings().isEmpty()) {
-      throw new AssertionError(
-          "Expected a contribution binding, but none found. *THIS IS A DAGGER BUG* - please "
-              + "report it on Github with as much context as you can provide. Thanks!"
-              + "\n\nKey: "
-              + resolvedBindings.key()
-              + "\nMultibinding declarations: "
-              + resolvedBindings.multibindingDeclarations()
-              + "\nSubcomponent declarations: "
-              + resolvedBindings.subcomponentDeclarations()
-              + "\nOptional binding declarations: "
-              + resolvedBindings.optionalBindingDeclarations());
-    }
-    ContributionBinding contributionBinding = resolvedBindings.contributionBinding();
+  static Optional<MemberSelect> staticFactoryCreation(ContributionBinding contributionBinding) {
     if (contributionBinding.factoryCreationStrategy().equals(SINGLETON_INSTANCE)
         && !contributionBinding.scope().isPresent()) {
       switch (contributionBinding.kind()) {
@@ -132,7 +118,7 @@ abstract class MemberSelect {
 
         case INJECTION:
         case PROVISION:
-          TypeMirror keyType = resolvedBindings.key().type();
+          TypeMirror keyType = contributionBinding.key().type();
           if (keyType.getKind().equals(DECLARED)) {
             ImmutableList<TypeVariableName> typeVariables =
                 bindingTypeElementTypeVariableNames(contributionBinding);

--- a/java/dagger/internal/codegen/MembersInjectionBindingExpression.java
+++ b/java/dagger/internal/codegen/MembersInjectionBindingExpression.java
@@ -35,8 +35,8 @@ final class MembersInjectionBindingExpression extends BindingExpression {
   private final MembersInjectionMethods membersInjectionMethods;
 
   MembersInjectionBindingExpression(
-      ResolvedBindings resolvedBindings, MembersInjectionMethods membersInjectionMethods) {
-    this.binding = resolvedBindings.membersInjectionBinding().get();
+      MembersInjectionBinding binding, MembersInjectionMethods membersInjectionMethods) {
+    this.binding = binding;
     this.membersInjectionMethods = membersInjectionMethods;
   }
 

--- a/java/dagger/internal/codegen/MultibindingExpression.java
+++ b/java/dagger/internal/codegen/MultibindingExpression.java
@@ -34,10 +34,10 @@ abstract class MultibindingExpression extends SimpleInvocationBindingExpression 
   private final ComponentImplementation componentImplementation;
 
   MultibindingExpression(
-      ResolvedBindings resolvedBindings, ComponentImplementation componentImplementation) {
-    super(resolvedBindings);
+      ProvisionBinding binding, ComponentImplementation componentImplementation) {
+    super(binding);
+    this.binding = binding;
     this.componentImplementation = componentImplementation;
-    this.binding = (ProvisionBinding) resolvedBindings.contributionBinding();
   }
 
   @Override

--- a/java/dagger/internal/codegen/OptionalBindingExpression.java
+++ b/java/dagger/internal/codegen/OptionalBindingExpression.java
@@ -38,12 +38,12 @@ final class OptionalBindingExpression extends SimpleInvocationBindingExpression 
 
   @Inject
   OptionalBindingExpression(
-      ResolvedBindings resolvedBindings,
+      ProvisionBinding binding,
       ComponentBindingExpressions componentBindingExpressions,
       DaggerTypes types,
       SourceVersion sourceVersion) {
-    super(resolvedBindings);
-    this.binding = (ProvisionBinding) resolvedBindings.contributionBinding();
+    super(binding);
+    this.binding = binding;
     this.componentBindingExpressions = componentBindingExpressions;
     this.types = types;
     this.sourceVersion = sourceVersion;

--- a/java/dagger/internal/codegen/ProducerNodeInstanceBindingExpression.java
+++ b/java/dagger/internal/codegen/ProducerNodeInstanceBindingExpression.java
@@ -33,14 +33,14 @@ final class ProducerNodeInstanceBindingExpression extends FrameworkInstanceBindi
   private final ProducerEntryPointView producerEntryPointView;
 
   ProducerNodeInstanceBindingExpression(
-      ResolvedBindings resolvedBindings,
+      ContributionBinding binding,
       FrameworkInstanceSupplier frameworkInstanceSupplier,
       DaggerTypes types,
       DaggerElements elements,
       ComponentImplementation componentImplementation) {
-    super(resolvedBindings, frameworkInstanceSupplier, types, elements);
+    super(binding, frameworkInstanceSupplier, types, elements);
     this.componentImplementation = checkNotNull(componentImplementation);
-    this.key = resolvedBindings.key();
+    this.key = binding.key();
     this.producerEntryPointView = new ProducerEntryPointView(types);
   }
 

--- a/java/dagger/internal/codegen/ProviderInstanceBindingExpression.java
+++ b/java/dagger/internal/codegen/ProviderInstanceBindingExpression.java
@@ -23,12 +23,12 @@ import dagger.internal.codegen.langmodel.DaggerTypes;
 final class ProviderInstanceBindingExpression extends FrameworkInstanceBindingExpression {
 
   ProviderInstanceBindingExpression(
-      ResolvedBindings resolvedBindings,
+      ContributionBinding binding,
       FrameworkInstanceSupplier frameworkInstanceSupplier,
       DaggerTypes types,
       DaggerElements elements) {
     super(
-        resolvedBindings,
+        binding,
         frameworkInstanceSupplier,
         types,
         elements);

--- a/java/dagger/internal/codegen/SetBindingExpression.java
+++ b/java/dagger/internal/codegen/SetBindingExpression.java
@@ -44,14 +44,14 @@ final class SetBindingExpression extends MultibindingExpression {
   private final DaggerElements elements;
 
   SetBindingExpression(
-      ResolvedBindings resolvedBindings,
+      ProvisionBinding binding,
       ComponentImplementation componentImplementation,
       BindingGraph graph,
       ComponentBindingExpressions componentBindingExpressions,
       DaggerTypes types,
       DaggerElements elements) {
-    super(resolvedBindings, componentImplementation);
-    this.binding = (ProvisionBinding) resolvedBindings.contributionBinding();
+    super(binding, componentImplementation);
+    this.binding = binding;
     this.graph = graph;
     this.componentBindingExpressions = componentBindingExpressions;
     this.types = types;

--- a/java/dagger/internal/codegen/SimpleInvocationBindingExpression.java
+++ b/java/dagger/internal/codegen/SimpleInvocationBindingExpression.java
@@ -20,15 +20,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 /** A simple binding expression for instance requests. Does not scope. */
 abstract class SimpleInvocationBindingExpression extends BindingExpression {
-  // TODO(dpb): Take ContributionBinding instead of ResolvedBindings.
-  private final ResolvedBindings resolvedBindings;
+  private final ContributionBinding binding;
 
-  SimpleInvocationBindingExpression(ResolvedBindings resolvedBindings) {
-    this.resolvedBindings = checkNotNull(resolvedBindings);
+  SimpleInvocationBindingExpression(ContributionBinding binding) {
+    this.binding = checkNotNull(binding);
   }
 
   @Override
   boolean requiresMethodEncapsulation() {
-    return !resolvedBindings.contributionBinding().dependencies().isEmpty();
+    return !binding.dependencies().isEmpty();
   }
 }

--- a/java/dagger/internal/codegen/SimpleMethodBindingExpression.java
+++ b/java/dagger/internal/codegen/SimpleMethodBindingExpression.java
@@ -58,7 +58,7 @@ final class SimpleMethodBindingExpression extends SimpleInvocationBindingExpress
   private final SourceVersion sourceVersion;
 
   SimpleMethodBindingExpression(
-      ResolvedBindings resolvedBindings,
+      ProvisionBinding binding,
       CompilerOptions compilerOptions,
       ComponentBindingExpressions componentBindingExpressions,
       MembersInjectionMethods membersInjectionMethods,
@@ -66,9 +66,9 @@ final class SimpleMethodBindingExpression extends SimpleInvocationBindingExpress
       DaggerTypes types,
       DaggerElements elements,
       SourceVersion sourceVersion) {
-    super(resolvedBindings);
+    super(binding);
     this.compilerOptions = compilerOptions;
-    this.provisionBinding = (ProvisionBinding) resolvedBindings.contributionBinding();
+    this.provisionBinding = binding;
     checkArgument(
         provisionBinding.implicitDependencies().isEmpty(),
         "framework deps are not currently supported");

--- a/java/dagger/internal/codegen/SubcomponentCreatorBindingExpression.java
+++ b/java/dagger/internal/codegen/SubcomponentCreatorBindingExpression.java
@@ -26,9 +26,9 @@ final class SubcomponentCreatorBindingExpression extends SimpleInvocationBinding
   private final String creatorImplementationName;
 
   SubcomponentCreatorBindingExpression(
-      ResolvedBindings resolvedBindings, String creatorImplementationName) {
-    super(resolvedBindings);
-    this.creatorType = resolvedBindings.key().type();
+      ContributionBinding binding, String creatorImplementationName) {
+    super(binding);
+    this.creatorType = binding.key().type();
     this.creatorImplementationName = creatorImplementationName;
   }
 

--- a/javatests/dagger/android/AndroidInjectionTest.java
+++ b/javatests/dagger/android/AndroidInjectionTest.java
@@ -29,7 +29,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.util.FragmentTestUtil;
 
-@Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
 public final class AndroidInjectionTest {
 
@@ -55,7 +54,7 @@ public final class AndroidInjectionTest {
     }
   }
 
-  @Config(manifest = Config.NONE, application = ApplicationInjectsFragment.class)
+  @Config(application = ApplicationInjectsFragment.class)
   @Test
   public void fragmentInjectedByApplication() {
     Activity activity = Robolectric.setupActivity(Activity.class);
@@ -74,7 +73,7 @@ public final class AndroidInjectionTest {
     }
   }
 
-  @Config(manifest = Config.NONE, application = ApplicationInjectsFragment.class)
+  @Config(application = ApplicationInjectsFragment.class)
   @Test
   public void fragmentInjectedByActivity() {
     ActivityInjectsFragment activity = Robolectric.setupActivity(ActivityInjectsFragment.class);
@@ -94,7 +93,7 @@ public final class AndroidInjectionTest {
     }
   }
 
-  @Config(manifest = Config.NONE, application = ApplicationInjectsFragment.class)
+  @Config(application = ApplicationInjectsFragment.class)
   @Test
   public void fragmentInjectedByParentFragment() {
     ActivityInjectsFragment activity = Robolectric.setupActivity(ActivityInjectsFragment.class);
@@ -153,7 +152,7 @@ public final class AndroidInjectionTest {
   }
 
   @Test
-  @Config(manifest = Config.NONE, application = ApplicationReturnsNull.class)
+  @Config(application = ApplicationReturnsNull.class)
   public void activityInjector_returnsNull() {
     Activity activity = Robolectric.setupActivity(Activity.class);
 
@@ -166,7 +165,7 @@ public final class AndroidInjectionTest {
   }
 
   @Test
-  @Config(manifest = Config.NONE, application = ApplicationReturnsNull.class)
+  @Config(application = ApplicationReturnsNull.class)
   public void fragmentInjector_returnsNull() {
     Fragment fragment = new Fragment();
     FragmentTestUtil.startFragment(fragment);

--- a/javatests/dagger/android/DispatchingAndroidInjectorTest.java
+++ b/javatests/dagger/android/DispatchingAndroidInjectorTest.java
@@ -29,9 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
 public final class DispatchingAndroidInjectorTest {
   @Test

--- a/javatests/dagger/android/support/AndroidSupportInjectionTest.java
+++ b/javatests/dagger/android/support/AndroidSupportInjectionTest.java
@@ -28,7 +28,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.support.v4.SupportFragmentTestUtil;
 
-@Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
 public final class AndroidSupportInjectionTest {
   @Test
@@ -53,7 +52,7 @@ public final class AndroidSupportInjectionTest {
   }
 
   @Test
-  @Config(manifest = Config.NONE, application = ApplicationReturnsNull.class)
+  @Config(application = ApplicationReturnsNull.class)
   public void fragmentInjector_returnsNull() {
     Fragment fragment = new Fragment();
     SupportFragmentTestUtil.startFragment(fragment);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove unnecessary "manifest = ..." entries from @Config annotations.

cfcbb56ac77b8530c4435e4043ad6861524e74bc

-------

<p> Remove unused parameter

e5714993957509ac05c605620d5fcbeb58d9de37

-------

<p> Fix a bug where an @Inject method has a parameter name that is valid on the JVM but invalid for the Java language.

This can happen with the following code in Kotlin:

class Test {
    @set:Inject
    internal var foo: String? = null
}

5e0fa252b9a7b1312347b11a21b03be328237212

-------

<p> Reduce usages of ResolvedBindings as much as possible.

This will make future refactoring easier when we migrate away from the internal binding graph to dagger.model.BindingGraph

98073c65a2480152acd3170475c97d931c9e271b