### PR TITLE
MOE Sync 2020-01-06

### DIFF
--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -15,9 +15,9 @@
 # Description:
 #   A JSR-330 compliant dependency injection system for android and java
 
-package(default_visibility = ["//:src"])
-
 load("//tools:maven.bzl", "POM_VERSION", "gen_maven_artifact")
+
+package(default_visibility = ["//:src"])
 
 java_library(
     name = "processor",

--- a/tools/maven.bzl
+++ b/tools/maven.bzl
@@ -139,7 +139,7 @@ def _validate_maven_deps_impl(ctx):
     exactly.
     """
     target = ctx.attr.target
-    if not target[MavenInfo].maven_artifacts:
+    if not target[MavenInfo].artifact:
         fail("\t[Error]: %s is not a maven artifact" % target.label)
 
     deps = [dep.label for dep in getattr(ctx.attr, "deps", [])]

--- a/util/execute-deploy.sh
+++ b/util/execute-deploy.sh
@@ -83,6 +83,7 @@ deploy_library \
   gwt/libgwt.jar \
   gwt/pom.xml
 
+
 deploy_library \
   java/dagger/internal/codegen/artifact.jar \
   java/dagger/internal/codegen/artifact-src.jar \


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update maven_info to exclude pure exports.

This is needed to correctly report required targets for an artifact's jarjar. In particular, targets without sources do not need to be included in the jarjar, so we want to skip them. This happens frequently in cases where a library contains only exports. For example:

  # Don't require foo in the jarjar since its jar is empty.
  java_library(
      name = "foo",
      exports = [":bar", ":baz"],
  )

This prevents the "gen_maven_artifact" macro from forcing the user to input unnecessary deps.

RELNOTES=N/A

af94e35ab7156aa04f59e11d288e5be10154496d

-------

<p> Add Cloak artifacts and fix random issues with Cloak needed for build.

RELNOTES=N/A

c8f5f21f6e93f25aaf0124791d9bbd9b8544ee4a