### PR TITLE
Start better Kotlin support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,6 +24,21 @@ load("@google_bazel_common//:workspace_defs.bzl", "google_common_workspace_rules
 
 google_common_workspace_rules()
 
+maven_jar(
+    name = "org_jetbrains_kotlinx_kotlinx_metadata_jvm",
+    artifact = "org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0",
+)
+
+maven_jar(
+    name = "org_jetbrains_kotlin_kotlin_stdlib",
+    artifact = "org.jetbrains.kotlin:kotlin-stdlib:1.3.41",
+)
+
+maven_jar(
+    name = "org_jetbrains_annotations",
+    artifact = "org.jetbrains:annotations:13.0",
+)
+
 # This fixes an issue with protobuf starting to use zlib by default in 3.7.0.
 # TODO(ronshapiro): Figure out if this is in fact necessary, or if proto can depend on the
 # @bazel_tools library directly. See discussion in

--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -53,6 +53,9 @@ CODEGEN_SHARED_DEPS = [
     "//java/dagger/model",
     "//java/dagger/spi",
     "//java/dagger/model:internal-proxies",
+    "@org_jetbrains_kotlinx_kotlinx_metadata_jvm//jar",
+    "@org_jetbrains_kotlin_kotlin_stdlib//jar",
+    "@org_jetbrains_annotations//jar"
 ]
 
 CODEGEN_DEPS = CODEGEN_SHARED_DEPS + [

--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -99,6 +99,7 @@ java_library(
         "FrameworkTypes.java",
         "InjectionAnnotations.java",
         "Keys.java",
+        "KotlinUtil.java",
         "MapKeyAccessibility.java",
         "MapType.java",
         "ModuleAnnotation.java",

--- a/java/dagger/internal/codegen/CompilerOptions.java
+++ b/java/dagger/internal/codegen/CompilerOptions.java
@@ -74,4 +74,6 @@ abstract class CompilerOptions {
   abstract Diagnostic.Kind moduleHasDifferentScopesDiagnosticKind();
 
   abstract ValidationType explicitBindingConflictsWithInjectValidationType();
+
+  abstract boolean kotlinMetadata();
 }

--- a/java/dagger/internal/codegen/ForwardingCompilerOptions.java
+++ b/java/dagger/internal/codegen/ForwardingCompilerOptions.java
@@ -16,10 +16,10 @@
 
 package dagger.internal.codegen;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /** A {@link CompilerOptions} object that delegates to another one. */
 class ForwardingCompilerOptions extends CompilerOptions {
@@ -103,5 +103,10 @@ class ForwardingCompilerOptions extends CompilerOptions {
   @Override
   ValidationType explicitBindingConflictsWithInjectValidationType() {
     return delegate.explicitBindingConflictsWithInjectValidationType();
+  }
+
+  @Override
+  boolean kotlinMetadata() {
+    return delegate.kotlinMetadata();
   }
 }

--- a/java/dagger/internal/codegen/JavacPluginModule.java
+++ b/java/dagger/internal/codegen/JavacPluginModule.java
@@ -16,9 +16,6 @@
 
 package dagger.internal.codegen;
 
-import static dagger.internal.codegen.ValidationType.NONE;
-import static javax.tools.Diagnostic.Kind.NOTE;
-
 import com.sun.tools.javac.model.JavacElements;
 import com.sun.tools.javac.model.JavacTypes;
 import com.sun.tools.javac.util.Context;
@@ -35,6 +32,9 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
+
+import static dagger.internal.codegen.ValidationType.NONE;
+import static javax.tools.Diagnostic.Kind.NOTE;
 
 /**
  * A module that provides a {@link BindingGraphFactory} and {@link ComponentDescriptorFactory} for
@@ -118,6 +118,11 @@ abstract class JavacPluginModule {
       @Override
       ValidationType explicitBindingConflictsWithInjectValidationType() {
         return NONE;
+      }
+
+      @Override
+      boolean kotlinMetadata() {
+        return false;
       }
     };
   }

--- a/java/dagger/internal/codegen/KotlinUtil.java
+++ b/java/dagger/internal/codegen/KotlinUtil.java
@@ -1,0 +1,43 @@
+package dagger.internal.codegen;
+
+import java.util.Optional;
+import javax.lang.model.element.TypeElement;
+import kotlin.Metadata;
+import kotlinx.metadata.KmClass;
+import kotlinx.metadata.jvm.KotlinClassHeader;
+import kotlinx.metadata.jvm.KotlinClassMetadata;
+
+final class KotlinUtil {
+
+  static Optional<KmClass> kmClassOf(Optional<TypeElement> optionalTypeElement) {
+    if (!optionalTypeElement.isPresent()) {
+      return Optional.empty();
+    }
+    Metadata metadataAnnotation = optionalTypeElement.get().getAnnotation(Metadata.class);
+    KotlinClassHeader header = new KotlinClassHeader(
+        metadataAnnotation.k(),
+        metadataAnnotation.mv(),
+        metadataAnnotation.bv(),
+        metadataAnnotation.d1(),
+        metadataAnnotation.d2(),
+        metadataAnnotation.xs(),
+        metadataAnnotation.pn(),
+        metadataAnnotation.xi()
+    );
+    KotlinClassMetadata metadata = KotlinClassMetadata.read(header);
+    if (metadata == null) {
+      // Should only happen on Kotlin <1.1
+      return Optional.empty();
+    }
+    if (metadata instanceof KotlinClassMetadata.Class) {
+      return Optional.of(((KotlinClassMetadata.Class) metadata).toKmClass());
+    } else {
+      // Unsupported
+      return Optional.empty();
+    }
+  }
+
+  private KotlinUtil() {
+
+  }
+}

--- a/java/dagger/internal/codegen/MembersInjectionBinding.java
+++ b/java/dagger/internal/codegen/MembersInjectionBinding.java
@@ -83,7 +83,7 @@ abstract class MembersInjectionBinding extends Binding {
   }
 
   @Override
-  boolean requiresModuleInstance() {
+  boolean requiresModuleInstance(CompilerOptions options) {
     return false;
   }
 

--- a/java/dagger/internal/codegen/ProcessingEnvironmentCompilerOptions.java
+++ b/java/dagger/internal/codegen/ProcessingEnvironmentCompilerOptions.java
@@ -16,6 +16,22 @@
 
 package dagger.internal.codegen;
 
+import com.google.common.base.Ascii;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import dagger.producers.Produces;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+
 import static com.google.common.base.CaseFormat.LOWER_CAMEL;
 import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -32,6 +48,7 @@ import static dagger.internal.codegen.ProcessingEnvironmentCompilerOptions.Featu
 import static dagger.internal.codegen.ProcessingEnvironmentCompilerOptions.Feature.WARN_IF_INJECTION_FACTORY_NOT_GENERATED_UPSTREAM;
 import static dagger.internal.codegen.ProcessingEnvironmentCompilerOptions.Feature.WRITE_PRODUCER_NAME_IN_TOKEN;
 import static dagger.internal.codegen.ProcessingEnvironmentCompilerOptions.KeyOnlyOption.HEADER_COMPILATION;
+import static dagger.internal.codegen.ProcessingEnvironmentCompilerOptions.KeyOnlyOption.KOTLIN_METADATA;
 import static dagger.internal.codegen.ProcessingEnvironmentCompilerOptions.KeyOnlyOption.USE_GRADLE_INCREMENTAL_PROCESSING;
 import static dagger.internal.codegen.ProcessingEnvironmentCompilerOptions.Validation.DISABLE_INTER_COMPONENT_SCOPE_VALIDATION;
 import static dagger.internal.codegen.ProcessingEnvironmentCompilerOptions.Validation.EXPLICIT_BINDING_CONFLICTS_WITH_INJECT;
@@ -45,22 +62,6 @@ import static dagger.internal.codegen.ValidationType.NONE;
 import static dagger.internal.codegen.ValidationType.WARNING;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Stream.concat;
-
-import com.google.common.base.Ascii;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import dagger.producers.Produces;
-import java.util.Arrays;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Stream;
-import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.TypeElement;
-import javax.tools.Diagnostic;
 
 final class ProcessingEnvironmentCompilerOptions extends CompilerOptions {
   /** Returns a valid {@link CompilerOptions} parsed from the processing environment. */
@@ -157,6 +158,10 @@ final class ProcessingEnvironmentCompilerOptions extends CompilerOptions {
     return parseOption(EXPLICIT_BINDING_CONFLICTS_WITH_INJECT);
   }
 
+  @Override boolean kotlinMetadata() {
+    return isEnabled(KOTLIN_METADATA);
+  }
+
   private boolean isEnabled(KeyOnlyOption keyOnlyOption) {
     return processingEnvironment.getOptions().containsKey(keyOnlyOption.toString());
   }
@@ -236,6 +241,13 @@ final class ProcessingEnvironmentCompilerOptions extends CompilerOptions {
       @Override
       public String toString() {
         return "dagger.gradle.incremental";
+      }
+    },,
+
+    KOTLIN_METADATA {
+      @Override
+      public String toString() {
+        return "dagger.kotlin.metadata";
       }
     },
   }

--- a/java/dagger/internal/codegen/ProductionBinding.java
+++ b/java/dagger/internal/codegen/ProductionBinding.java
@@ -103,8 +103,8 @@ abstract class ProductionBinding extends ContributionBinding {
   // performance improvement for large components.
   @Memoized
   @Override
-  boolean requiresModuleInstance() {
-    return super.requiresModuleInstance();
+  boolean requiresModuleInstance(CompilerOptions options) {
+    return super.requiresModuleInstance(options);
   }
 
   static Builder builder() {

--- a/java/dagger/internal/codegen/ProvisionBinding.java
+++ b/java/dagger/internal/codegen/ProvisionBinding.java
@@ -101,8 +101,8 @@ abstract class ProvisionBinding extends ContributionBinding {
   // performance improvement for large components.
   @Memoized
   @Override
-  boolean requiresModuleInstance() {
-    return super.requiresModuleInstance();
+  boolean requiresModuleInstance(CompilerOptions options) {
+    return super.requiresModuleInstance(options);
   }
 
   @Memoized


### PR DESCRIPTION
This is a first pass at trying to facilitate more idiomatic Kotlin support. This definitely requires review, and I've also got a doc of ideas that I've discussed with @ronshapiro in the past [here](https://docs.google.com/document/d/1LuTnkHpiVnr1ge6xrSSg4eNlIVrXtqJx30kR2v6TdbQ/edit?usp=sharing).

This is a simple first touch point that tries to make `object` modules more idiomatic. Right now in Kotlin, developers have to write an object module with all `@JvmStatic` provides.

```kotlin
@Module
object MyModule {
  @JvmStatic fun provideString(): String
}
```

The static annotation is for dagger, which otherwise doesn't know how to call `provideString()` from java as it's behind a static singleton `INSTANCE` field. This handles that case by just making a module reference `MyModule.INSTANCE.provideString()`. Note that if developers want to keep the `@JvmStatic` annotations anyway (for performance or otherwise), that still works fine just like before.

This allows this

```kotlin
@Module
object MyModule {
  fun provideString(): String
}
```

Some notes:
- `object` types can extend other classes and implement interfaces. Those implementations would be available via this singleton access as well. I think that should Just Work here, but it's a concept that maybe hasn't existed to dagger in this form before
- It's best to try to parse the `KmClass` data from a `TypeElement` once and share them, for performance reasons. This doesn't do that currently just for a trivial case
- Probably due to my lack of bazel familiarity, but I'm unsure of how to add Kotlin tests for this behavior in the project in its current structure. Am planning to test with a local maven installation instead. Putting up the PR early to start the discussion though
- kotlinx-metadata-jvm is not stable yet, but is friendly to shading as long as the service file for it is also rewritten
- We're working on adding metadata support to KotlinPoet to allow for using it as an IR, which should be able to replace some of this metadata parsing code in a more idiomatic way that can interop easily to JavaPoet.