### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/ProcessingEnvironmentModule.java
+++ b/java/dagger/internal/codegen/ProcessingEnvironmentModule.java
@@ -22,11 +22,13 @@ import com.google.googlejavaformat.java.filer.FormattingFiler;
 import dagger.Module;
 import dagger.Provides;
 import dagger.Reusable;
+import dagger.internal.codegen.SpiModule.ProcessorClassLoader;
 import dagger.internal.codegen.compileroption.CompilerOptions;
 import dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions;
 import dagger.internal.codegen.compileroption.ProcessingOptions;
 import dagger.internal.codegen.langmodel.DaggerElements;
 import dagger.internal.codegen.statistics.DaggerStatisticsRecorder;
+import dagger.internal.codegen.validation.BindingGraphValidator;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.processing.Filer;
@@ -89,5 +91,11 @@ final class ProcessingEnvironmentModule {
   @Provides
   Optional<DaggerStatisticsRecorder> daggerStatisticsRecorder() {
     return Optional.empty();
+  }
+
+  @Provides
+  @ProcessorClassLoader
+  ClassLoader processorClassloader() {
+    return BindingGraphValidator.class.getClassLoader();
   }
 }

--- a/java/dagger/internal/codegen/SpiModule.java
+++ b/java/dagger/internal/codegen/SpiModule.java
@@ -41,16 +41,21 @@ abstract class SpiModule {
   @Provides
   @Singleton
   static ImmutableSet<BindingGraphPlugin> externalPlugins(
-      @TestingPlugins Optional<ImmutableSet<BindingGraphPlugin>> testingPlugins) {
+      @TestingPlugins Optional<ImmutableSet<BindingGraphPlugin>> testingPlugins,
+      @ProcessorClassLoader ClassLoader processorClassLoader) {
     return testingPlugins.orElseGet(
         () ->
             ImmutableSet.copyOf(
-                ServiceLoader.load(
-                    BindingGraphPlugin.class, BindingGraphValidator.class.getClassLoader())));
+                ServiceLoader.load(BindingGraphPlugin.class, processorClassLoader)));
   }
 
   @Qualifier
   @Retention(RUNTIME)
   @Target({FIELD, PARAMETER, METHOD})
   @interface TestingPlugins {}
+
+  @Qualifier
+  @Retention(RUNTIME)
+  @Target({PARAMETER, METHOD})
+  @interface ProcessorClassLoader {}
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Explicitly use the processorpath for SPI service loading
instead of assuming BindingGraphValidator was loaded from the processorpath.

c1e8f2ae73e0e19a750ee3658a93a9ed54bd2989