### PR TITLE
Moe Sync

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,8 +16,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "google_bazel_common",
-    strip_prefix = "bazel-common-597824dfc652477e08f229707fa167f595cf7060",
-    urls = ["https://github.com/google/bazel-common/archive/597824dfc652477e08f229707fa167f595cf7060.zip"],
+    strip_prefix = "bazel-common-3ce0644a7d7da09218b96b3218f409ea8f8c84e6",
+    urls = ["https://github.com/google/bazel-common/archive/3ce0644a7d7da09218b96b3218f409ea8f8c84e6.zip"],
 )
 
 load("@google_bazel_common//:workspace_defs.bzl", "google_common_workspace_rules")

--- a/javatests/dagger/android/processor/BUILD
+++ b/javatests/dagger/android/processor/BUILD
@@ -34,7 +34,6 @@ GenJavaTests(
         "//:dagger_with_compiler",
         "@google_bazel_common//third_party/java/junit",
         "@google_bazel_common//third_party/java/truth",
-        "@google_bazel_common//third_party/java/truth:truth8",
         "//java/dagger/android",
         "//java/dagger/android/processor",
         "//java/dagger/internal/codegen:processor",

--- a/javatests/dagger/functional/jdk8/BUILD
+++ b/javatests/dagger/functional/jdk8/BUILD
@@ -27,7 +27,7 @@ GenJavaTests(
     test_only_deps = [
         "@google_bazel_common//third_party/java/guava",
         "@google_bazel_common//third_party/java/junit",
-        "@google_bazel_common//third_party/java/truth:truth8",
+        "@google_bazel_common//third_party/java/truth",
     ],
     deps = [
         "//:dagger_with_compiler",

--- a/javatests/dagger/functional/producers/BUILD
+++ b/javatests/dagger/functional/producers/BUILD
@@ -38,7 +38,6 @@ GenJavaTests(
         "@google_bazel_common//third_party/java/junit",
         "@google_bazel_common//third_party/java/mockito",
         "@google_bazel_common//third_party/java/truth",
-        "@google_bazel_common//third_party/java/truth:truth8",
     ],
 )
 

--- a/javatests/dagger/internal/codegen/BUILD
+++ b/javatests/dagger/internal/codegen/BUILD
@@ -50,6 +50,5 @@ GenJavaTests(
         "@google_bazel_common//third_party/java/junit",
         "@google_bazel_common//third_party/java/mockito",
         "@google_bazel_common//third_party/java/truth",
-        "@google_bazel_common//third_party/java/truth:truth8",
     ],
 )


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update to a version of bazel-common that exports truth8 from the regular truth target

ea4c26fa41fcde535e36a64650084593e13f55a6

-------

<p> Remove usages of :truth8, which is now exported by :truth.

7b7ac0f601560051090f359e09fbf08eeaf6b596