### PR TITLE
Moe Sync

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -65,6 +65,7 @@ jarjar_library(
         "//java/dagger/internal/codegen:writing",
         "//java/dagger/internal/codegen/javapoet",
         "//java/dagger/internal/codegen/langmodel",
+        "//java/dagger/internal/codegen/statistics",
         "//java/dagger/model:internal-proxies",
         "//java/dagger/errorprone",
         "@com_google_auto_auto_common//jar",
@@ -84,6 +85,7 @@ jarjar_library(
         "//java/dagger/internal/codegen:libwriting-src.jar",
         "//java/dagger/internal/codegen/javapoet:libjavapoet-src.jar",
         "//java/dagger/internal/codegen/langmodel:liblangmodel-src.jar",
+        "//java/dagger/internal/codegen/statistics:libstatistics-src.jar",
         # TODO(ronshapiro): is there a generated src.jar for protos in Bazel?
         "//java/dagger/errorprone:liberrorprone-src.jar",
     ],

--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -86,10 +86,6 @@ java_library(
         "CompilerOptions.java",
         "ComponentAnnotation.java",
         "ContributionType.java",
-        "DaggerStatistics.java",
-        "DaggerStatisticsCollectingProcessingStep.java",
-        "DaggerStatisticsCollector.java",
-        "DaggerStatisticsRecorder.java",
         "DiagnosticFormatting.java",
         "ElementFormatter.java",
         "FeatureStatus.java",
@@ -338,6 +334,7 @@ java_library(
         ":binding",
         "//java/dagger/internal/codegen/javapoet",
         "//java/dagger/internal/codegen/langmodel",
+        "//java/dagger/internal/codegen/statistics",
     ],
 )
 
@@ -377,6 +374,7 @@ java_library(
         ":validation",
         "//java/dagger/internal/codegen/javapoet",
         "//java/dagger/internal/codegen/langmodel",
+        "//java/dagger/internal/codegen/statistics",
         "@google_bazel_common//third_party/java/incap",
     ],
 )
@@ -463,6 +461,7 @@ java_library(
     deps = CODEGEN_DEPS + [
         "//java/dagger/internal/codegen/langmodel",
         "//java/dagger/internal/codegen/javapoet",
+        "//java/dagger/internal/codegen/statistics",
         "@google_bazel_common//third_party/java/incap",
     ],
 )

--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -35,7 +35,9 @@ CODEGEN_SRCS = glob(
               JAVAC_PLUGIN_MODULE_SRCS,
 )
 
-CODEGEN_PLUGINS = [":bootstrap_compiler_plugin"]
+CODEGEN_PLUGINS = [
+    "//java/dagger/internal/codegen/bootstrap",
+]
 
 CODEGEN_SHARED_DEPS = [
     "@google_bazel_common//third_party/java/auto:service",
@@ -443,19 +445,6 @@ java_import(
     name = "kythe_plugin",
     jars = ["kythe_plugin_deploy.jar"],
     neverlink = 1,
-)
-
-java_import(
-    name = "bootstrap_compiler",
-    jars = ["bootstrap_compiler_deploy.jar"],
-    visibility = ["//visibility:private"],
-)
-
-java_plugin(
-    name = "bootstrap_compiler_plugin",
-    generates_api = 1,
-    processor_class = "dagger.internal.codegen.ComponentProcessor",
-    deps = [":bootstrap_compiler"],
 )
 
 javadoc_library(

--- a/java/dagger/internal/codegen/ComponentProcessor.java
+++ b/java/dagger/internal/codegen/ComponentProcessor.java
@@ -32,6 +32,8 @@ import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
 import dagger.internal.codegen.SpiModule.TestingPlugins;
+import dagger.internal.codegen.statistics.DaggerStatisticsCollectingProcessingStep;
+import dagger.internal.codegen.statistics.DaggerStatisticsCollector;
 import dagger.spi.BindingGraphPlugin;
 import java.util.Arrays;
 import java.util.Optional;

--- a/java/dagger/internal/codegen/FactoryGenerator.java
+++ b/java/dagger/internal/codegen/FactoryGenerator.java
@@ -59,6 +59,7 @@ import dagger.internal.codegen.InjectionMethods.ProvisionMethod;
 import dagger.internal.codegen.javapoet.CodeBlocks;
 import dagger.internal.codegen.langmodel.DaggerElements;
 import dagger.internal.codegen.langmodel.DaggerTypes;
+import dagger.internal.codegen.statistics.DaggerStatisticsCollector;
 import dagger.model.Key;
 import java.util.List;
 import java.util.Optional;

--- a/java/dagger/internal/codegen/MembersInjectorGenerator.java
+++ b/java/dagger/internal/codegen/MembersInjectorGenerator.java
@@ -52,6 +52,7 @@ import dagger.internal.codegen.InjectionMethods.InjectionSiteMethod;
 import dagger.internal.codegen.MembersInjectionBinding.InjectionSite;
 import dagger.internal.codegen.langmodel.DaggerElements;
 import dagger.internal.codegen.langmodel.DaggerTypes;
+import dagger.internal.codegen.statistics.DaggerStatisticsCollector;
 import dagger.model.Key;
 import java.util.Map.Entry;
 import java.util.Optional;

--- a/java/dagger/internal/codegen/ProcessingEnvironmentModule.java
+++ b/java/dagger/internal/codegen/ProcessingEnvironmentModule.java
@@ -23,6 +23,7 @@ import dagger.Module;
 import dagger.Provides;
 import dagger.Reusable;
 import dagger.internal.codegen.langmodel.DaggerElements;
+import dagger.internal.codegen.statistics.DaggerStatisticsRecorder;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.processing.Filer;

--- a/java/dagger/internal/codegen/bootstrap/BUILD
+++ b/java/dagger/internal/codegen/bootstrap/BUILD
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 The Dagger Authors.
+# Copyright (C) 2019 The Dagger Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,19 +13,19 @@
 # limitations under the License.
 
 # Description:
-#   Dagger-specific extensions to the javax.lang.model APIs
+#   Bootstrap libraries for building Dagger with Dagger.
 
 package(default_visibility = ["//:src"])
 
-java_library(
-    name = "langmodel",
-    srcs = glob(["*.java"]),
-    plugins = ["//java/dagger/internal/codegen/bootstrap"],
-    tags = ["maven:merged"],
-    deps = [
-        "//java/dagger:core",
-        "@google_bazel_common//third_party/java/auto:common",
-        "@google_bazel_common//third_party/java/guava",
-        "@google_bazel_common//third_party/java/javapoet",
-    ],
+java_plugin(
+    name = "bootstrap",
+    generates_api = 1,
+    processor_class = "dagger.internal.codegen.ComponentProcessor",
+    deps = [":bootstrap_compiler"],
+)
+
+java_import(
+    name = "bootstrap_compiler",
+    jars = ["bootstrap_compiler_deploy.jar"],
+    visibility = ["//visibility:private"],
 )

--- a/java/dagger/internal/codegen/javapoet/BUILD
+++ b/java/dagger/internal/codegen/javapoet/BUILD
@@ -20,7 +20,7 @@ package(default_visibility = ["//:src"])
 java_library(
     name = "javapoet",
     srcs = glob(["*.java"]),
-    plugins = ["//java/dagger/internal/codegen:bootstrap_compiler_plugin"],
+    plugins = ["//java/dagger/internal/codegen/bootstrap"],
     tags = ["maven:merged"],
     deps = [
         "//java/dagger:core",

--- a/java/dagger/internal/codegen/statistics/BUILD
+++ b/java/dagger/internal/codegen/statistics/BUILD
@@ -1,0 +1,38 @@
+# Copyright (C) 2017 The Dagger Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Description:
+#   Dagger-specific extensions for statistics.
+
+package(default_visibility = ["//:src"])
+
+java_library(
+    name = "statistics",
+    srcs = [
+        "DaggerStatistics.java",
+        "DaggerStatisticsCollectingProcessingStep.java",
+        "DaggerStatisticsCollector.java",
+        "DaggerStatisticsRecorder.java",
+    ],
+    plugins = ["//java/dagger/internal/codegen/bootstrap"],
+    tags = ["maven:merged"],
+    deps = [
+        "//java/dagger:core",
+        "@google_bazel_common//third_party/java/auto:common",
+        "@google_bazel_common//third_party/java/auto:value",
+        "@google_bazel_common//third_party/java/error_prone:annotations",
+        "@google_bazel_common//third_party/java/guava",
+        "@google_bazel_common//third_party/java/jsr330_inject",
+    ],
+)

--- a/java/dagger/internal/codegen/statistics/DaggerStatistics.java
+++ b/java/dagger/internal/codegen/statistics/DaggerStatistics.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dagger.internal.codegen;
+package dagger.internal.codegen.statistics;
 
 import com.google.auto.common.BasicAnnotationProcessor.ProcessingStep;
 import com.google.auto.value.AutoValue;
@@ -26,7 +26,7 @@ import java.time.Duration;
 
 /** Statistics collected over the course of Dagger annotation processing. */
 @AutoValue
-abstract class DaggerStatistics {
+public abstract class DaggerStatistics {
   /** Returns a new {@link Builder}. */
   static Builder builder() {
     return new AutoValue_DaggerStatistics.Builder();
@@ -38,16 +38,16 @@ abstract class DaggerStatistics {
   }
 
   /** Total time spent in Dagger annotation processing. */
-  abstract Duration totalProcessingTime();
+  public abstract Duration totalProcessingTime();
 
   /** List of statistics for processing rounds that the Dagger processor handled. */
-  abstract ImmutableList<RoundStatistics> rounds();
+  public abstract ImmutableList<RoundStatistics> rounds();
 
   /** Records the number of {@code @Inject} constructor factories generated in this compilation. */
-  abstract int injectFactoriesGenerated();
+  public abstract int injectFactoriesGenerated();
 
   /** Records the number of {@link dagger.MembersInjector}s generated in this compilation. */
-  abstract int membersInjectorsGenerated();
+  public abstract int membersInjectorsGenerated();
 
   /** Builder for {@link DaggerStatistics}. */
   @AutoValue.Builder
@@ -79,9 +79,9 @@ abstract class DaggerStatistics {
 
   /** Statistics for each processing step in a single processing round. */
   @AutoValue
-  abstract static class RoundStatistics {
+  public abstract static class RoundStatistics {
     /** Map of processing step class to duration of that step for this round. */
-    abstract ImmutableMap<Class<? extends ProcessingStep>, Duration> stepDurations();
+    public abstract ImmutableMap<Class<? extends ProcessingStep>, Duration> stepDurations();
 
     /** Builder for {@link RoundStatistics}. */
     @AutoValue.Builder

--- a/java/dagger/internal/codegen/statistics/DaggerStatisticsCollectingProcessingStep.java
+++ b/java/dagger/internal/codegen/statistics/DaggerStatisticsCollectingProcessingStep.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dagger.internal.codegen;
+package dagger.internal.codegen.statistics;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -28,12 +28,12 @@ import javax.lang.model.element.Element;
  * {@link ProcessingStep} that delegates to another {@code ProcessingStep} and collects timing
  * statistics for each processing round for that step.
  */
-final class DaggerStatisticsCollectingProcessingStep implements ProcessingStep {
+public final class DaggerStatisticsCollectingProcessingStep implements ProcessingStep {
 
   private final ProcessingStep delegate;
   private final DaggerStatisticsCollector statisticsCollector;
 
-  DaggerStatisticsCollectingProcessingStep(
+  public DaggerStatisticsCollectingProcessingStep(
       ProcessingStep delegate, DaggerStatisticsCollector statisticsCollector) {
     this.delegate = checkNotNull(delegate);
     this.statisticsCollector = checkNotNull(statisticsCollector);

--- a/java/dagger/internal/codegen/statistics/DaggerStatisticsCollector.java
+++ b/java/dagger/internal/codegen/statistics/DaggerStatisticsCollector.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dagger.internal.codegen;
+package dagger.internal.codegen.statistics;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -31,7 +31,7 @@ import javax.inject.Singleton;
 
 /** Collects {@link DaggerStatistics} over the course of Dagger annotation processing. */
 @Singleton // for state sharing
-final class DaggerStatisticsCollector {
+public final class DaggerStatisticsCollector {
 
   private final Ticker ticker;
   private final Stopwatch totalRuntimeStopwatch;
@@ -52,7 +52,7 @@ final class DaggerStatisticsCollector {
   }
 
   /** Called when Dagger annotation processing starts. */
-  void processingStarted() {
+  public void processingStarted() {
     checkState(!totalRuntimeStopwatch.isRunning());
     totalRuntimeStopwatch.start();
   }
@@ -72,13 +72,13 @@ final class DaggerStatisticsCollector {
   }
 
   /** Called when Dagger finishes a processing round. */
-  void roundFinished() {
+  public void roundFinished() {
     statisticsBuilder.addRound(roundBuilder.build());
     roundBuilder = DaggerStatistics.roundBuilder();
   }
 
   /** Called when Dagger annotation processing completes. */
-  void processingStopped() {
+  public void processingStopped() {
     checkState(totalRuntimeStopwatch.isRunning());
     totalRuntimeStopwatch.stop();
     statisticsBuilder
@@ -90,11 +90,11 @@ final class DaggerStatisticsCollector {
         recorder -> recorder.recordStatistics(statisticsBuilder.build()));
   }
 
-  void recordInjectFactoryGenerated() {
+  public void recordInjectFactoryGenerated() {
     injectFactoriesGenerated++;
   }
 
-  void recordMembersInjectorGenerated() {
+  public void recordMembersInjectorGenerated() {
     membersInjectorsGenerated++;
   }
 

--- a/java/dagger/internal/codegen/statistics/DaggerStatisticsRecorder.java
+++ b/java/dagger/internal/codegen/statistics/DaggerStatisticsRecorder.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package dagger.internal.codegen;
+package dagger.internal.codegen.statistics;
 
 /** Records collected {@link DaggerStatistics}. */
-interface DaggerStatisticsRecorder {
+public interface DaggerStatisticsRecorder {
   /** Records the given {@code statistics}. */
   void recordStatistics(DaggerStatistics statistics);
 }

--- a/javatests/dagger/internal/codegen/DependencyCycleValidationTest.java
+++ b/javatests/dagger/internal/codegen/DependencyCycleValidationTest.java
@@ -106,7 +106,8 @@ public class DependencyCycleValidationTest {
 
     Compilation compilation =
         daggerCompiler()
-            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions(
+                "-Adagger.fullBindingGraphValidation=ERROR")
             .compile(SIMPLE_CYCLIC_DEPENDENCY);
     assertThat(compilation).failed();
 

--- a/javatests/dagger/internal/codegen/DuplicateBindingsValidationTest.java
+++ b/javatests/dagger/internal/codegen/DuplicateBindingsValidationTest.java
@@ -82,7 +82,10 @@ public class DuplicateBindingsValidationTest {
         "}");
 
     Compilation compilation =
-        daggerCompiler().withOptions(fullBindingGraphValidationOption()).compile(component);
+        daggerCompiler()
+            .withOptions(
+                fullBindingGraphValidationOption())
+            .compile(component);
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
@@ -134,7 +137,10 @@ public class DuplicateBindingsValidationTest {
             "}");
 
     Compilation compilation =
-        daggerCompiler().withOptions(fullBindingGraphValidationOption()).compile(component);
+        daggerCompiler()
+            .withOptions(
+                fullBindingGraphValidationOption())
+            .compile(component);
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
@@ -200,7 +206,10 @@ public class DuplicateBindingsValidationTest {
             "}");
 
     Compilation compilation =
-        daggerCompiler().withOptions(fullBindingGraphValidationOption()).compile(component);
+        daggerCompiler()
+            .withOptions(
+                fullBindingGraphValidationOption())
+            .compile(component);
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
@@ -268,7 +277,10 @@ public class DuplicateBindingsValidationTest {
             "}");
 
     Compilation compilation =
-        daggerCompiler().withOptions(fullBindingGraphValidationOption()).compile(component);
+        daggerCompiler()
+            .withOptions(
+                fullBindingGraphValidationOption())
+            .compile(component);
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
@@ -337,7 +349,10 @@ public class DuplicateBindingsValidationTest {
             "}");
 
     Compilation compilation =
-        daggerCompiler().withOptions(fullBindingGraphValidationOption()).compile(component);
+        daggerCompiler()
+            .withOptions(
+                fullBindingGraphValidationOption())
+            .compile(component);
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
@@ -394,7 +409,10 @@ public class DuplicateBindingsValidationTest {
             "}");
 
     Compilation compilation =
-        daggerCompiler().withOptions(fullBindingGraphValidationOption()).compile(component);
+        daggerCompiler()
+            .withOptions(
+                fullBindingGraphValidationOption())
+            .compile(component);
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
@@ -447,7 +465,10 @@ public class DuplicateBindingsValidationTest {
             "}");
 
     Compilation compilation =
-        daggerCompiler().withOptions(fullBindingGraphValidationOption()).compile(component);
+        daggerCompiler()
+            .withOptions(
+                fullBindingGraphValidationOption())
+            .compile(component);
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
@@ -574,7 +595,10 @@ public class DuplicateBindingsValidationTest {
             "}");
 
     Compilation compilation =
-        daggerCompiler().withOptions(fullBindingGraphValidationOption()).compile(component);
+        daggerCompiler()
+            .withOptions(
+                fullBindingGraphValidationOption())
+            .compile(component);
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
@@ -647,7 +671,8 @@ public class DuplicateBindingsValidationTest {
 
     Compilation compilation =
         daggerCompiler()
-            .withOptions(fullBindingGraphValidationOption())
+            .withOptions(
+                fullBindingGraphValidationOption())
             .compile(aComponent, bComponent);
     assertThat(compilation).failed();
     assertThat(compilation)
@@ -728,7 +753,8 @@ public class DuplicateBindingsValidationTest {
 
     Compilation compilation =
         daggerCompiler()
-            .withOptions(fullBindingGraphValidationOption())
+            .withOptions(
+                fullBindingGraphValidationOption())
             .compile(aComponent, bComponent, cComponent);
     assertThat(compilation).failed();
     assertThat(compilation)
@@ -804,7 +830,8 @@ public class DuplicateBindingsValidationTest {
 
     Compilation compilation =
         daggerCompiler()
-            .withOptions(fullBindingGraphValidationOption())
+            .withOptions(
+                fullBindingGraphValidationOption())
             .compile(aComponent, bComponent, cComponent);
     assertThat(compilation).failed();
     assertThat(compilation)
@@ -992,7 +1019,9 @@ public class DuplicateBindingsValidationTest {
 
     Compilation compilation =
         daggerCompiler()
-            .withOptions("-Adagger.nullableValidation=WARNING", fullBindingGraphValidationOption())
+            .withOptions(
+                "-Adagger.nullableValidation=WARNING",
+                fullBindingGraphValidationOption())
             .compile(parentConflictsWithChild, child);
     assertThat(compilation).failed();
     assertThat(compilation)

--- a/javatests/dagger/internal/codegen/FullBindingGraphValidationTest.java
+++ b/javatests/dagger/internal/codegen/FullBindingGraphValidationTest.java
@@ -62,7 +62,8 @@ public final class FullBindingGraphValidationTest {
   public void moduleWithErrors_validationTypeError() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions(
+                "-Adagger.fullBindingGraphValidation=ERROR")
             .compile(MODULE_WITH_ERRORS);
 
     assertThat(compilation).failed();
@@ -79,7 +80,8 @@ public final class FullBindingGraphValidationTest {
   public void moduleWithErrors_validationTypeWarning() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions("-Adagger.fullBindingGraphValidation=WARNING")
+            .withOptions(
+                "-Adagger.fullBindingGraphValidation=WARNING")
             .compile(MODULE_WITH_ERRORS);
 
     assertThat(compilation).succeeded();
@@ -114,7 +116,8 @@ public final class FullBindingGraphValidationTest {
   public void includesModuleWithErrors_validationTypeError() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions(
+                "-Adagger.fullBindingGraphValidation=ERROR")
             .compile(MODULE_WITH_ERRORS, INCLUDES_MODULE_WITH_ERRORS);
 
     assertThat(compilation).failed();
@@ -136,7 +139,8 @@ public final class FullBindingGraphValidationTest {
   public void includesModuleWithErrors_validationTypeWarning() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions("-Adagger.fullBindingGraphValidation=WARNING")
+            .withOptions(
+                "-Adagger.fullBindingGraphValidation=WARNING")
             .compile(MODULE_WITH_ERRORS, INCLUDES_MODULE_WITH_ERRORS);
 
     assertThat(compilation).succeeded();
@@ -199,7 +203,8 @@ public final class FullBindingGraphValidationTest {
   public void moduleIncludingModuleWithCombinedErrors_validationTypeError() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions(
+                "-Adagger.fullBindingGraphValidation=ERROR")
             .compile(A_MODULE, COMBINED_WITH_A_MODULE_HAS_ERRORS);
 
     assertThat(compilation).failed();
@@ -216,7 +221,8 @@ public final class FullBindingGraphValidationTest {
   public void moduleIncludingModuleWithCombinedErrors_validationTypeWarning() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions("-Adagger.fullBindingGraphValidation=WARNING")
+            .withOptions(
+                "-Adagger.fullBindingGraphValidation=WARNING")
             .compile(A_MODULE, COMBINED_WITH_A_MODULE_HAS_ERRORS);
 
     assertThat(compilation).succeeded();
@@ -265,7 +271,8 @@ public final class FullBindingGraphValidationTest {
   public void subcomponentWithErrors_validationTypeError() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions(
+                "-Adagger.fullBindingGraphValidation=ERROR")
             .compile(SUBCOMPONENT_WITH_ERRORS, A_MODULE);
 
     assertThat(compilation).failed();
@@ -282,7 +289,8 @@ public final class FullBindingGraphValidationTest {
   public void subcomponentWithErrors_validationTypeWarning() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions("-Adagger.fullBindingGraphValidation=WARNING")
+            .withOptions(
+                "-Adagger.fullBindingGraphValidation=WARNING")
             .compile(SUBCOMPONENT_WITH_ERRORS, A_MODULE);
 
     assertThat(compilation).succeeded();
@@ -319,7 +327,8 @@ public final class FullBindingGraphValidationTest {
   public void moduleWithSubcomponentWithErrors_validationTypeError() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions(
+                "-Adagger.fullBindingGraphValidation=ERROR")
             .compile(MODULE_WITH_SUBCOMPONENT_WITH_ERRORS, SUBCOMPONENT_WITH_ERRORS, A_MODULE);
 
     assertThat(compilation).failed();
@@ -342,7 +351,8 @@ public final class FullBindingGraphValidationTest {
   public void moduleWithSubcomponentWithErrors_validationTypeWarning() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions("-Adagger.fullBindingGraphValidation=WARNING")
+            .withOptions(
+                "-Adagger.fullBindingGraphValidation=WARNING")
             .compile(MODULE_WITH_SUBCOMPONENT_WITH_ERRORS, SUBCOMPONENT_WITH_ERRORS, A_MODULE);
 
     assertThat(compilation).succeeded();
@@ -409,7 +419,8 @@ public final class FullBindingGraphValidationTest {
   public void moduleWithSubcomponentWithCombinedErrors_validationTypeError() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions(
+                "-Adagger.fullBindingGraphValidation=ERROR")
             .compile(COMBINED_WITH_A_SUBCOMPONENT_HAS_ERRORS, A_SUBCOMPONENT, A_MODULE);
 
     assertThat(compilation).failed();
@@ -426,7 +437,8 @@ public final class FullBindingGraphValidationTest {
   public void moduleWithSubcomponentWithCombinedErrors_validationTypeWarning() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions("-Adagger.fullBindingGraphValidation=WARNING")
+            .withOptions(
+                "-Adagger.fullBindingGraphValidation=WARNING")
             .compile(COMBINED_WITH_A_SUBCOMPONENT_HAS_ERRORS, A_SUBCOMPONENT, A_MODULE);
 
     assertThat(compilation).succeeded();

--- a/javatests/dagger/internal/codegen/MapMultibindingValidationTest.java
+++ b/javatests/dagger/internal/codegen/MapMultibindingValidationTest.java
@@ -72,7 +72,10 @@ public class MapMultibindingValidationTest {
     assertThat(compilation).hadErrorCount(1);
 
     compilation =
-        daggerCompiler().withOptions("-Adagger.fullBindingGraphValidation=ERROR").compile(module);
+        daggerCompiler()
+            .withOptions(
+                "-Adagger.fullBindingGraphValidation=ERROR")
+            .compile(module);
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
@@ -264,7 +267,8 @@ public class MapMultibindingValidationTest {
 
     compilation =
         daggerCompiler()
-            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions(
+                "-Adagger.fullBindingGraphValidation=ERROR")
             .compile(module, stringKeyTwoFile);
     assertThat(compilation).failed();
     assertThat(compilation)

--- a/javatests/dagger/internal/codegen/ScopingValidationTest.java
+++ b/javatests/dagger/internal/codegen/ScopingValidationTest.java
@@ -243,7 +243,8 @@ public class ScopingValidationTest {
 
     compilation =
         daggerCompiler()
-            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions(
+                "-Adagger.fullBindingGraphValidation=ERROR")
             .compile(componentFile, scopeFile, scopeWithAttribute, typeFile, moduleFile);
     // The @Inject binding for ScopedType should not appear here, but the @Singleton binding should.
     assertThat(compilation)


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Move the Dagger bootstrap logic into its own subdirectory and update the script.

3ec9dd077bd9f6172b82c7a6442ddb9b7af934ec

-------

<p> Move Dagger statistics into a separate subpackage.

176ce2e8980dfbf2e06a3e4c054855f1469e22aa

-------

<p> Add check to ensure fullBindingGraphValidation is not used without pluginsVisitFullBindingGraphs.

Currently, fullBindingGraphValidation runs both internal and external plugins and pluginsVisitFullBindingGraphs is a noop. However, after a future change, fullBindingGraphValidation will run internal plugins and pluginsVisitFullBindingGraphs will run external plugins.

This is CL is a follow-up to [] and is required to ensure [] doesn't change the behavior of fullBindingGraphValidation usages by forcing users to depend on both flags.

RELNOTES=N/A

a671246d1de30e49a937d49d1534b6e6f1aa7837