### PR TITLE
Fix error in Dagger tutorial

### DIFF
--- a/tutorial/04-depending-on-interface.md
+++ b/tutorial/04-depending-on-interface.md
@@ -60,8 +60,8 @@ interface CommandRouterFactory {
 > answer is that Dagger already knows to look at those types because they appear
 > somewhere in a component or module that Dagger is using. In the case of
 > `CommandRouter`, it's the return type of the `CommandRouterFactory`'s entry
-> point method. And in the case of `HelloWorldModule`, it's the parameter type
-> of the [`@Binds`] method we just wrote. And before that, it appeared as a
+> point method. And in the case of `HelloWorldCommand`, it's the parameter type
+> of the [`@Binds`] method we just wrote in `HelloWorldModule`. And before that, it appeared as a
 > constructor parameter to `CommandRouter`, so Dagger learned about it
 > transitively when looking at `CommandRouter`.
 


### PR DESCRIPTION
- the aside is talking about the Inject-annotated classes, like CommandRouter
and HelloWorldCommand but references HelloWorldModule instead