### PR TITLE
MOE Sync 2019-11-07

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,6 +16,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "google_bazel_common",
+    sha256 = "f20aaaf1d80fa5fbe9843792cd199ab213ab63ee8a0f3931dd14ae7a9d528f05",
     strip_prefix = "bazel-common-4c4c70bdf2a9f5bc9afdf2c27dfcb905cac2eea1",
     urls = ["https://github.com/google/bazel-common/archive/4c4c70bdf2a9f5bc9afdf2c27dfcb905cac2eea1.zip"],
 )


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add bazel_common's sha256

5e060b6be149b4eafff01f4650a3b40cca4675bc

-------

<p> Fix issue with Kotlin object class modules and primitive types where methods were not being dispatching through the singleton INSTANCE.

Fixes https://github.com/google/dagger/issues/1648

RELNOTES=Fix #1648 where Kotlin object module providers of a primitive type would fail to compile

e4a754eca60bde0b1e9b20d63dfc2043670111a4