### PR TITLE
Moe Sync

### DIFF
--- a/java/dagger/internal/codegen/validation/InjectBindingRegistryImpl.java
+++ b/java/dagger/internal/codegen/validation/InjectBindingRegistryImpl.java
@@ -31,7 +31,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import com.squareup.javapoet.ClassName;
 import dagger.Component;
 import dagger.MembersInjector;
 import dagger.Provides;
@@ -120,7 +119,7 @@ final class InjectBindingRegistryImpl implements InjectBindingRegistry {
      * bindings, this will try to generate the unresolved version of the binding.
      */
     void tryToGenerateBinding(B binding, boolean warnIfNotAlreadyGenerated) {
-      if (shouldGenerateBinding(binding, generatedClassNameForBinding(binding))) {
+      if (shouldGenerateBinding(binding)) {
         bindingsRequiringGeneration.offer(binding);
         if (compilerOptions.warnIfInjectionFactoryNotGeneratedUpstream()
             && warnIfNotAlreadyGenerated) {
@@ -136,11 +135,11 @@ final class InjectBindingRegistryImpl implements InjectBindingRegistry {
     }
 
     /** Returns true if the binding needs to be generated. */
-    private boolean shouldGenerateBinding(B binding, ClassName factoryName) {
+    private boolean shouldGenerateBinding(B binding) {
       return !binding.unresolved().isPresent()
           && !materializedBindingKeys.contains(binding.key())
           && !bindingsRequiringGeneration.contains(binding)
-          && elements.getTypeElement(factoryName) == null;
+          && elements.getTypeElement(generatedClassNameForBinding(binding)) == null;
     }
 
     /** Caches the binding for future lookups by key. */

--- a/java/dagger/internal/codegen/writing/FactoryGenerator.java
+++ b/java/dagger/internal/codegen/writing/FactoryGenerator.java
@@ -53,7 +53,6 @@ import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import dagger.internal.Factory;
-import dagger.internal.Preconditions;
 import dagger.internal.codegen.base.SourceFileGenerator;
 import dagger.internal.codegen.base.UniqueNameSet;
 import dagger.internal.codegen.binding.ProvisionBinding;
@@ -295,17 +294,5 @@ public final class FactoryGenerator extends SourceFileGenerator<ProvisionBinding
 
   private static ParameterSpec toParameter(FieldSpec field) {
     return ParameterSpec.builder(field.type, field.name).build();
-  }
-
-  /**
-   * Returns {@code Preconditions.checkNotNull(providesMethodInvocation)} with a message suitable
-   * for {@code @Provides} methods.
-   */
-  static CodeBlock checkNotNullProvidesMethod(CodeBlock providesMethodInvocation) {
-    return CodeBlock.of(
-        "$T.checkNotNull($L, $S)",
-        Preconditions.class,
-        providesMethodInvocation,
-        "Cannot return null from a non-@Nullable @Provides method");
   }
 }

--- a/javatests/dagger/producers/monitoring/TimingProductionComponentMonitorTest.java
+++ b/javatests/dagger/producers/monitoring/TimingProductionComponentMonitorTest.java
@@ -16,7 +16,7 @@
 
 package dagger.producers.monitoring;
 
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -46,7 +46,7 @@ public final class TimingProductionComponentMonitorTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    when(productionComponentTimingRecorderFactory.create(any(Object.class)))
+    when(productionComponentTimingRecorderFactory.create(nullable(Object.class)))
         .thenReturn(productionComponentTimingRecorder);
     when(
             productionComponentTimingRecorder.producerTimingRecorderFor(

--- a/javatests/dagger/producers/monitoring/TimingProductionComponentMonitorTest.java
+++ b/javatests/dagger/producers/monitoring/TimingProductionComponentMonitorTest.java
@@ -16,7 +16,7 @@
 
 package dagger.producers.monitoring;
 
-import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -46,7 +46,7 @@ public final class TimingProductionComponentMonitorTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    when(productionComponentTimingRecorderFactory.create(nullable(Object.class)))
+    when(productionComponentTimingRecorderFactory.create(any(Object.class)))
         .thenReturn(productionComponentTimingRecorder);
     when(
             productionComponentTimingRecorder.producerTimingRecorderFor(

--- a/javatests/dagger/producers/monitoring/TimingRecordersTest.java
+++ b/javatests/dagger/producers/monitoring/TimingRecordersTest.java
@@ -17,8 +17,8 @@
 package dagger.producers.monitoring;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyLong;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -73,7 +73,8 @@ public final class TimingRecordersTest {
 
   @Test
   public void singleRecorder_nullProductionComponentTimingRecorder() {
-    when(mockProductionComponentTimingRecorderFactory.create(any(Object.class))).thenReturn(null);
+    when(mockProductionComponentTimingRecorderFactory.create(nullable(Object.class)))
+        .thenReturn(null);
     ProductionComponentTimingRecorder.Factory factory =
         TimingRecorders.delegatingProductionComponentTimingRecorderFactory(
             ImmutableList.of(mockProductionComponentTimingRecorderFactory));
@@ -83,7 +84,7 @@ public final class TimingRecordersTest {
 
   @Test
   public void singleRecorder_throwingProductionComponentTimingRecorderFactory() {
-    when(mockProductionComponentTimingRecorderFactory.create(any(Object.class)))
+    when(mockProductionComponentTimingRecorderFactory.create(nullable(Object.class)))
         .thenThrow(new RuntimeException("monkey"));
     ProductionComponentTimingRecorder.Factory factory =
         TimingRecorders.delegatingProductionComponentTimingRecorderFactory(
@@ -94,9 +95,10 @@ public final class TimingRecordersTest {
 
   @Test
   public void singleRecorder_nullProducerTimingRecorder() {
-    when(mockProductionComponentTimingRecorderFactory.create(any(Object.class)))
+    when(mockProductionComponentTimingRecorderFactory.create(nullable(Object.class)))
         .thenReturn(mockProductionComponentTimingRecorder);
-    when(mockProductionComponentTimingRecorder.producerTimingRecorderFor(any(ProducerToken.class)))
+    when(mockProductionComponentTimingRecorder.producerTimingRecorderFor(
+            nullable(ProducerToken.class)))
         .thenReturn(null);
     ProductionComponentTimingRecorder.Factory factory =
         TimingRecorders.delegatingProductionComponentTimingRecorderFactory(
@@ -108,9 +110,10 @@ public final class TimingRecordersTest {
 
   @Test
   public void singleRecorder_throwingProductionComponentTimingRecorder() {
-    when(mockProductionComponentTimingRecorderFactory.create(any(Object.class)))
+    when(mockProductionComponentTimingRecorderFactory.create(nullable(Object.class)))
         .thenReturn(mockProductionComponentTimingRecorder);
-    when(mockProductionComponentTimingRecorder.producerTimingRecorderFor(any(ProducerToken.class)))
+    when(mockProductionComponentTimingRecorder.producerTimingRecorderFor(
+            nullable(ProducerToken.class)))
         .thenThrow(new RuntimeException("monkey"));
     ProductionComponentTimingRecorder.Factory factory =
         TimingRecorders.delegatingProductionComponentTimingRecorderFactory(
@@ -183,9 +186,12 @@ public final class TimingRecordersTest {
 
   @Test
   public void multipleRecorders_nullProductionComponentTimingRecorders() {
-    when(mockProductionComponentTimingRecorderFactoryA.create(any(Object.class))).thenReturn(null);
-    when(mockProductionComponentTimingRecorderFactoryB.create(any(Object.class))).thenReturn(null);
-    when(mockProductionComponentTimingRecorderFactoryC.create(any(Object.class))).thenReturn(null);
+    when(mockProductionComponentTimingRecorderFactoryA.create(nullable(Object.class)))
+        .thenReturn(null);
+    when(mockProductionComponentTimingRecorderFactoryB.create(nullable(Object.class)))
+        .thenReturn(null);
+    when(mockProductionComponentTimingRecorderFactoryC.create(nullable(Object.class)))
+        .thenReturn(null);
     ProductionComponentTimingRecorder.Factory factory =
         TimingRecorders.delegatingProductionComponentTimingRecorderFactory(
             ImmutableList.of(
@@ -198,11 +204,11 @@ public final class TimingRecordersTest {
 
   @Test
   public void multipleRecorders_throwingProductionComponentTimingRecorderFactories() {
-    when(mockProductionComponentTimingRecorderFactoryA.create(any(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryA.create(nullable(Object.class)))
         .thenThrow(new RuntimeException("monkey"));
-    when(mockProductionComponentTimingRecorderFactoryB.create(any(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryB.create(nullable(Object.class)))
         .thenThrow(new RuntimeException("monkey"));
-    when(mockProductionComponentTimingRecorderFactoryC.create(any(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryC.create(nullable(Object.class)))
         .thenThrow(new RuntimeException("monkey"));
     ProductionComponentTimingRecorder.Factory factory =
         TimingRecorders.delegatingProductionComponentTimingRecorderFactory(
@@ -216,11 +222,14 @@ public final class TimingRecordersTest {
 
   @Test
   public void multipleRecorders_someNullProductionComponentTimingRecorders() {
-    when(mockProductionComponentTimingRecorderFactoryA.create(any(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryA.create(nullable(Object.class)))
         .thenReturn(mockProductionComponentTimingRecorderA);
-    when(mockProductionComponentTimingRecorderFactoryB.create(any(Object.class))).thenReturn(null);
-    when(mockProductionComponentTimingRecorderFactoryC.create(any(Object.class))).thenReturn(null);
-    when(mockProductionComponentTimingRecorderA.producerTimingRecorderFor(any(ProducerToken.class)))
+    when(mockProductionComponentTimingRecorderFactoryB.create(nullable(Object.class)))
+        .thenReturn(null);
+    when(mockProductionComponentTimingRecorderFactoryC.create(nullable(Object.class)))
+        .thenReturn(null);
+    when(mockProductionComponentTimingRecorderA.producerTimingRecorderFor(
+            nullable(ProducerToken.class)))
         .thenReturn(mockProducerTimingRecorderA);
     ProductionComponentTimingRecorder.Factory factory =
         TimingRecorders.delegatingProductionComponentTimingRecorderFactory(
@@ -243,13 +252,14 @@ public final class TimingRecordersTest {
 
   @Test
   public void multipleRecorders_someThrowingProductionComponentTimingRecorderFactories() {
-    when(mockProductionComponentTimingRecorderFactoryA.create(any(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryA.create(nullable(Object.class)))
         .thenReturn(mockProductionComponentTimingRecorderA);
-    when(mockProductionComponentTimingRecorderFactoryB.create(any(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryB.create(nullable(Object.class)))
         .thenThrow(new RuntimeException("monkey"));
-    when(mockProductionComponentTimingRecorderFactoryC.create(any(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryC.create(nullable(Object.class)))
         .thenThrow(new RuntimeException("monkey"));
-    when(mockProductionComponentTimingRecorderA.producerTimingRecorderFor(any(ProducerToken.class)))
+    when(mockProductionComponentTimingRecorderA.producerTimingRecorderFor(
+            nullable(ProducerToken.class)))
         .thenReturn(mockProducerTimingRecorderA);
     ProductionComponentTimingRecorder.Factory factory =
         TimingRecorders.delegatingProductionComponentTimingRecorderFactory(
@@ -338,24 +348,28 @@ public final class TimingRecordersTest {
   }
 
   private void setUpNormalSingleRecorder() {
-    when(mockProductionComponentTimingRecorderFactory.create(any(Object.class)))
+    when(mockProductionComponentTimingRecorderFactory.create(nullable(Object.class)))
         .thenReturn(mockProductionComponentTimingRecorder);
-    when(mockProductionComponentTimingRecorder.producerTimingRecorderFor(any(ProducerToken.class)))
+    when(mockProductionComponentTimingRecorder.producerTimingRecorderFor(
+            nullable(ProducerToken.class)))
         .thenReturn(mockProducerTimingRecorder);
   }
 
   private void setUpNormalMultipleRecorders() {
-    when(mockProductionComponentTimingRecorderFactoryA.create(any(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryA.create(nullable(Object.class)))
         .thenReturn(mockProductionComponentTimingRecorderA);
-    when(mockProductionComponentTimingRecorderFactoryB.create(any(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryB.create(nullable(Object.class)))
         .thenReturn(mockProductionComponentTimingRecorderB);
-    when(mockProductionComponentTimingRecorderFactoryC.create(any(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryC.create(nullable(Object.class)))
         .thenReturn(mockProductionComponentTimingRecorderC);
-    when(mockProductionComponentTimingRecorderA.producerTimingRecorderFor(any(ProducerToken.class)))
+    when(mockProductionComponentTimingRecorderA.producerTimingRecorderFor(
+            nullable(ProducerToken.class)))
         .thenReturn(mockProducerTimingRecorderA);
-    when(mockProductionComponentTimingRecorderB.producerTimingRecorderFor(any(ProducerToken.class)))
+    when(mockProductionComponentTimingRecorderB.producerTimingRecorderFor(
+            nullable(ProducerToken.class)))
         .thenReturn(mockProducerTimingRecorderB);
-    when(mockProductionComponentTimingRecorderC.producerTimingRecorderFor(any(ProducerToken.class)))
+    when(mockProductionComponentTimingRecorderC.producerTimingRecorderFor(
+            nullable(ProducerToken.class)))
         .thenReturn(mockProducerTimingRecorderC);
   }
 }

--- a/javatests/dagger/producers/monitoring/TimingRecordersTest.java
+++ b/javatests/dagger/producers/monitoring/TimingRecordersTest.java
@@ -17,6 +17,7 @@
 package dagger.producers.monitoring;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doThrow;
@@ -73,8 +74,7 @@ public final class TimingRecordersTest {
 
   @Test
   public void singleRecorder_nullProductionComponentTimingRecorder() {
-    when(mockProductionComponentTimingRecorderFactory.create(nullable(Object.class)))
-        .thenReturn(null);
+    when(mockProductionComponentTimingRecorderFactory.create(any(Object.class))).thenReturn(null);
     ProductionComponentTimingRecorder.Factory factory =
         TimingRecorders.delegatingProductionComponentTimingRecorderFactory(
             ImmutableList.of(mockProductionComponentTimingRecorderFactory));
@@ -84,7 +84,7 @@ public final class TimingRecordersTest {
 
   @Test
   public void singleRecorder_throwingProductionComponentTimingRecorderFactory() {
-    when(mockProductionComponentTimingRecorderFactory.create(nullable(Object.class)))
+    when(mockProductionComponentTimingRecorderFactory.create(any(Object.class)))
         .thenThrow(new RuntimeException("monkey"));
     ProductionComponentTimingRecorder.Factory factory =
         TimingRecorders.delegatingProductionComponentTimingRecorderFactory(
@@ -95,7 +95,7 @@ public final class TimingRecordersTest {
 
   @Test
   public void singleRecorder_nullProducerTimingRecorder() {
-    when(mockProductionComponentTimingRecorderFactory.create(nullable(Object.class)))
+    when(mockProductionComponentTimingRecorderFactory.create(any(Object.class)))
         .thenReturn(mockProductionComponentTimingRecorder);
     when(mockProductionComponentTimingRecorder.producerTimingRecorderFor(
             nullable(ProducerToken.class)))
@@ -110,7 +110,7 @@ public final class TimingRecordersTest {
 
   @Test
   public void singleRecorder_throwingProductionComponentTimingRecorder() {
-    when(mockProductionComponentTimingRecorderFactory.create(nullable(Object.class)))
+    when(mockProductionComponentTimingRecorderFactory.create(any(Object.class)))
         .thenReturn(mockProductionComponentTimingRecorder);
     when(mockProductionComponentTimingRecorder.producerTimingRecorderFor(
             nullable(ProducerToken.class)))
@@ -186,12 +186,9 @@ public final class TimingRecordersTest {
 
   @Test
   public void multipleRecorders_nullProductionComponentTimingRecorders() {
-    when(mockProductionComponentTimingRecorderFactoryA.create(nullable(Object.class)))
-        .thenReturn(null);
-    when(mockProductionComponentTimingRecorderFactoryB.create(nullable(Object.class)))
-        .thenReturn(null);
-    when(mockProductionComponentTimingRecorderFactoryC.create(nullable(Object.class)))
-        .thenReturn(null);
+    when(mockProductionComponentTimingRecorderFactoryA.create(any(Object.class))).thenReturn(null);
+    when(mockProductionComponentTimingRecorderFactoryB.create(any(Object.class))).thenReturn(null);
+    when(mockProductionComponentTimingRecorderFactoryC.create(any(Object.class))).thenReturn(null);
     ProductionComponentTimingRecorder.Factory factory =
         TimingRecorders.delegatingProductionComponentTimingRecorderFactory(
             ImmutableList.of(
@@ -204,11 +201,11 @@ public final class TimingRecordersTest {
 
   @Test
   public void multipleRecorders_throwingProductionComponentTimingRecorderFactories() {
-    when(mockProductionComponentTimingRecorderFactoryA.create(nullable(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryA.create(any(Object.class)))
         .thenThrow(new RuntimeException("monkey"));
-    when(mockProductionComponentTimingRecorderFactoryB.create(nullable(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryB.create(any(Object.class)))
         .thenThrow(new RuntimeException("monkey"));
-    when(mockProductionComponentTimingRecorderFactoryC.create(nullable(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryC.create(any(Object.class)))
         .thenThrow(new RuntimeException("monkey"));
     ProductionComponentTimingRecorder.Factory factory =
         TimingRecorders.delegatingProductionComponentTimingRecorderFactory(
@@ -222,12 +219,10 @@ public final class TimingRecordersTest {
 
   @Test
   public void multipleRecorders_someNullProductionComponentTimingRecorders() {
-    when(mockProductionComponentTimingRecorderFactoryA.create(nullable(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryA.create(any(Object.class)))
         .thenReturn(mockProductionComponentTimingRecorderA);
-    when(mockProductionComponentTimingRecorderFactoryB.create(nullable(Object.class)))
-        .thenReturn(null);
-    when(mockProductionComponentTimingRecorderFactoryC.create(nullable(Object.class)))
-        .thenReturn(null);
+    when(mockProductionComponentTimingRecorderFactoryB.create(any(Object.class))).thenReturn(null);
+    when(mockProductionComponentTimingRecorderFactoryC.create(any(Object.class))).thenReturn(null);
     when(mockProductionComponentTimingRecorderA.producerTimingRecorderFor(
             nullable(ProducerToken.class)))
         .thenReturn(mockProducerTimingRecorderA);
@@ -252,11 +247,11 @@ public final class TimingRecordersTest {
 
   @Test
   public void multipleRecorders_someThrowingProductionComponentTimingRecorderFactories() {
-    when(mockProductionComponentTimingRecorderFactoryA.create(nullable(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryA.create(any(Object.class)))
         .thenReturn(mockProductionComponentTimingRecorderA);
-    when(mockProductionComponentTimingRecorderFactoryB.create(nullable(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryB.create(any(Object.class)))
         .thenThrow(new RuntimeException("monkey"));
-    when(mockProductionComponentTimingRecorderFactoryC.create(nullable(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryC.create(any(Object.class)))
         .thenThrow(new RuntimeException("monkey"));
     when(mockProductionComponentTimingRecorderA.producerTimingRecorderFor(
             nullable(ProducerToken.class)))
@@ -348,7 +343,7 @@ public final class TimingRecordersTest {
   }
 
   private void setUpNormalSingleRecorder() {
-    when(mockProductionComponentTimingRecorderFactory.create(nullable(Object.class)))
+    when(mockProductionComponentTimingRecorderFactory.create(any(Object.class)))
         .thenReturn(mockProductionComponentTimingRecorder);
     when(mockProductionComponentTimingRecorder.producerTimingRecorderFor(
             nullable(ProducerToken.class)))
@@ -356,11 +351,11 @@ public final class TimingRecordersTest {
   }
 
   private void setUpNormalMultipleRecorders() {
-    when(mockProductionComponentTimingRecorderFactoryA.create(nullable(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryA.create(any(Object.class)))
         .thenReturn(mockProductionComponentTimingRecorderA);
-    when(mockProductionComponentTimingRecorderFactoryB.create(nullable(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryB.create(any(Object.class)))
         .thenReturn(mockProductionComponentTimingRecorderB);
-    when(mockProductionComponentTimingRecorderFactoryC.create(nullable(Object.class)))
+    when(mockProductionComponentTimingRecorderFactoryC.create(any(Object.class)))
         .thenReturn(mockProductionComponentTimingRecorderC);
     when(mockProductionComponentTimingRecorderA.producerTimingRecorderFor(
             nullable(ProducerToken.class)))

--- a/javatests/dagger/producers/monitoring/internal/MonitorsTest.java
+++ b/javatests/dagger/producers/monitoring/internal/MonitorsTest.java
@@ -17,7 +17,7 @@
 package dagger.producers.monitoring.internal;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -65,7 +65,7 @@ public final class MonitorsTest {
 
   @Test
   public void singleMonitor_nullProductionComponentMonitor() {
-    when(mockProductionComponentMonitorFactory.create(any(Object.class))).thenReturn(null);
+    when(mockProductionComponentMonitorFactory.create(nullable(Object.class))).thenReturn(null);
     ProductionComponentMonitor.Factory factory =
         Monitors.delegatingProductionComponentMonitorFactory(
             ImmutableList.of(mockProductionComponentMonitorFactory));
@@ -76,7 +76,7 @@ public final class MonitorsTest {
   public void singleMonitor_throwingProductionComponentMonitorFactory() {
     doThrow(new RuntimeException("monkey"))
         .when(mockProductionComponentMonitorFactory)
-        .create(any(Object.class));
+        .create(nullable(Object.class));
     ProductionComponentMonitor.Factory factory =
         Monitors.delegatingProductionComponentMonitorFactory(
             ImmutableList.of(mockProductionComponentMonitorFactory));
@@ -85,9 +85,9 @@ public final class MonitorsTest {
 
   @Test
   public void singleMonitor_nullProducerMonitor() {
-    when(mockProductionComponentMonitorFactory.create(any(Object.class)))
+    when(mockProductionComponentMonitorFactory.create(nullable(Object.class)))
         .thenReturn(mockProductionComponentMonitor);
-    when(mockProductionComponentMonitor.producerMonitorFor(any(ProducerToken.class)))
+    when(mockProductionComponentMonitor.producerMonitorFor(nullable(ProducerToken.class)))
         .thenReturn(null);
     ProductionComponentMonitor.Factory factory =
         Monitors.delegatingProductionComponentMonitorFactory(
@@ -99,11 +99,11 @@ public final class MonitorsTest {
 
   @Test
   public void singleMonitor_throwingProductionComponentMonitor() {
-    when(mockProductionComponentMonitorFactory.create(any(Object.class)))
+    when(mockProductionComponentMonitorFactory.create(nullable(Object.class)))
         .thenReturn(mockProductionComponentMonitor);
     doThrow(new RuntimeException("monkey"))
         .when(mockProductionComponentMonitor)
-        .producerMonitorFor(any(ProducerToken.class));
+        .producerMonitorFor(nullable(ProducerToken.class));
     ProductionComponentMonitor.Factory factory =
         Monitors.delegatingProductionComponentMonitorFactory(
             ImmutableList.of(mockProductionComponentMonitorFactory));
@@ -164,7 +164,9 @@ public final class MonitorsTest {
     doThrow(new RuntimeException("monkey")).when(mockProducerMonitor).requested();
     doThrow(new RuntimeException("monkey")).when(mockProducerMonitor).methodStarting();
     doThrow(new RuntimeException("monkey")).when(mockProducerMonitor).methodFinished();
-    doThrow(new RuntimeException("monkey")).when(mockProducerMonitor).succeeded(any(Object.class));
+    doThrow(new RuntimeException("monkey"))
+        .when(mockProducerMonitor)
+        .succeeded(nullable(Object.class));
     ProductionComponentMonitor.Factory factory =
         Monitors.delegatingProductionComponentMonitorFactory(
             ImmutableList.of(mockProductionComponentMonitorFactory));
@@ -191,7 +193,9 @@ public final class MonitorsTest {
     doThrow(new RuntimeException("monkey")).when(mockProducerMonitor).requested();
     doThrow(new RuntimeException("monkey")).when(mockProducerMonitor).methodStarting();
     doThrow(new RuntimeException("monkey")).when(mockProducerMonitor).methodFinished();
-    doThrow(new RuntimeException("monkey")).when(mockProducerMonitor).failed(any(Throwable.class));
+    doThrow(new RuntimeException("monkey"))
+        .when(mockProducerMonitor)
+        .failed(nullable(Throwable.class));
     ProductionComponentMonitor.Factory factory =
         Monitors.delegatingProductionComponentMonitorFactory(
             ImmutableList.of(mockProductionComponentMonitorFactory));
@@ -214,9 +218,9 @@ public final class MonitorsTest {
 
   @Test
   public void multipleMonitors_nullProductionComponentMonitors() {
-    when(mockProductionComponentMonitorFactoryA.create(any(Object.class))).thenReturn(null);
-    when(mockProductionComponentMonitorFactoryB.create(any(Object.class))).thenReturn(null);
-    when(mockProductionComponentMonitorFactoryC.create(any(Object.class))).thenReturn(null);
+    when(mockProductionComponentMonitorFactoryA.create(nullable(Object.class))).thenReturn(null);
+    when(mockProductionComponentMonitorFactoryB.create(nullable(Object.class))).thenReturn(null);
+    when(mockProductionComponentMonitorFactoryC.create(nullable(Object.class))).thenReturn(null);
     ProductionComponentMonitor.Factory factory =
         Monitors.delegatingProductionComponentMonitorFactory(
             ImmutableList.of(
@@ -230,13 +234,13 @@ public final class MonitorsTest {
   public void multipleMonitors_throwingProductionComponentMonitorFactories() {
     doThrow(new RuntimeException("monkey"))
         .when(mockProductionComponentMonitorFactoryA)
-        .create(any(Object.class));
+        .create(nullable(Object.class));
     doThrow(new RuntimeException("monkey"))
         .when(mockProductionComponentMonitorFactoryB)
-        .create(any(Object.class));
+        .create(nullable(Object.class));
     doThrow(new RuntimeException("monkey"))
         .when(mockProductionComponentMonitorFactoryC)
-        .create(any(Object.class));
+        .create(nullable(Object.class));
     ProductionComponentMonitor.Factory factory =
         Monitors.delegatingProductionComponentMonitorFactory(
             ImmutableList.of(
@@ -248,11 +252,11 @@ public final class MonitorsTest {
 
   @Test
   public void multipleMonitors_someNullProductionComponentMonitors() {
-    when(mockProductionComponentMonitorFactoryA.create(any(Object.class)))
+    when(mockProductionComponentMonitorFactoryA.create(nullable(Object.class)))
         .thenReturn(mockProductionComponentMonitorA);
-    when(mockProductionComponentMonitorFactoryB.create(any(Object.class))).thenReturn(null);
-    when(mockProductionComponentMonitorFactoryC.create(any(Object.class))).thenReturn(null);
-    when(mockProductionComponentMonitorA.producerMonitorFor(any(ProducerToken.class)))
+    when(mockProductionComponentMonitorFactoryB.create(nullable(Object.class))).thenReturn(null);
+    when(mockProductionComponentMonitorFactoryC.create(nullable(Object.class))).thenReturn(null);
+    when(mockProductionComponentMonitorA.producerMonitorFor(nullable(ProducerToken.class)))
         .thenReturn(mockProducerMonitorA);
     ProductionComponentMonitor.Factory factory =
         Monitors.delegatingProductionComponentMonitorFactory(
@@ -280,15 +284,15 @@ public final class MonitorsTest {
 
   @Test
   public void multipleMonitors_someThrowingProductionComponentMonitorFactories() {
-    when(mockProductionComponentMonitorFactoryA.create(any(Object.class)))
+    when(mockProductionComponentMonitorFactoryA.create(nullable(Object.class)))
         .thenReturn(mockProductionComponentMonitorA);
     doThrow(new RuntimeException("monkey"))
         .when(mockProductionComponentMonitorFactoryB)
-        .create(any(Object.class));
+        .create(nullable(Object.class));
     doThrow(new RuntimeException("monkey"))
         .when(mockProductionComponentMonitorFactoryC)
-        .create(any(Object.class));
-    when(mockProductionComponentMonitorA.producerMonitorFor(any(ProducerToken.class)))
+        .create(nullable(Object.class));
+    when(mockProductionComponentMonitorA.producerMonitorFor(nullable(ProducerToken.class)))
         .thenReturn(mockProducerMonitorA);
     ProductionComponentMonitor.Factory factory =
         Monitors.delegatingProductionComponentMonitorFactory(
@@ -390,7 +394,9 @@ public final class MonitorsTest {
     doThrow(new RuntimeException("monkey")).when(mockProducerMonitorA).requested();
     doThrow(new RuntimeException("monkey")).when(mockProducerMonitorA).methodStarting();
     doThrow(new RuntimeException("monkey")).when(mockProducerMonitorB).methodFinished();
-    doThrow(new RuntimeException("monkey")).when(mockProducerMonitorC).succeeded(any(Object.class));
+    doThrow(new RuntimeException("monkey"))
+        .when(mockProducerMonitorC)
+        .succeeded(nullable(Object.class));
     ProductionComponentMonitor.Factory factory =
         Monitors.delegatingProductionComponentMonitorFactory(
             ImmutableList.of(
@@ -429,7 +435,9 @@ public final class MonitorsTest {
     doThrow(new RuntimeException("monkey")).when(mockProducerMonitorA).requested();
     doThrow(new RuntimeException("monkey")).when(mockProducerMonitorA).methodStarting();
     doThrow(new RuntimeException("monkey")).when(mockProducerMonitorB).methodFinished();
-    doThrow(new RuntimeException("monkey")).when(mockProducerMonitorC).failed(any(Throwable.class));
+    doThrow(new RuntimeException("monkey"))
+        .when(mockProducerMonitorC)
+        .failed(nullable(Throwable.class));
     ProductionComponentMonitor.Factory factory =
         Monitors.delegatingProductionComponentMonitorFactory(
             ImmutableList.of(
@@ -463,24 +471,24 @@ public final class MonitorsTest {
   }
 
   private void setUpNormalSingleMonitor() {
-    when(mockProductionComponentMonitorFactory.create(any(Object.class)))
+    when(mockProductionComponentMonitorFactory.create(nullable(Object.class)))
         .thenReturn(mockProductionComponentMonitor);
-    when(mockProductionComponentMonitor.producerMonitorFor(any(ProducerToken.class)))
+    when(mockProductionComponentMonitor.producerMonitorFor(nullable(ProducerToken.class)))
         .thenReturn(mockProducerMonitor);
   }
 
   private void setUpNormalMultipleMonitors() {
-    when(mockProductionComponentMonitorFactoryA.create(any(Object.class)))
+    when(mockProductionComponentMonitorFactoryA.create(nullable(Object.class)))
         .thenReturn(mockProductionComponentMonitorA);
-    when(mockProductionComponentMonitorFactoryB.create(any(Object.class)))
+    when(mockProductionComponentMonitorFactoryB.create(nullable(Object.class)))
         .thenReturn(mockProductionComponentMonitorB);
-    when(mockProductionComponentMonitorFactoryC.create(any(Object.class)))
+    when(mockProductionComponentMonitorFactoryC.create(nullable(Object.class)))
         .thenReturn(mockProductionComponentMonitorC);
-    when(mockProductionComponentMonitorA.producerMonitorFor(any(ProducerToken.class)))
+    when(mockProductionComponentMonitorA.producerMonitorFor(nullable(ProducerToken.class)))
         .thenReturn(mockProducerMonitorA);
-    when(mockProductionComponentMonitorB.producerMonitorFor(any(ProducerToken.class)))
+    when(mockProductionComponentMonitorB.producerMonitorFor(nullable(ProducerToken.class)))
         .thenReturn(mockProducerMonitorB);
-    when(mockProductionComponentMonitorC.producerMonitorFor(any(ProducerToken.class)))
+    when(mockProductionComponentMonitorC.producerMonitorFor(nullable(ProducerToken.class)))
         .thenReturn(mockProducerMonitorC);
   }
 }

--- a/javatests/dagger/producers/monitoring/internal/MonitorsTest.java
+++ b/javatests/dagger/producers/monitoring/internal/MonitorsTest.java
@@ -17,6 +17,7 @@
 package dagger.producers.monitoring.internal;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
@@ -65,7 +66,7 @@ public final class MonitorsTest {
 
   @Test
   public void singleMonitor_nullProductionComponentMonitor() {
-    when(mockProductionComponentMonitorFactory.create(nullable(Object.class))).thenReturn(null);
+    when(mockProductionComponentMonitorFactory.create(any(Object.class))).thenReturn(null);
     ProductionComponentMonitor.Factory factory =
         Monitors.delegatingProductionComponentMonitorFactory(
             ImmutableList.of(mockProductionComponentMonitorFactory));
@@ -76,7 +77,7 @@ public final class MonitorsTest {
   public void singleMonitor_throwingProductionComponentMonitorFactory() {
     doThrow(new RuntimeException("monkey"))
         .when(mockProductionComponentMonitorFactory)
-        .create(nullable(Object.class));
+        .create(any(Object.class));
     ProductionComponentMonitor.Factory factory =
         Monitors.delegatingProductionComponentMonitorFactory(
             ImmutableList.of(mockProductionComponentMonitorFactory));
@@ -85,7 +86,7 @@ public final class MonitorsTest {
 
   @Test
   public void singleMonitor_nullProducerMonitor() {
-    when(mockProductionComponentMonitorFactory.create(nullable(Object.class)))
+    when(mockProductionComponentMonitorFactory.create(any(Object.class)))
         .thenReturn(mockProductionComponentMonitor);
     when(mockProductionComponentMonitor.producerMonitorFor(nullable(ProducerToken.class)))
         .thenReturn(null);
@@ -99,7 +100,7 @@ public final class MonitorsTest {
 
   @Test
   public void singleMonitor_throwingProductionComponentMonitor() {
-    when(mockProductionComponentMonitorFactory.create(nullable(Object.class)))
+    when(mockProductionComponentMonitorFactory.create(any(Object.class)))
         .thenReturn(mockProductionComponentMonitor);
     doThrow(new RuntimeException("monkey"))
         .when(mockProductionComponentMonitor)
@@ -193,9 +194,7 @@ public final class MonitorsTest {
     doThrow(new RuntimeException("monkey")).when(mockProducerMonitor).requested();
     doThrow(new RuntimeException("monkey")).when(mockProducerMonitor).methodStarting();
     doThrow(new RuntimeException("monkey")).when(mockProducerMonitor).methodFinished();
-    doThrow(new RuntimeException("monkey"))
-        .when(mockProducerMonitor)
-        .failed(nullable(Throwable.class));
+    doThrow(new RuntimeException("monkey")).when(mockProducerMonitor).failed(any(Throwable.class));
     ProductionComponentMonitor.Factory factory =
         Monitors.delegatingProductionComponentMonitorFactory(
             ImmutableList.of(mockProductionComponentMonitorFactory));
@@ -218,9 +217,9 @@ public final class MonitorsTest {
 
   @Test
   public void multipleMonitors_nullProductionComponentMonitors() {
-    when(mockProductionComponentMonitorFactoryA.create(nullable(Object.class))).thenReturn(null);
-    when(mockProductionComponentMonitorFactoryB.create(nullable(Object.class))).thenReturn(null);
-    when(mockProductionComponentMonitorFactoryC.create(nullable(Object.class))).thenReturn(null);
+    when(mockProductionComponentMonitorFactoryA.create(any(Object.class))).thenReturn(null);
+    when(mockProductionComponentMonitorFactoryB.create(any(Object.class))).thenReturn(null);
+    when(mockProductionComponentMonitorFactoryC.create(any(Object.class))).thenReturn(null);
     ProductionComponentMonitor.Factory factory =
         Monitors.delegatingProductionComponentMonitorFactory(
             ImmutableList.of(
@@ -234,13 +233,13 @@ public final class MonitorsTest {
   public void multipleMonitors_throwingProductionComponentMonitorFactories() {
     doThrow(new RuntimeException("monkey"))
         .when(mockProductionComponentMonitorFactoryA)
-        .create(nullable(Object.class));
+        .create(any(Object.class));
     doThrow(new RuntimeException("monkey"))
         .when(mockProductionComponentMonitorFactoryB)
-        .create(nullable(Object.class));
+        .create(any(Object.class));
     doThrow(new RuntimeException("monkey"))
         .when(mockProductionComponentMonitorFactoryC)
-        .create(nullable(Object.class));
+        .create(any(Object.class));
     ProductionComponentMonitor.Factory factory =
         Monitors.delegatingProductionComponentMonitorFactory(
             ImmutableList.of(
@@ -252,10 +251,10 @@ public final class MonitorsTest {
 
   @Test
   public void multipleMonitors_someNullProductionComponentMonitors() {
-    when(mockProductionComponentMonitorFactoryA.create(nullable(Object.class)))
+    when(mockProductionComponentMonitorFactoryA.create(any(Object.class)))
         .thenReturn(mockProductionComponentMonitorA);
-    when(mockProductionComponentMonitorFactoryB.create(nullable(Object.class))).thenReturn(null);
-    when(mockProductionComponentMonitorFactoryC.create(nullable(Object.class))).thenReturn(null);
+    when(mockProductionComponentMonitorFactoryB.create(any(Object.class))).thenReturn(null);
+    when(mockProductionComponentMonitorFactoryC.create(any(Object.class))).thenReturn(null);
     when(mockProductionComponentMonitorA.producerMonitorFor(nullable(ProducerToken.class)))
         .thenReturn(mockProducerMonitorA);
     ProductionComponentMonitor.Factory factory =
@@ -284,14 +283,14 @@ public final class MonitorsTest {
 
   @Test
   public void multipleMonitors_someThrowingProductionComponentMonitorFactories() {
-    when(mockProductionComponentMonitorFactoryA.create(nullable(Object.class)))
+    when(mockProductionComponentMonitorFactoryA.create(any(Object.class)))
         .thenReturn(mockProductionComponentMonitorA);
     doThrow(new RuntimeException("monkey"))
         .when(mockProductionComponentMonitorFactoryB)
-        .create(nullable(Object.class));
+        .create(any(Object.class));
     doThrow(new RuntimeException("monkey"))
         .when(mockProductionComponentMonitorFactoryC)
-        .create(nullable(Object.class));
+        .create(any(Object.class));
     when(mockProductionComponentMonitorA.producerMonitorFor(nullable(ProducerToken.class)))
         .thenReturn(mockProducerMonitorA);
     ProductionComponentMonitor.Factory factory =
@@ -435,9 +434,7 @@ public final class MonitorsTest {
     doThrow(new RuntimeException("monkey")).when(mockProducerMonitorA).requested();
     doThrow(new RuntimeException("monkey")).when(mockProducerMonitorA).methodStarting();
     doThrow(new RuntimeException("monkey")).when(mockProducerMonitorB).methodFinished();
-    doThrow(new RuntimeException("monkey"))
-        .when(mockProducerMonitorC)
-        .failed(nullable(Throwable.class));
+    doThrow(new RuntimeException("monkey")).when(mockProducerMonitorC).failed(any(Throwable.class));
     ProductionComponentMonitor.Factory factory =
         Monitors.delegatingProductionComponentMonitorFactory(
             ImmutableList.of(
@@ -471,18 +468,18 @@ public final class MonitorsTest {
   }
 
   private void setUpNormalSingleMonitor() {
-    when(mockProductionComponentMonitorFactory.create(nullable(Object.class)))
+    when(mockProductionComponentMonitorFactory.create(any(Object.class)))
         .thenReturn(mockProductionComponentMonitor);
     when(mockProductionComponentMonitor.producerMonitorFor(nullable(ProducerToken.class)))
         .thenReturn(mockProducerMonitor);
   }
 
   private void setUpNormalMultipleMonitors() {
-    when(mockProductionComponentMonitorFactoryA.create(nullable(Object.class)))
+    when(mockProductionComponentMonitorFactoryA.create(any(Object.class)))
         .thenReturn(mockProductionComponentMonitorA);
-    when(mockProductionComponentMonitorFactoryB.create(nullable(Object.class)))
+    when(mockProductionComponentMonitorFactoryB.create(any(Object.class)))
         .thenReturn(mockProductionComponentMonitorB);
-    when(mockProductionComponentMonitorFactoryC.create(nullable(Object.class)))
+    when(mockProductionComponentMonitorFactoryC.create(any(Object.class)))
         .thenReturn(mockProductionComponentMonitorC);
     when(mockProductionComponentMonitorA.producerMonitorFor(nullable(ProducerToken.class)))
         .thenReturn(mockProducerMonitorA);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Migrate org.mockito.Matchers#any* to org.mockito.ArgumentMatchers

The former is deprecated and replaced by the latter in Mockito 2. However, there is a
functional difference: ArgumentMatchers will reject `null` and check the type
if the matcher specified a type (e.g. `any(Class)` or `anyInt()`). `any()` will
remain to accept anything.

All remaining `any(Class)` references are migrated to `nulllable(Class)` to maintain the functionality of Mockito 1.

774211a89e6a62b6ce371e43a12c92fc26bfec9c

-------

<p> [Dagger Refactor] Inline single-use method.

FactoryGenerator.checkNotNullProvidesMethod is only used in InjectionMethods, so I've inlined it there.

RELNOTES=N/A

b28c36b5abe60876c2415778eef28951377039a2

-------

<p> Use any() argument matcher where we know the argument is never null.

d0e7201776b0e24e755c34272dfe8dd566a0f75c

-------

<p> [Dagger Refactor] Remove unnecessary method parameter in shouldGenerateBinding().

RELNOTES=N/A

14dee357f32b905db1ae3648ac035ca18eb560d1