### PR TITLE
MOE Sync 2019-12-24

### DIFF
--- a/java/dagger/internal/codegen/binding/DependencyRequestFactory.java
+++ b/java/dagger/internal/codegen/binding/DependencyRequestFactory.java
@@ -25,6 +25,7 @@ import static dagger.internal.codegen.base.RequestKinds.extractKeyType;
 import static dagger.internal.codegen.base.RequestKinds.frameworkClass;
 import static dagger.internal.codegen.base.RequestKinds.getRequestKind;
 import static dagger.internal.codegen.binding.ConfigurationAnnotations.getNullableType;
+import static dagger.internal.codegen.langmodel.DaggerTypes.unwrapType;
 import static dagger.model.RequestKind.FUTURE;
 import static dagger.model.RequestKind.INSTANCE;
 import static dagger.model.RequestKind.MEMBERS_INJECTION;
@@ -36,7 +37,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import dagger.Lazy;
 import dagger.internal.codegen.base.MapType;
 import dagger.internal.codegen.base.OptionalType;
-import dagger.internal.codegen.langmodel.DaggerTypes;
 import dagger.model.DependencyRequest;
 import dagger.model.Key;
 import dagger.model.RequestKind;
@@ -60,14 +60,11 @@ import javax.lang.model.type.TypeMirror;
  */
 public final class DependencyRequestFactory {
   private final KeyFactory keyFactory;
-  private final DaggerTypes types;
   private final InjectionAnnotations injectionAnnotations;
 
   @Inject
-  DependencyRequestFactory(
-      KeyFactory keyFactory, DaggerTypes types, InjectionAnnotations injectionAnnotations) {
+  DependencyRequestFactory(KeyFactory keyFactory, InjectionAnnotations injectionAnnotations) {
     this.keyFactory = keyFactory;
-    this.types = types;
     this.injectionAnnotations = injectionAnnotations;
   }
 
@@ -167,7 +164,7 @@ public final class DependencyRequestFactory {
     if (isTypeOf(ListenableFuture.class, type)) {
       return DependencyRequest.builder()
           .kind(FUTURE)
-          .key(keyFactory.forQualifiedType(qualifier, types.unwrapType(type)))
+          .key(keyFactory.forQualifiedType(qualifier, unwrapType(type)))
           .requestElement(productionMethod)
           .build();
     } else {
@@ -224,7 +221,7 @@ public final class DependencyRequestFactory {
     RequestKind requestKind = getRequestKind(type);
     return DependencyRequest.builder()
         .kind(requestKind)
-        .key(keyFactory.forQualifiedType(qualifier, extractKeyType(requestKind, type)))
+        .key(keyFactory.forQualifiedType(qualifier, extractKeyType(type)))
         .requestElement(requestElement)
         .isNullable(allowsNull(requestKind, getNullableType(requestElement)))
         .build();

--- a/java/dagger/internal/codegen/binding/KeyFactory.java
+++ b/java/dagger/internal/codegen/binding/KeyFactory.java
@@ -23,12 +23,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static dagger.internal.codegen.base.RequestKinds.extractKeyType;
-import static dagger.internal.codegen.base.RequestKinds.getRequestKind;
 import static dagger.internal.codegen.binding.MapKeys.getMapKey;
 import static dagger.internal.codegen.binding.MapKeys.mapKeyType;
 import static dagger.internal.codegen.extension.DaggerStreams.toImmutableSet;
 import static dagger.internal.codegen.extension.Optionals.firstPresent;
 import static dagger.internal.codegen.langmodel.DaggerTypes.isFutureType;
+import static dagger.internal.codegen.langmodel.DaggerTypes.unwrapType;
 import static java.util.Arrays.asList;
 import static javax.lang.model.element.ElementKind.METHOD;
 
@@ -172,7 +172,7 @@ public final class KeyFactory {
         if (isFutureType(setType.elementType())) {
           returnType =
               types.getDeclaredType(
-                  elements.getTypeElement(Set.class), types.unwrapType(setType.elementType()));
+                  elements.getTypeElement(Set.class), unwrapType(setType.elementType()));
         }
       }
     }
@@ -429,9 +429,6 @@ public final class KeyFactory {
     }
 
     TypeMirror optionalValueType = OptionalType.from(key).valueType();
-    return Optional.of(
-        key.toBuilder()
-            .type(extractKeyType(getRequestKind(optionalValueType), optionalValueType))
-            .build());
+    return Optional.of(key.toBuilder().type(extractKeyType(optionalValueType)).build());
   }
 }

--- a/java/dagger/internal/codegen/bindinggraphvalidation/BindingGraphValidationModule.java
+++ b/java/dagger/internal/codegen/bindinggraphvalidation/BindingGraphValidationModule.java
@@ -16,64 +16,48 @@
 
 package dagger.internal.codegen.bindinggraphvalidation;
 
-import dagger.Binds;
+import com.google.common.collect.ImmutableSet;
 import dagger.Module;
+import dagger.Provides;
+import dagger.internal.codegen.compileroption.CompilerOptions;
+import dagger.internal.codegen.validation.CompositeBindingGraphPlugin;
 import dagger.internal.codegen.validation.Validation;
-import dagger.multibindings.IntoSet;
 import dagger.spi.BindingGraphPlugin;
 
 /** Binds the set of {@link BindingGraphPlugin}s used to implement Dagger validation. */
 @Module
 public interface BindingGraphValidationModule {
 
-  @Binds
-  @IntoSet
+  @Provides
   @Validation
-  BindingGraphPlugin dependencyCycle(DependencyCycleValidator validation);
-
-  @Binds
-  @IntoSet
-  @Validation
-  BindingGraphPlugin dependsOnProductionExecutor(DependsOnProductionExecutorValidator validation);
-
-  @Binds
-  @IntoSet
-  @Validation
-  BindingGraphPlugin duplicateBindings(DuplicateBindingsValidator validation);
-
-  @Binds
-  @IntoSet
-  @Validation
-  BindingGraphPlugin incompatiblyScopedBindings(IncompatiblyScopedBindingsValidator validation);
-
-  @Binds
-  @IntoSet
-  @Validation
-  BindingGraphPlugin injectBinding(InjectBindingValidator validation);
-
-  @Binds
-  @IntoSet
-  @Validation
-  BindingGraphPlugin mapMultibinding(MapMultibindingValidator validation);
-
-  @Binds
-  @IntoSet
-  @Validation
-  BindingGraphPlugin missingBinding(MissingBindingValidator validation);
-
-  @Binds
-  @IntoSet
-  @Validation
-  BindingGraphPlugin nullableBinding(NullableBindingValidator validation);
-
-  @Binds
-  @IntoSet
-  @Validation
-  BindingGraphPlugin provisionDependencyOnProducerBinding(
-      ProvisionDependencyOnProducerBindingValidator validation);
-
-  @Binds
-  @IntoSet
-  @Validation
-  BindingGraphPlugin subcomponentFactoryMethod(SubcomponentFactoryMethodValidator validation);
+  static ImmutableSet<BindingGraphPlugin> providePlugins(
+      CompositeBindingGraphPlugin.Factory factory,
+      CompilerOptions compilerOptions,
+      DependencyCycleValidator validation1,
+      DependsOnProductionExecutorValidator validation2,
+      DuplicateBindingsValidator validation3,
+      IncompatiblyScopedBindingsValidator validation4,
+      InjectBindingValidator validation5,
+      MapMultibindingValidator validation6,
+      MissingBindingValidator validation7,
+      NullableBindingValidator validation8,
+      ProvisionDependencyOnProducerBindingValidator validation9,
+      SubcomponentFactoryMethodValidator validation10) {
+    ImmutableSet<BindingGraphPlugin> plugins = ImmutableSet.of(
+        validation1,
+        validation2,
+        validation3,
+        validation4,
+        validation5,
+        validation6,
+        validation7,
+        validation8,
+        validation9,
+        validation10);
+    if (compilerOptions.experimentalDaggerErrorMessages()) {
+      return ImmutableSet.of(factory.create(plugins, "Dagger/Validation"));
+    } else {
+      return plugins;
+    }
+  }
 }

--- a/java/dagger/internal/codegen/bindinggraphvalidation/DependencyCycleValidator.java
+++ b/java/dagger/internal/codegen/bindinggraphvalidation/DependencyCycleValidator.java
@@ -213,7 +213,7 @@ final class DependencyCycleValidator implements BindingGraphPlugin {
        * breaks the cycle, so does the optional binding. */
       TypeMirror optionalValueType = OptionalType.from(edge.dependencyRequest().key()).valueType();
       RequestKind requestKind = getRequestKind(optionalValueType);
-      return breaksCycle(extractKeyType(requestKind, optionalValueType), requestKind);
+      return breaksCycle(extractKeyType(optionalValueType), requestKind);
     }
     return false;
   }

--- a/java/dagger/internal/codegen/compileroption/CompilerOptions.java
+++ b/java/dagger/internal/codegen/compileroption/CompilerOptions.java
@@ -74,4 +74,6 @@ public abstract class CompilerOptions {
   public abstract Diagnostic.Kind moduleHasDifferentScopesDiagnosticKind();
 
   public abstract ValidationType explicitBindingConflictsWithInjectValidationType();
+
+  public abstract boolean experimentalDaggerErrorMessages();
 }

--- a/java/dagger/internal/codegen/compileroption/JavacPluginCompilerOptions.java
+++ b/java/dagger/internal/codegen/compileroption/JavacPluginCompilerOptions.java
@@ -103,4 +103,9 @@ public final class JavacPluginCompilerOptions extends CompilerOptions {
   public ValidationType explicitBindingConflictsWithInjectValidationType() {
     return NONE;
   }
+
+  @Override
+  public boolean experimentalDaggerErrorMessages() {
+    return false;
+  }
 }

--- a/java/dagger/internal/codegen/compileroption/ProcessingEnvironmentCompilerOptions.java
+++ b/java/dagger/internal/codegen/compileroption/ProcessingEnvironmentCompilerOptions.java
@@ -24,6 +24,7 @@ import static dagger.internal.codegen.compileroption.FeatureStatus.DISABLED;
 import static dagger.internal.codegen.compileroption.FeatureStatus.ENABLED;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.EXPERIMENTAL_AHEAD_OF_TIME_SUBCOMPONENTS;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.EXPERIMENTAL_ANDROID_MODE;
+import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.EXPERIMENTAL_DAGGER_ERROR_MESSAGES;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.FAST_INIT;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.FLOATING_BINDS_METHODS;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.FORMAT_GENERATED_SOURCE;
@@ -157,6 +158,11 @@ public final class ProcessingEnvironmentCompilerOptions extends CompilerOptions 
     return parseOption(EXPLICIT_BINDING_CONFLICTS_WITH_INJECT);
   }
 
+  @Override
+  public boolean experimentalDaggerErrorMessages() {
+    return isEnabled(EXPERIMENTAL_DAGGER_ERROR_MESSAGES);
+  }
+
   private boolean isEnabled(KeyOnlyOption keyOnlyOption) {
     return processingEnvironment.getOptions().containsKey(keyOnlyOption.toString());
   }
@@ -266,6 +272,8 @@ public final class ProcessingEnvironmentCompilerOptions extends CompilerOptions 
     PLUGINS_VISIT_FULL_BINDING_GRAPHS,
 
     FLOATING_BINDS_METHODS,
+
+    EXPERIMENTAL_DAGGER_ERROR_MESSAGES,
     ;
 
     final FeatureStatus defaultValue;

--- a/java/dagger/internal/codegen/langmodel/DaggerTypes.java
+++ b/java/dagger/internal/codegen/langmodel/DaggerTypes.java
@@ -83,7 +83,7 @@ public final class DaggerTypes implements Types {
    * @throws IllegalArgumentException if {@code type} is not a declared type or has zero or more
    *     than one type arguments.
    */
-  public TypeMirror unwrapType(TypeMirror type) {
+  public static TypeMirror unwrapType(TypeMirror type) {
     TypeMirror unwrapped = unwrapTypeOrDefault(type, null);
     checkArgument(unwrapped != null, "%s is a raw type", type);
     return unwrapped;
@@ -101,7 +101,7 @@ public final class DaggerTypes implements Types {
     return unwrapTypeOrDefault(type, elements.getTypeElement(Object.class).asType());
   }
 
-  private TypeMirror unwrapTypeOrDefault(TypeMirror type, TypeMirror defaultType) {
+  private static TypeMirror unwrapTypeOrDefault(TypeMirror type, TypeMirror defaultType) {
     DeclaredType declaredType = MoreTypes.asDeclared(type);
     TypeElement typeElement = MoreElements.asType(declaredType.asElement());
     checkArgument(

--- a/java/dagger/internal/codegen/validation/BindingGraphPlugins.java
+++ b/java/dagger/internal/codegen/validation/BindingGraphPlugins.java
@@ -40,7 +40,7 @@ public final class BindingGraphPlugins {
 
   @Inject
   BindingGraphPlugins(
-      @Validation Set<BindingGraphPlugin> validationPlugins,
+      @Validation ImmutableSet<BindingGraphPlugin> validationPlugins,
       ImmutableSet<BindingGraphPlugin> externalPlugins,
       Filer filer,
       DaggerTypes types,

--- a/java/dagger/internal/codegen/validation/BindingGraphValidator.java
+++ b/java/dagger/internal/codegen/validation/BindingGraphValidator.java
@@ -25,7 +25,6 @@ import dagger.internal.codegen.compileroption.ValidationType;
 import dagger.internal.codegen.validation.DiagnosticReporterFactory.DiagnosticReporterImpl;
 import dagger.model.BindingGraph;
 import dagger.spi.BindingGraphPlugin;
-import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.lang.model.element.TypeElement;
@@ -40,12 +39,12 @@ public final class BindingGraphValidator {
 
   @Inject
   BindingGraphValidator(
-      @Validation Set<BindingGraphPlugin> validationPlugins,
+      @Validation ImmutableSet<BindingGraphPlugin> validationPlugins,
       ImmutableSet<BindingGraphPlugin> externalPlugins,
       DiagnosticReporterFactory diagnosticReporterFactory,
       CompilerOptions compilerOptions) {
-    this.validationPlugins = ImmutableSet.copyOf(validationPlugins);
-    this.externalPlugins = ImmutableSet.copyOf(externalPlugins);
+    this.validationPlugins = validationPlugins;
+    this.externalPlugins = externalPlugins;
     this.diagnosticReporterFactory = checkNotNull(diagnosticReporterFactory);
     this.compilerOptions = compilerOptions;
   }

--- a/java/dagger/internal/codegen/validation/CompositeBindingGraphPlugin.java
+++ b/java/dagger/internal/codegen/validation/CompositeBindingGraphPlugin.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen.validation;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Lists.asList;
+import static dagger.internal.codegen.base.ElementFormatter.elementToString;
+import static dagger.internal.codegen.extension.DaggerStreams.toImmutableSet;
+import static dagger.internal.codegen.langmodel.DaggerElements.elementEncloses;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.FormatMethod;
+import dagger.model.BindingGraph;
+import dagger.model.BindingGraph.ChildFactoryMethodEdge;
+import dagger.model.BindingGraph.ComponentNode;
+import dagger.model.BindingGraph.DependencyEdge;
+import dagger.model.BindingGraph.MaybeBinding;
+import dagger.spi.BindingGraphPlugin;
+import dagger.spi.DiagnosticReporter;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.processing.Filer;
+import javax.inject.Inject;
+import javax.lang.model.util.Elements;  // ALLOW_TYPES_ELEMENTS because of interface dependencies
+import javax.lang.model.util.Types;  // ALLOW_TYPES_ELEMENTS because of interface dependencies
+import javax.tools.Diagnostic;
+
+/**
+ * Combines many {@link BindingGraphPlugin} implementations. This helps reduce spam by combining
+ * all of the messages that are reported on the root component.
+ */
+public final class CompositeBindingGraphPlugin implements BindingGraphPlugin {
+
+  private final ImmutableSet<BindingGraphPlugin> plugins;
+  private final String pluginName;
+  private final DiagnosticMessageGenerator.Factory messageGeneratorFactory;
+
+  /** Factory class for {@link CompositeBindingGraphPlugin}. */
+  public static final class Factory {
+    private final DiagnosticMessageGenerator.Factory messageGeneratorFactory;
+
+    @Inject Factory(DiagnosticMessageGenerator.Factory messageGeneratorFactory) {
+      this.messageGeneratorFactory = messageGeneratorFactory;
+    }
+
+    public CompositeBindingGraphPlugin create(
+        ImmutableSet<BindingGraphPlugin> plugins, String pluginName) {
+      return new CompositeBindingGraphPlugin(plugins, pluginName, messageGeneratorFactory);
+    }
+  }
+
+  private CompositeBindingGraphPlugin(
+      ImmutableSet<BindingGraphPlugin> plugins,
+      String pluginName,
+      DiagnosticMessageGenerator.Factory messageGeneratorFactory) {
+    this.plugins = plugins;
+    this.pluginName = pluginName;
+    this.messageGeneratorFactory = messageGeneratorFactory;
+  }
+
+  @Override
+  public void visitGraph(BindingGraph bindingGraph, DiagnosticReporter diagnosticReporter) {
+    AggregatingDiagnosticReporter aggregatingDiagnosticReporter = new AggregatingDiagnosticReporter(
+        bindingGraph, diagnosticReporter, messageGeneratorFactory.create(bindingGraph));
+    plugins.forEach(plugin -> {
+      aggregatingDiagnosticReporter.setCurrentPlugin(plugin.pluginName());
+      plugin.visitGraph(bindingGraph, aggregatingDiagnosticReporter);
+    });
+    aggregatingDiagnosticReporter.report();
+  }
+
+  @Override
+  public void initFiler(Filer filer) {
+    plugins.forEach(plugin -> plugin.initFiler(filer));
+  }
+
+  @Override
+  public void initTypes(Types types) {
+    plugins.forEach(plugin -> plugin.initTypes(types));
+  }
+
+  @Override
+  public void initElements(Elements elements) {
+    plugins.forEach(plugin -> plugin.initElements(elements));
+  }
+
+  @Override
+  public void initOptions(Map<String, String> options) {
+    plugins.forEach(plugin -> plugin.initOptions(options));
+  }
+
+  @Override
+  public Set<String> supportedOptions() {
+    return plugins.stream().flatMap(
+        plugin -> plugin.supportedOptions().stream()).collect(toImmutableSet());
+  }
+
+  @Override
+  public String pluginName() {
+    return pluginName;
+  }
+
+  // TODO(user): This kind of breaks some of the encapsulation by relying on or repeating
+  // logic within DiagnosticReporterImpl. Hopefully if the experiment for aggregated messages
+  // goes well though this can be merged with that implementation.
+  private static final class AggregatingDiagnosticReporter implements DiagnosticReporter {
+    private final DiagnosticReporter delegate;
+    private final BindingGraph graph;
+    // Initialize with a new line so the first message appears below the reported component
+    private final StringBuilder messageBuilder = new StringBuilder("\n");
+    private final DiagnosticMessageGenerator messageGenerator;
+    private Optional<Diagnostic.Kind> mergedDiagnosticKind = Optional.empty();
+    private String currentPluginName = null;
+
+    AggregatingDiagnosticReporter(
+        BindingGraph graph,
+        DiagnosticReporter delegate,
+        DiagnosticMessageGenerator messageGenerator) {
+      this.graph = graph;
+      this.delegate = delegate;
+      this.messageGenerator = messageGenerator;
+    }
+
+    /** Sets the currently running aggregated plugin. Used to add a diagnostic prefix. */
+    void setCurrentPlugin(String pluginName) {
+      currentPluginName = pluginName;
+    }
+
+    /** Reports all of the stored diagnostics. */
+    void report() {
+      if (mergedDiagnosticKind.isPresent()) {
+        delegate.reportComponent(
+            mergedDiagnosticKind.get(), graph.rootComponentNode(), messageBuilder.toString());
+      }
+    }
+
+    @Override
+    public void reportComponent(Diagnostic.Kind diagnosticKind, ComponentNode componentNode,
+        String message) {
+      addMessage(diagnosticKind, message);
+      messageGenerator.appendComponentPathUnlessAtRoot(messageBuilder, componentNode);
+    }
+
+    @Override
+    @FormatMethod
+    public void reportComponent(
+        Diagnostic.Kind diagnosticKind,
+        ComponentNode componentNode,
+        String messageFormat,
+        Object firstArg,
+        Object... moreArgs) {
+      reportComponent(
+          diagnosticKind, componentNode, formatMessage(messageFormat, firstArg, moreArgs));
+    }
+
+    @Override
+    public void reportBinding(Diagnostic.Kind diagnosticKind, MaybeBinding binding,
+        String message) {
+      addMessage(diagnosticKind,
+          String.format("%s%s", message, messageGenerator.getMessage(binding)));
+    }
+
+    @Override
+    @FormatMethod
+    public void reportBinding(
+        Diagnostic.Kind diagnosticKind,
+        MaybeBinding binding,
+        String messageFormat,
+        Object firstArg,
+        Object... moreArgs) {
+      reportBinding(diagnosticKind, binding, formatMessage(messageFormat, firstArg, moreArgs));
+    }
+
+    @Override
+    public void reportDependency(
+        Diagnostic.Kind diagnosticKind, DependencyEdge dependencyEdge, String message) {
+      addMessage(diagnosticKind,
+          String.format("%s%s", message, messageGenerator.getMessage(dependencyEdge)));
+    }
+
+    @Override
+    @FormatMethod
+    public void reportDependency(
+        Diagnostic.Kind diagnosticKind,
+        DependencyEdge dependencyEdge,
+        String messageFormat,
+        Object firstArg,
+        Object... moreArgs) {
+      reportDependency(
+          diagnosticKind, dependencyEdge, formatMessage(messageFormat, firstArg, moreArgs));
+    }
+
+    @Override
+    public void reportSubcomponentFactoryMethod(
+        Diagnostic.Kind diagnosticKind,
+        ChildFactoryMethodEdge childFactoryMethodEdge,
+        String message) {
+      // TODO(user): This repeats some of the logic in DiagnosticReporterImpl. Remove when
+      // merged.
+      if (elementEncloses(
+          graph.rootComponentNode().componentPath().currentComponent(),
+          childFactoryMethodEdge.factoryMethod())) {
+        // Let this pass through since it is not an error reported on the root component
+        delegate.reportSubcomponentFactoryMethod(diagnosticKind, childFactoryMethodEdge, message);
+      } else {
+        addMessage(
+            diagnosticKind,
+            String.format(
+                "[%s] %s", elementToString(childFactoryMethodEdge.factoryMethod()), message));
+      }
+    }
+
+    @Override
+    @FormatMethod
+    public void reportSubcomponentFactoryMethod(
+        Diagnostic.Kind diagnosticKind,
+        ChildFactoryMethodEdge childFactoryMethodEdge,
+        String messageFormat,
+        Object firstArg,
+        Object... moreArgs) {
+      reportSubcomponentFactoryMethod(
+          diagnosticKind, childFactoryMethodEdge, formatMessage(messageFormat, firstArg, moreArgs));
+    }
+
+    /** Adds a message to the stored aggregated message. */
+    private void addMessage(Diagnostic.Kind diagnosticKind, String message) {
+      checkNotNull(diagnosticKind);
+      checkNotNull(message);
+      checkState(currentPluginName != null);
+
+      // Add a separator if this isn't the first message
+      if (mergedDiagnosticKind.isPresent()) {
+        messageBuilder.append("\n\n");
+      }
+
+      mergeDiagnosticKind(diagnosticKind);
+      messageBuilder.append(String.format("[%s] ", currentPluginName));
+      messageBuilder.append(message);
+    }
+
+    private static String formatMessage(String messageFormat, Object firstArg, Object[] moreArgs) {
+      return String.format(messageFormat, asList(firstArg, moreArgs).toArray());
+    }
+
+    private void mergeDiagnosticKind(Diagnostic.Kind diagnosticKind) {
+      checkArgument(diagnosticKind != Diagnostic.Kind.MANDATORY_WARNING,
+          "Dagger plugins should not be issuing mandatory warnings");
+      if (!mergedDiagnosticKind.isPresent()) {
+        mergedDiagnosticKind = Optional.of(diagnosticKind);
+        return;
+      }
+      Diagnostic.Kind current = mergedDiagnosticKind.get();
+      if (current == Diagnostic.Kind.ERROR || diagnosticKind == Diagnostic.Kind.ERROR) {
+        mergedDiagnosticKind = Optional.of(Diagnostic.Kind.ERROR);
+      } else if (current == Diagnostic.Kind.WARNING || diagnosticKind == Diagnostic.Kind.WARNING) {
+        mergedDiagnosticKind = Optional.of(Diagnostic.Kind.WARNING);
+      } else if (current == Diagnostic.Kind.NOTE || diagnosticKind == Diagnostic.Kind.NOTE) {
+        mergedDiagnosticKind = Optional.of(Diagnostic.Kind.NOTE);
+      } else {
+        mergedDiagnosticKind = Optional.of(Diagnostic.Kind.OTHER);
+      }
+    }
+  }
+}

--- a/java/dagger/internal/codegen/validation/DependencyRequestValidator.java
+++ b/java/dagger/internal/codegen/validation/DependencyRequestValidator.java
@@ -19,7 +19,6 @@ package dagger.internal.codegen.validation;
 import static com.google.auto.common.MoreElements.asType;
 import static com.google.auto.common.MoreElements.asVariable;
 import static dagger.internal.codegen.base.RequestKinds.extractKeyType;
-import static dagger.internal.codegen.base.RequestKinds.getRequestKind;
 import static dagger.internal.codegen.binding.SourceFiles.membersInjectorNameForType;
 import static javax.lang.model.type.TypeKind.WILDCARD;
 
@@ -100,7 +99,7 @@ final class DependencyRequestValidator {
 
   private void checkType(
       ValidationReport.Builder<?> report, Element requestElement, TypeMirror requestType) {
-    TypeMirror keyType = extractKeyType(getRequestKind(requestType), requestType);
+    TypeMirror keyType = extractKeyType(requestType);
     if (keyType.getKind().equals(WILDCARD)) {
       // TODO(ronshapiro): Explore creating this message using RequestKinds.
       report.addError(


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Refactor RequestKinds.extractKeyType(RequestKind, TypeMirror) to RequestKinds.extractKeyType(TypeMirror)

RequestKinds.extractKeyType(RequestKind, TypeMirror) currently requires passing in the "correct" RequestKind for the given TypeMirror. This CL refactors the method so that the RequestKind is no longer needed because it's calculated internally. This makes the method easier to use, and we no longer have to check that the user passed in a valid RequestKind.

RELNOTES=N/A

5d863f03e2d61b0e022ed3291f9da948430eec25

-------

<p> Remove static RequestKinds cache and improve build performance.

See https://github.com/google/dagger/issues/1645

The static RequestKinds cache causes a memory leak in gradle due to the persistent GradleDaemon. This CL removes that cache entirely, and instead fixes the root causes of the performance issues, by short circuiting InjectionSiteVisitor to abort early if the method is not injectable. This avoids a lot of unnecessary calls to RequestKinds.getRequestKind() for methods that are not injectable (e.g. aren't annotated with @Inject).

The aggregated pprof results from 10 runs before and after changes in this CL are below.

                                            Before (s)    After (s)     Diff
-----------------------------------------------------------------------------
ComponentProcessingStep.process               51.80         43.25      -16.5%
RequestKinds.getRequestKind                    8.48          0.33      -95.9%
-----------------------------------------------------------------------------

RELNOTES=Fix memory leak with RequestKinds cache.

72a2b37285d95df44bc05e04318954cd06318326

-------

<p> Add a flag -Adagger.experimentalDaggerErrorMessages for controlling the new error messages.

Also add a CompositeBindingGraphPlugin for combining error messages so that root components are only reported once.

d7f8294a99f0c4a18074ddebd6a43a0f402fb28f