### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/compileroption/CompilerOptions.java
+++ b/java/dagger/internal/codegen/compileroption/CompilerOptions.java
@@ -64,12 +64,14 @@ public abstract class CompilerOptions {
 
   public abstract boolean useGradleIncrementalProcessing();
 
+  public abstract ValidationType fullBindingGraphValidationType();
+
   /**
-   * Returns the validation that should be done for the full binding graph for the element.
+   * If {@code true}, each plugin will visit the full binding graph for the given element.
    *
    * @throws IllegalArgumentException if {@code element} is not a module or (sub)component
    */
-  public abstract ValidationType fullBindingGraphValidationType(TypeElement element);
+  public abstract boolean pluginsVisitFullBindingGraphs(TypeElement element);
 
   public abstract Diagnostic.Kind moduleHasDifferentScopesDiagnosticKind();
 

--- a/java/dagger/internal/codegen/compileroption/JavacPluginCompilerOptions.java
+++ b/java/dagger/internal/codegen/compileroption/JavacPluginCompilerOptions.java
@@ -90,8 +90,13 @@ public final class JavacPluginCompilerOptions extends CompilerOptions {
   }
 
   @Override
-  public ValidationType fullBindingGraphValidationType(TypeElement element) {
+  public ValidationType fullBindingGraphValidationType() {
     return NONE;
+  }
+
+  @Override
+  public boolean pluginsVisitFullBindingGraphs(TypeElement element) {
+    return false;
   }
 
   @Override

--- a/java/dagger/internal/codegen/compileroption/ProcessingEnvironmentCompilerOptions.java
+++ b/java/dagger/internal/codegen/compileroption/ProcessingEnvironmentCompilerOptions.java
@@ -28,6 +28,7 @@ import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompil
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.FLOATING_BINDS_METHODS;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.FORMAT_GENERATED_SOURCE;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.IGNORE_PRIVATE_AND_STATIC_INJECTION_FOR_COMPONENT;
+import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.PLUGINS_VISIT_FULL_BINDING_GRAPHS;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.WARN_IF_INJECTION_FACTORY_NOT_GENERATED_UPSTREAM;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.WRITE_PRODUCER_NAME_IN_TOKEN;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.KeyOnlyOption.HEADER_COMPILATION;
@@ -140,12 +141,13 @@ public final class ProcessingEnvironmentCompilerOptions extends CompilerOptions 
   }
 
   @Override
-  public ValidationType fullBindingGraphValidationType(TypeElement element) {
-    return fullBindingGraphValidationType();
+  public ValidationType fullBindingGraphValidationType() {
+    return parseOption(FULL_BINDING_GRAPH_VALIDATION);
   }
 
-  private ValidationType fullBindingGraphValidationType() {
-    return parseOption(FULL_BINDING_GRAPH_VALIDATION);
+  @Override
+  public boolean pluginsVisitFullBindingGraphs(TypeElement component) {
+    return isEnabled(PLUGINS_VISIT_FULL_BINDING_GRAPHS);
   }
 
   @Override
@@ -263,6 +265,8 @@ public final class ProcessingEnvironmentCompilerOptions extends CompilerOptions 
     FORCE_USE_SERIALIZED_COMPONENT_IMPLEMENTATIONS,
 
     EMIT_MODIFIABLE_METADATA_ANNOTATIONS(ENABLED),
+
+    PLUGINS_VISIT_FULL_BINDING_GRAPHS,
 
     FLOATING_BINDS_METHODS,
     ;

--- a/java/dagger/internal/codegen/validation/BindingGraphValidator.java
+++ b/java/dagger/internal/codegen/validation/BindingGraphValidator.java
@@ -20,12 +20,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static javax.tools.Diagnostic.Kind.ERROR;
 
 import com.google.common.collect.ImmutableSet;
+import dagger.internal.codegen.compileroption.CompilerOptions;
+import dagger.internal.codegen.compileroption.ValidationType;
 import dagger.internal.codegen.validation.DiagnosticReporterFactory.DiagnosticReporterImpl;
 import dagger.model.BindingGraph;
 import dagger.spi.BindingGraphPlugin;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import javax.lang.model.element.TypeElement;
 
 /** Validates a {@link BindingGraph}. */
 @Singleton
@@ -33,31 +36,73 @@ public final class BindingGraphValidator {
   private final ImmutableSet<BindingGraphPlugin> validationPlugins;
   private final ImmutableSet<BindingGraphPlugin> externalPlugins;
   private final DiagnosticReporterFactory diagnosticReporterFactory;
+  private final CompilerOptions compilerOptions;
 
   @Inject
   BindingGraphValidator(
       @Validation Set<BindingGraphPlugin> validationPlugins,
       ImmutableSet<BindingGraphPlugin> externalPlugins,
-      DiagnosticReporterFactory diagnosticReporterFactory) {
+      DiagnosticReporterFactory diagnosticReporterFactory,
+      CompilerOptions compilerOptions) {
     this.validationPlugins = ImmutableSet.copyOf(validationPlugins);
     this.externalPlugins = ImmutableSet.copyOf(externalPlugins);
     this.diagnosticReporterFactory = checkNotNull(diagnosticReporterFactory);
+    this.compilerOptions = compilerOptions;
+  }
+
+  /** Returns {@code true} if validation or analysis is required on the full binding graph. */
+  public boolean shouldDoFullBindingGraphValidation(TypeElement component) {
+    return requiresFullBindingGraphValidation()
+        || compilerOptions.pluginsVisitFullBindingGraphs(component);
+  }
+
+  private boolean requiresFullBindingGraphValidation() {
+    return !compilerOptions.fullBindingGraphValidationType().equals(ValidationType.NONE);
   }
 
   /** Returns {@code true} if no errors are reported for {@code graph}. */
   public boolean isValid(BindingGraph graph) {
-    return isValid(validationPlugins, graph) && isValid(externalPlugins, graph);
+    return validate(graph) && visitPlugins(graph);
   }
 
-  private boolean isValid(ImmutableSet<BindingGraphPlugin> plugins, BindingGraph graph) {
-    boolean isValid = true;
+  /** Returns {@code true} if validation plugins report no errors. */
+  private boolean validate(BindingGraph graph) {
+    if (graph.isFullBindingGraph() && !requiresFullBindingGraphValidation()) {
+      return true;
+    }
+
+    boolean errorsAsWarnings =
+        graph.isFullBindingGraph()
+        && compilerOptions.fullBindingGraphValidationType().equals(ValidationType.WARNING);
+
+    return runPlugins(validationPlugins, graph, errorsAsWarnings);
+  }
+
+  /** Returns {@code true} if external plugins report no errors. */
+  private boolean visitPlugins(BindingGraph graph) {
+    TypeElement component = graph.rootComponentNode().componentPath().currentComponent();
+    if (graph.isFullBindingGraph()
+        // TODO(b/135938915): Consider not visiting plugins if only
+        // fullBindingGraphValidation is enabled.
+        && !requiresFullBindingGraphValidation()
+        && !compilerOptions.pluginsVisitFullBindingGraphs(component)) {
+      return true;
+    }
+    return runPlugins(externalPlugins, graph, /*errorsAsWarnings=*/ false);
+  }
+
+  /** Returns {@code false} if any of the plugins reported an error. */
+  private boolean runPlugins(
+      ImmutableSet<BindingGraphPlugin> plugins, BindingGraph graph, boolean errorsAsWarnings) {
+    boolean isClean = true;
     for (BindingGraphPlugin plugin : plugins) {
-      DiagnosticReporterImpl reporter = diagnosticReporterFactory.reporter(graph, plugin);
+      DiagnosticReporterImpl reporter =
+          diagnosticReporterFactory.reporter(graph, plugin, errorsAsWarnings);
       plugin.visitGraph(graph, reporter);
       if (reporter.reportedDiagnosticKinds().contains(ERROR)) {
-        isValid = false;
+        isClean = false;
       }
     }
-    return isValid;
+    return isClean;
   }
 }

--- a/java/dagger/internal/codegen/validation/ModuleValidator.java
+++ b/java/dagger/internal/codegen/validation/ModuleValidator.java
@@ -31,7 +31,6 @@ import static dagger.internal.codegen.base.MoreAnnotationValues.asType;
 import static dagger.internal.codegen.base.Util.reentrantComputeIfAbsent;
 import static dagger.internal.codegen.binding.ComponentCreatorAnnotation.getCreatorAnnotations;
 import static dagger.internal.codegen.binding.ConfigurationAnnotations.getSubcomponentCreator;
-import static dagger.internal.codegen.compileroption.ValidationType.NONE;
 import static dagger.internal.codegen.extension.DaggerStreams.toImmutableSet;
 import static dagger.internal.codegen.langmodel.DaggerElements.getAnnotationMirror;
 import static dagger.internal.codegen.langmodel.DaggerElements.isAnyAnnotationPresent;
@@ -61,7 +60,6 @@ import dagger.internal.codegen.binding.ComponentCreatorAnnotation;
 import dagger.internal.codegen.binding.ComponentDescriptorFactory;
 import dagger.internal.codegen.binding.MethodSignatureFormatter;
 import dagger.internal.codegen.binding.ModuleKind;
-import dagger.internal.codegen.compileroption.CompilerOptions;
 import dagger.internal.codegen.langmodel.DaggerElements;
 import dagger.internal.codegen.langmodel.DaggerTypes;
 import dagger.model.BindingGraph;
@@ -126,7 +124,6 @@ public final class ModuleValidator {
   private final BindingGraphFactory bindingGraphFactory;
   private final BindingGraphConverter bindingGraphConverter;
   private final BindingGraphValidator bindingGraphValidator;
-  private final CompilerOptions compilerOptions;
   private final Map<TypeElement, ValidationReport<TypeElement>> cache = new HashMap<>();
   private final Set<TypeElement> knownModules = new HashSet<>();
 
@@ -139,8 +136,7 @@ public final class ModuleValidator {
       ComponentDescriptorFactory componentDescriptorFactory,
       BindingGraphFactory bindingGraphFactory,
       BindingGraphConverter bindingGraphConverter,
-      BindingGraphValidator bindingGraphValidator,
-      CompilerOptions compilerOptions) {
+      BindingGraphValidator bindingGraphValidator) {
     this.types = types;
     this.elements = elements;
     this.anyBindingMethodValidator = anyBindingMethodValidator;
@@ -149,7 +145,6 @@ public final class ModuleValidator {
     this.bindingGraphFactory = bindingGraphFactory;
     this.bindingGraphConverter = bindingGraphConverter;
     this.bindingGraphValidator = bindingGraphValidator;
-    this.compilerOptions = compilerOptions;
   }
 
   /**
@@ -245,7 +240,7 @@ public final class ModuleValidator {
     validateSelfCycles(module, builder);
 
     if (builder.build().isClean()
-        && !compilerOptions.fullBindingGraphValidationType(module).equals(NONE)) {
+        && bindingGraphValidator.shouldDoFullBindingGraphValidation(module)) {
       validateModuleBindings(module, builder);
     }
 

--- a/javatests/dagger/internal/codegen/DependencyCycleValidationTest.java
+++ b/javatests/dagger/internal/codegen/DependencyCycleValidationTest.java
@@ -106,8 +106,7 @@ public class DependencyCycleValidationTest {
 
     Compilation compilation =
         daggerCompiler()
-            .withOptions(
-                "-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
             .compile(SIMPLE_CYCLIC_DEPENDENCY);
     assertThat(compilation).failed();
 

--- a/javatests/dagger/internal/codegen/FullBindingGraphValidationTest.java
+++ b/javatests/dagger/internal/codegen/FullBindingGraphValidationTest.java
@@ -62,8 +62,7 @@ public final class FullBindingGraphValidationTest {
   public void moduleWithErrors_validationTypeError() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions(
-                "-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
             .compile(MODULE_WITH_ERRORS);
 
     assertThat(compilation).failed();
@@ -80,8 +79,7 @@ public final class FullBindingGraphValidationTest {
   public void moduleWithErrors_validationTypeWarning() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions(
-                "-Adagger.fullBindingGraphValidation=WARNING")
+            .withOptions("-Adagger.fullBindingGraphValidation=WARNING")
             .compile(MODULE_WITH_ERRORS);
 
     assertThat(compilation).succeeded();
@@ -116,8 +114,7 @@ public final class FullBindingGraphValidationTest {
   public void includesModuleWithErrors_validationTypeError() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions(
-                "-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
             .compile(MODULE_WITH_ERRORS, INCLUDES_MODULE_WITH_ERRORS);
 
     assertThat(compilation).failed();
@@ -139,8 +136,7 @@ public final class FullBindingGraphValidationTest {
   public void includesModuleWithErrors_validationTypeWarning() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions(
-                "-Adagger.fullBindingGraphValidation=WARNING")
+            .withOptions("-Adagger.fullBindingGraphValidation=WARNING")
             .compile(MODULE_WITH_ERRORS, INCLUDES_MODULE_WITH_ERRORS);
 
     assertThat(compilation).succeeded();
@@ -203,8 +199,7 @@ public final class FullBindingGraphValidationTest {
   public void moduleIncludingModuleWithCombinedErrors_validationTypeError() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions(
-                "-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
             .compile(A_MODULE, COMBINED_WITH_A_MODULE_HAS_ERRORS);
 
     assertThat(compilation).failed();
@@ -221,8 +216,7 @@ public final class FullBindingGraphValidationTest {
   public void moduleIncludingModuleWithCombinedErrors_validationTypeWarning() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions(
-                "-Adagger.fullBindingGraphValidation=WARNING")
+            .withOptions("-Adagger.fullBindingGraphValidation=WARNING")
             .compile(A_MODULE, COMBINED_WITH_A_MODULE_HAS_ERRORS);
 
     assertThat(compilation).succeeded();
@@ -271,8 +265,7 @@ public final class FullBindingGraphValidationTest {
   public void subcomponentWithErrors_validationTypeError() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions(
-                "-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
             .compile(SUBCOMPONENT_WITH_ERRORS, A_MODULE);
 
     assertThat(compilation).failed();
@@ -289,8 +282,7 @@ public final class FullBindingGraphValidationTest {
   public void subcomponentWithErrors_validationTypeWarning() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions(
-                "-Adagger.fullBindingGraphValidation=WARNING")
+            .withOptions("-Adagger.fullBindingGraphValidation=WARNING")
             .compile(SUBCOMPONENT_WITH_ERRORS, A_MODULE);
 
     assertThat(compilation).succeeded();
@@ -327,8 +319,7 @@ public final class FullBindingGraphValidationTest {
   public void moduleWithSubcomponentWithErrors_validationTypeError() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions(
-                "-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
             .compile(MODULE_WITH_SUBCOMPONENT_WITH_ERRORS, SUBCOMPONENT_WITH_ERRORS, A_MODULE);
 
     assertThat(compilation).failed();
@@ -351,8 +342,7 @@ public final class FullBindingGraphValidationTest {
   public void moduleWithSubcomponentWithErrors_validationTypeWarning() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions(
-                "-Adagger.fullBindingGraphValidation=WARNING")
+            .withOptions("-Adagger.fullBindingGraphValidation=WARNING")
             .compile(MODULE_WITH_SUBCOMPONENT_WITH_ERRORS, SUBCOMPONENT_WITH_ERRORS, A_MODULE);
 
     assertThat(compilation).succeeded();
@@ -419,8 +409,7 @@ public final class FullBindingGraphValidationTest {
   public void moduleWithSubcomponentWithCombinedErrors_validationTypeError() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions(
-                "-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
             .compile(COMBINED_WITH_A_SUBCOMPONENT_HAS_ERRORS, A_SUBCOMPONENT, A_MODULE);
 
     assertThat(compilation).failed();
@@ -437,8 +426,7 @@ public final class FullBindingGraphValidationTest {
   public void moduleWithSubcomponentWithCombinedErrors_validationTypeWarning() {
     Compilation compilation =
         daggerCompiler()
-            .withOptions(
-                "-Adagger.fullBindingGraphValidation=WARNING")
+            .withOptions("-Adagger.fullBindingGraphValidation=WARNING")
             .compile(COMBINED_WITH_A_SUBCOMPONENT_HAS_ERRORS, A_SUBCOMPONENT, A_MODULE);
 
     assertThat(compilation).succeeded();

--- a/javatests/dagger/internal/codegen/MapMultibindingValidationTest.java
+++ b/javatests/dagger/internal/codegen/MapMultibindingValidationTest.java
@@ -73,8 +73,7 @@ public class MapMultibindingValidationTest {
 
     compilation =
         daggerCompiler()
-            .withOptions(
-                "-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
             .compile(module);
     assertThat(compilation).failed();
     assertThat(compilation)
@@ -267,8 +266,7 @@ public class MapMultibindingValidationTest {
 
     compilation =
         daggerCompiler()
-            .withOptions(
-                "-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
             .compile(module, stringKeyTwoFile);
     assertThat(compilation).failed();
     assertThat(compilation)

--- a/javatests/dagger/internal/codegen/PluginsVisitFullBindingGraphTest.java
+++ b/javatests/dagger/internal/codegen/PluginsVisitFullBindingGraphTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2018 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static dagger.internal.codegen.TestUtils.endsWithMessage;
+import static javax.tools.Diagnostic.Kind.ERROR;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.Compiler;
+import com.google.testing.compile.JavaFileObjects;
+import dagger.model.BindingGraph;
+import dagger.spi.BindingGraphPlugin;
+import dagger.spi.DiagnosticReporter;
+import java.util.regex.Pattern;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for -Adagger.pluginsVisitFullBindingGraph. */
+@RunWith(JUnit4.class)
+public final class PluginsVisitFullBindingGraphTest {
+  private static final JavaFileObject MODULE_WITHOUT_ERRORS =
+      JavaFileObjects.forSourceLines(
+          "test.ModuleWithoutErrors",
+          "package test;",
+          "",
+          "import dagger.Binds;",
+          "import dagger.Module;",
+          "",
+          "@Module",
+          "interface ModuleWithoutErrors {",
+          "  @Binds Object object(String string);",
+          "}");
+
+  private static final JavaFileObject MODULE_WITH_ERRORS =
+      JavaFileObjects.forSourceLines(
+          "test.ModuleWithErrors",
+          "package test;",
+          "",
+          "import dagger.Binds;",
+          "import dagger.Module;",
+          "",
+          "@Module",
+          "interface ModuleWithErrors {",
+          "  @Binds Object object1(String string);",
+          "  @Binds Object object2(Long l);",
+          "}");
+
+  private static final Pattern PLUGIN_ERROR_MESSAGE =
+      endsWithMessage(
+          "[dagger.internal.codegen.PluginsVisitFullBindingGraphTest.ErrorPlugin] Error!");
+
+  @Test
+  public void testNoFlags() {
+    Compilation compilation = daggerCompiler().compile(MODULE_WITH_ERRORS);
+    assertThat(compilation).succeeded();
+  }
+
+  @Test
+  public void testWithVisitPlugins() {
+    Compilation compilation =
+        daggerCompiler()
+            .withOptions("-Adagger.pluginsVisitFullBindingGraphs=Enabled")
+            .compile(MODULE_WITH_ERRORS);
+
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
+    assertThat(compilation)
+        .hadErrorContainingMatch(PLUGIN_ERROR_MESSAGE)
+        .inFile(MODULE_WITH_ERRORS)
+        .onLineContaining("interface ModuleWithErrors");
+  }
+
+  @Test
+  public void testWithValidationNone() {
+    Compilation compilation =
+        daggerCompiler()
+            .withOptions("-Adagger.fullBindingGraphValidation=NONE")
+            .compile(MODULE_WITHOUT_ERRORS);
+    assertThat(compilation).succeeded();
+  }
+
+  @Test
+  public void testWithValidationError() {
+    // Test that pluginsVisitFullBindingGraph is enabled with fullBindingGraphValidation.
+    Compilation compilation =
+        daggerCompiler()
+            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
+            .compile(MODULE_WITHOUT_ERRORS);
+
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
+    assertThat(compilation)
+        .hadErrorContainingMatch(PLUGIN_ERROR_MESSAGE)
+        .inFile(MODULE_WITHOUT_ERRORS)
+        .onLineContaining("interface ModuleWithoutErrors");
+  }
+
+  @Test
+  public void testWithValidationErrorAndVisitPlugins() {
+    Compilation compilation =
+        daggerCompiler()
+            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions("-Adagger.pluginsVisitFullBindingGraphs=Enabled")
+            .compile(MODULE_WITHOUT_ERRORS);
+
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
+    assertThat(compilation)
+        .hadErrorContainingMatch(PLUGIN_ERROR_MESSAGE)
+        .inFile(MODULE_WITHOUT_ERRORS)
+        .onLineContaining("interface ModuleWithoutErrors");
+  }
+
+  /** A test plugin that just reports each component with the given {@link Diagnostic.Kind}. */
+  private static final class ErrorPlugin implements BindingGraphPlugin {
+    @Override
+    public void visitGraph(BindingGraph bindingGraph, DiagnosticReporter diagnosticReporter) {
+      diagnosticReporter.reportComponent(ERROR, bindingGraph.rootComponentNode(), "Error!");
+    }
+  }
+
+  private static Compiler daggerCompiler() {
+    return javac().withProcessors(ComponentProcessor.forTesting(new ErrorPlugin()));
+  }
+}

--- a/javatests/dagger/internal/codegen/ScopingValidationTest.java
+++ b/javatests/dagger/internal/codegen/ScopingValidationTest.java
@@ -243,8 +243,7 @@ public class ScopingValidationTest {
 
     compilation =
         daggerCompiler()
-            .withOptions(
-                "-Adagger.fullBindingGraphValidation=ERROR")
+            .withOptions("-Adagger.fullBindingGraphValidation=ERROR")
             .compile(componentFile, scopeFile, scopeWithAttribute, typeFile, moduleFile);
     // The @Inject binding for ScopedType should not appear here, but the @Singleton binding should.
     assertThat(compilation)


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Separate fullBindingGraphValidation from pluginsVisitFullBindingGraphs.

This CL does 2 main things:
  1. Allows external plugins to run via the DaggerProcessingOptions annotation.
  2. Allows external plugins to be run independently of binding validation.

One difference from the design doc is that fullBindingGraphValidation behavior does not change to avoid breaking external developers. In particular, fullBindingGraphValidation still runs both internal validation and external plugins.

RELNOTES="Adds a separate Dagger flag, `-Adagger.pluginsVisitFullBindingGraphs`, for visiting external plugins without doing BindingGraph validation first."

894bceb720cf086d8d6b9fd0bb84d91f739a3cf2