### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -18,7 +18,6 @@
 package(default_visibility = ["//:src"])
 
 load("@google_bazel_common//tools/javadoc:javadoc.bzl", "javadoc_library")
-load("//:build_defs.bzl", "DOCLINT_HTML_AND_SYNTAX", "DOCLINT_REFERENCES")
 load("//tools:maven.bzl", "POM_VERSION", "pom_file")
 
 DAGGER_DEPS = [
@@ -62,9 +61,10 @@ java_library(
 )
 
 java_library(
-    name = "codegen-deps",
-    visibility = ["//visibility:private"],
-    exports = [
+    name = "processor",
+    srcs = [":codegen-srcs"],
+    tags = ["maven_coordinates=com.google.dagger:dagger-compiler:" + POM_VERSION],
+    deps = [
         ":codegen-shared-deps",
         "@google_bazel_common//third_party/java/guava",
     ],
@@ -81,14 +81,6 @@ java_library(
     srcs = ["package-info.java"],
     tags = ["maven:merged"],
     deps = ["@google_bazel_common//third_party/java/error_prone:annotations"],
-)
-
-# The processor's "main", if you will
-java_library(
-    name = "processor",
-    srcs = [":codegen-srcs"],
-    tags = ["maven_coordinates=com.google.dagger:dagger-compiler:" + POM_VERSION],
-    deps = [":codegen-deps"],
 )
 
 pom_file(

--- a/java/dagger/internal/codegen/binding/BindingGraphConverter.java
+++ b/java/dagger/internal/codegen/binding/BindingGraphConverter.java
@@ -23,6 +23,7 @@ import static dagger.internal.codegen.extension.DaggerGraphs.unreachableNodes;
 import static dagger.internal.codegen.extension.DaggerStreams.toImmutableList;
 import static dagger.model.BindingKind.SUBCOMPONENT_CREATOR;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
@@ -326,10 +327,11 @@ public final class BindingGraphConverter {
     }
 
     private MissingBinding missingBindingNode(ResolvedBindings dependencies) {
-      // TODO(ronshapiro): Revisit whether missing binding nodes should all use the root component
-      // path, and the component(s) that have the missing bindings should be determined by the
-      // predecessors of missing binding nodes.
-      return BindingGraphProxies.missingBindingNode(componentPath(), dependencies.key());
+      // Put all missing binding nodes in the root component. This simplifies the binding graph
+      // and produces better error messages for users since all dependents point to the same node.
+      return BindingGraphProxies.missingBindingNode(
+          ComponentPath.create(ImmutableList.of(componentPath().rootComponent())),
+          dependencies.key());
     }
 
     private ComponentNode subcomponentNode(TypeMirror subcomponentBuilderType, BindingGraph graph) {

--- a/java/dagger/internal/codegen/binding/ComponentCreatorAnnotation.java
+++ b/java/dagger/internal/codegen/binding/ComponentCreatorAnnotation.java
@@ -49,6 +49,7 @@ public enum ComponentCreatorAnnotation {
   private final ComponentCreatorKind creatorKind;
   private final Class<? extends Annotation> componentAnnotation;
 
+  @SuppressWarnings("unchecked") // Builder/factory annotations live within their parent annotation.
   ComponentCreatorAnnotation(Class<? extends Annotation> annotation) {
     this.annotation = annotation;
     this.creatorKind = ComponentCreatorKind.valueOf(toUpperCase(annotation.getSimpleName()));

--- a/java/dagger/internal/codegen/extension/BUILD
+++ b/java/dagger/internal/codegen/extension/BUILD
@@ -21,7 +21,6 @@ package(default_visibility = ["//:src"])
 java_library(
     name = "extension",
     srcs = glob(["*.java"]),
-    plugins = ["//java/dagger/internal/codegen/bootstrap"],
     tags = ["maven:merged"],
     deps = [
         "@google_bazel_common//third_party/java/guava",

--- a/javatests/dagger/internal/codegen/MissingBindingValidationTest.java
+++ b/javatests/dagger/internal/codegen/MissingBindingValidationTest.java
@@ -56,6 +56,7 @@ public class MissingBindingValidationTest {
         "interface Bar {}");
     Compilation compilation = daggerCompiler().compile(component, injectable, nonInjectable);
     assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
     assertThat(compilation)
         .hadErrorContaining("test.Bar cannot be provided without an @Provides-annotated method.")
         .inFile(component)
@@ -81,6 +82,7 @@ public class MissingBindingValidationTest {
             "}");
     Compilation compilation = daggerCompiler().compile(component);
     assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
     assertThat(compilation)
         .hadErrorContaining(
             "[Dagger/MissingBinding] test.TestClass.A cannot be provided "
@@ -110,6 +112,7 @@ public class MissingBindingValidationTest {
             "}");
     Compilation compilation = daggerCompiler().compile(component);
     assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
     assertThat(compilation)
         .hadErrorContaining(
             "[Dagger/MissingBinding] @test.TestClass.Q test.TestClass.A cannot be provided "
@@ -140,6 +143,7 @@ public class MissingBindingValidationTest {
 
     Compilation compilation = daggerCompiler().compile(component);
     assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
     assertThat(compilation)
         .hadErrorContaining(
             "test.TestClass.A cannot be provided without an @Inject constructor or an "
@@ -174,6 +178,7 @@ public class MissingBindingValidationTest {
 
     Compilation compilation = daggerCompiler().compile(component);
     assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
     assertThat(compilation)
         .hadErrorContaining(
             "test.TestClass.B cannot be provided without an @Inject constructor or an "
@@ -210,6 +215,7 @@ public class MissingBindingValidationTest {
 
     Compilation compilation = daggerCompiler().compile(self, component);
     assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
     assertThat(compilation)
         .hadErrorContaining("test.Self cannot be provided without an @Inject constructor")
         .inFile(component)
@@ -241,6 +247,7 @@ public class MissingBindingValidationTest {
             "}");
     Compilation compilation = daggerCompiler().compile(component, foo);
     assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
     assertThat(compilation)
         .hadErrorContaining(
             "test.Foo<? extends java.lang.Number> cannot be provided "
@@ -300,6 +307,7 @@ public class MissingBindingValidationTest {
 
     Compilation compilation = daggerCompiler().compile(component);
     assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
     assertThat(compilation)
         .hadErrorContaining(
             message(
@@ -354,6 +362,7 @@ public class MissingBindingValidationTest {
     Compilation compilation =
         daggerCompiler().compile(component, module, interfaceFile, implementationFile);
     assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
     assertThat(compilation)
         .hadErrorContaining(
             message(
@@ -408,6 +417,7 @@ public class MissingBindingValidationTest {
 
     Compilation compilation = daggerCompiler().compile(generic, testClass, usesTest, component);
     assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
     assertThat(compilation)
         .hadErrorContaining(
             message(
@@ -462,6 +472,7 @@ public class MissingBindingValidationTest {
 
     Compilation compilation = daggerCompiler().compile(generic, testClass, usesTest, component);
     assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
     assertThat(compilation)
         .hadErrorContaining(
             message(
@@ -524,6 +535,7 @@ public class MissingBindingValidationTest {
 
     Compilation compilation = daggerCompiler().compile(parent, parentModule, child, childModule);
     assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
     assertThat(compilation)
         .hadErrorContainingMatch(
             "(?s)\\Qjava.lang.String cannot be provided\\E.*\\QChild.needsString()\\E")
@@ -599,6 +611,7 @@ public class MissingBindingValidationTest {
     Compilation compilation =
         daggerCompiler().compile(parent, parentModule, child, childModule, grandchild);
     assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
     assertThat(compilation)
         .hadErrorContainingMatch(
             "(?s)\\Qjava.lang.Double cannot be provided\\E.*"
@@ -646,6 +659,7 @@ public class MissingBindingValidationTest {
             "interface NotBound {}");
     Compilation compilation = daggerCompiler().compile(component, module, notBound);
     assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
     assertThat(compilation)
         .hadErrorContaining(
             message(
@@ -705,6 +719,7 @@ public class MissingBindingValidationTest {
 
     Compilation compilation = daggerCompiler().compile(foo, component);
     assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
     assertThat(compilation)
         .hadErrorContaining(
             message(
@@ -755,6 +770,7 @@ public class MissingBindingValidationTest {
 
     Compilation compilation = daggerCompiler().compile(component);
     assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
     assertThat(compilation)
         .hadErrorContaining(
             message(
@@ -776,5 +792,66 @@ public class MissingBindingValidationTest {
                 "    and 1 other"))
         .inFile(component)
         .onLineContaining("interface TestComponent");
+  }
+
+  @Test
+  public void missingBindingInAllComponentsAndEntryPoints() {
+    JavaFileObject parent =
+        JavaFileObjects.forSourceLines(
+            "Parent",
+            "import dagger.Component;",
+            "",
+            "@Component",
+            "interface Parent {",
+            "  Foo foo();",
+            "  Bar bar();",
+            "  Child child();",
+            "}");
+    JavaFileObject child =
+        JavaFileObjects.forSourceLines(
+            "Child",
+            "import dagger.Subcomponent;",
+            "",
+            "@Subcomponent",
+            "interface Child {",
+            "  Foo foo();",
+            "  Baz baz();",
+            "}");
+    JavaFileObject foo =
+        JavaFileObjects.forSourceLines(
+            "Foo",
+            "import javax.inject.Inject;",
+            "",
+            "class Foo {",
+            "  @Inject Foo(Bar bar) {}",
+            "}");
+    JavaFileObject bar =
+        JavaFileObjects.forSourceLines(
+            "Bar",
+            "import javax.inject.Inject;",
+            "",
+            "class Bar {",
+            "  @Inject Bar(Baz baz) {}",
+            "}");
+    JavaFileObject baz = JavaFileObjects.forSourceLines("Baz", "class Baz {}");
+
+    Compilation compilation = daggerCompiler().compile(parent, child, foo, bar, baz);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
+    assertThat(compilation)
+        .hadErrorContaining(
+            message(
+                "[Dagger/MissingBinding] Baz cannot be provided without an @Inject constructor or "
+                    + "an @Provides-annotated method.",
+                "    Baz is injected at",
+                "        Bar(baz)",
+                "    Bar is provided at",
+                "        Parent.bar()",
+                "The following other entry points also depend on it:",
+                "    Parent.foo()",
+                "    Child.foo() [Parent → Child]",
+                "    Child.baz() [Parent → Child]"))
+        .inFile(parent)
+        .onLineContaining("interface Parent");
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove duplicate missing binding messages.

A missing binding was being reported for each component/subcomponent in the graph. This leads to error spam.

This CL changes the way missing bindings are included into the BindingGraph. In particular, we create a single missing binding node in the root component rather than 1 in every component. This change should be equally as valid as the previous choice because we don't know where a missing binding will be provided anyway. However, choosing the root component has two benefits: it produces much more succinct error messages, and it simplifies the BindingGraph for plugins.

RELNOTES=Fix duplicate missing binding error messages.

cae77c1956c1f99cb1ebb0544ff24c4ecd906221

-------

<p> Remove check-package-javadoc target and add javacopts checks to each library.

RELNOTES=N/A

3e253c1af39e3dc627009610b7b592e6cbc6aa3c