### PR TITLE
Moe Sync

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,6 +31,9 @@ nav:
       name: Home
       url: /
   - item:
+      name: Tutorial
+      url: /tutorial
+  - item:
       name: "User's Guide"
       url: /users-guide
   - item:

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,16 @@ description:
 
 themeColor: blue
 
-exclude: [_site, CHANGELOG.md, LICENSE, README.md, Gemfile, Gemfile.lock]
+exclude:
+  - CHANGELOG.md
+  - Gemfile
+  - Gemfile.lock
+  - LICENSE
+  - README.md
+  - _site
+  - node_modules
+  - vendor
+
 sass:
   style: compressed
 

--- a/_sass/components/_article.scss
+++ b/_sass/components/_article.scss
@@ -37,6 +37,16 @@
     color: rgba($c__black, .7);
   }
 
+  /*
+   * The stylesheet sets a default margin of 0 on everything. Then it overrides
+   * it above -- but only for direct children of the main article div. To
+   * restore the margin for paragraphs nested inside other elements (like
+   * lists), we need another rule.
+   */
+  * p {
+    margin-bottom: 1.8rem;
+  }
+
   a:not(.c-btn) {
     text-decoration: underline;
   }

--- a/android.md
+++ b/android.md
@@ -27,7 +27,7 @@ ensure that the Java source that it generates is consistently compatible with
 ProGuard optimizations.
 
 Of course, not all issues can be addressed in that manner, but it is the primary
-mechanism by which Android-specific compatbility will be provided.
+mechanism by which Android-specific compatibility will be provided.
 
 ### tl;dr
 

--- a/tutorial/13-max-withdrawal-across-commands.md
+++ b/tutorial/13-max-withdrawal-across-commands.md
@@ -43,7 +43,9 @@ if (amount.compareTo(remainingWithdrawalLimit) > 0) {
 
 account.withdraw(amount);
 withdrawalLimiter.recordWithdrawal(amount);
+```
 
+```java
 // in DepositCommand
 account.deposit(amount);
 withdrawalLimiter.recordDeposit(amount);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Separate deposit and withdrawal commands.

It was just a tiny bit confusing to have two files inside the same gray box, I would have expected one-gray-box per file. Different colors can separate different things, and having a bit of white in between can help separate visually the separate things.

505c7da6caac779866844cc5e715e9f793c79306

-------

<p> Exclude node_modules and vendor.

The same as what CL 267169945 did for Truth.

7a08deb4e65ed10129bc9789f8c6c9dcf3685159

-------

<p> Fixed typo

423aa82f6ef532ae4b6e646b8712c3eaff0f5647

-------

<p> Title the old users guide and add Tutorial to the dagger.dev navbar

fb96972156519b24668eb6147a755a4c74c10839

-------

<p> Fix doc annoyances:

- Add space between paragraphs inside a list item.
- Avoid highlighting "…" as an "errors" in code.

ad7ec1dbc49c57ddbf5d45a36bc607e9f2703a40