### PR TITLE
MOE Sync 2020-01-08

### DIFF
--- a/java/dagger/example/gradle/android/simple/app/build.gradle
+++ b/java/dagger/example/gradle/android/simple/app/build.gradle
@@ -34,4 +34,7 @@ dependencies {
   implementation 'com.google.dagger:dagger-android-support:LOCAL-SNAPSHOT'
   annotationProcessor 'com.google.dagger:dagger-compiler:LOCAL-SNAPSHOT'
   annotationProcessor 'com.google.dagger:dagger-android-processor:LOCAL-SNAPSHOT'
+
+  // To help us catch usages of Guava APIs for Java 8 in the '-jre' variant.
+  annotationProcessor'com.google.guava:guava:28.1-android'
 }

--- a/java/dagger/internal/codegen/binding/InjectionAnnotations.java
+++ b/java/dagger/internal/codegen/binding/InjectionAnnotations.java
@@ -32,10 +32,10 @@ import com.google.common.base.Equivalence;
 import com.google.common.base.Equivalence.Wrapper;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableCollection;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.MoreCollectors;
 import dagger.internal.InjectedFieldSignature;
+import dagger.internal.codegen.extension.DaggerCollectors;
+import dagger.internal.codegen.extension.DaggerStreams;
 import dagger.internal.codegen.kotlin.KotlinMetadataUtil;
 import dagger.internal.codegen.langmodel.DaggerElements;
 import java.util.Optional;
@@ -92,7 +92,7 @@ public final class InjectionAnnotations {
           .map(EQUIVALENCE::wrap) // Wrap in equivalence to deduplicate
           .distinct()
           .map(Wrapper::get)
-          .collect(ImmutableList.toImmutableList());
+          .collect(DaggerStreams.toImmutableList());
     } else {
       return qualifiers.asList();
     }
@@ -133,7 +133,7 @@ public final class InjectionAnnotations {
                         .map(memberInjectedFieldSignature::equals)
                         // If a method is not an @InjectedFieldSignature method then filter it out
                         .orElse(false))
-            .collect(MoreCollectors.toOptional())
+            .collect(DaggerCollectors.toOptional())
             .map(this::getQualifiers)
             .orElseThrow(
                 () ->

--- a/java/dagger/internal/codegen/extension/BUILD
+++ b/java/dagger/internal/codegen/extension/BUILD
@@ -26,5 +26,6 @@ java_library(
         "//java/dagger/internal/guava:base",
         "//java/dagger/internal/guava:collect",
         "//java/dagger/internal/guava:graph",
+        "@google_bazel_common//third_party/java/jsr305_annotations",
     ],
 )

--- a/java/dagger/internal/codegen/extension/DaggerCollectors.java
+++ b/java/dagger/internal/codegen/extension/DaggerCollectors.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen.extension;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.stream.Collector;
+import javax.annotation.Nullable;
+
+/**
+ * A copy of {@link com.google.common.collect.MoreCollectors} to avoid issues with the '-android'
+ * variant of Guava. See b/68008628
+ */
+public final class DaggerCollectors {
+
+  private static final Collector<Object, ?, Optional<Object>> TO_OPTIONAL =
+      Collector.of(
+          ToOptionalState::new,
+          ToOptionalState::add,
+          ToOptionalState::combine,
+          ToOptionalState::getOptional,
+          Collector.Characteristics.UNORDERED);
+
+  /**
+   * A collector that converts a stream of zero or one elements to an {@code Optional}. The returned
+   * collector throws an {@code IllegalArgumentException} if the stream consists of two or more
+   * elements, and a {@code NullPointerException} if the stream consists of exactly one element,
+   * which is null.
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> Collector<T, ?, Optional<T>> toOptional() {
+    return (Collector) TO_OPTIONAL;
+  }
+
+  private static final Object NULL_PLACEHOLDER = new Object();
+
+  private static final Collector<Object, ?, Object> ONLY_ELEMENT =
+      Collector.of(
+          ToOptionalState::new,
+          (state, o) -> state.add((o == null) ? NULL_PLACEHOLDER : o),
+          ToOptionalState::combine,
+          state -> {
+            Object result = state.getElement();
+            return (result == NULL_PLACEHOLDER) ? null : result;
+          },
+          Collector.Characteristics.UNORDERED);
+
+  /**
+   * A collector that takes a stream containing exactly one element and returns that element. The
+   * returned collector throws an {@code IllegalArgumentException} if the stream consists of two or
+   * more elements, and a {@code NoSuchElementException} if the stream is empty.
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> Collector<T, ?, T> onlyElement() {
+    return (Collector) ONLY_ELEMENT;
+  }
+
+  private static final class ToOptionalState {
+    static final int MAX_EXTRAS = 4;
+
+    @Nullable Object element;
+    @Nullable List<Object> extras;
+
+    ToOptionalState() {
+      element = null;
+      extras = null;
+    }
+
+    IllegalArgumentException multiples(boolean overflow) {
+      StringBuilder sb =
+          new StringBuilder().append("expected one element but was: <").append(element);
+      for (Object o : extras) {
+        sb.append(", ").append(o);
+      }
+      if (overflow) {
+        sb.append(", ...");
+      }
+      sb.append('>');
+      throw new IllegalArgumentException(sb.toString());
+    }
+
+    void add(Object o) {
+      checkNotNull(o);
+      if (element == null) {
+        this.element = o;
+      } else if (extras == null) {
+        extras = new ArrayList<>(MAX_EXTRAS);
+        extras.add(o);
+      } else if (extras.size() < MAX_EXTRAS) {
+        extras.add(o);
+      } else {
+        throw multiples(true);
+      }
+    }
+
+    ToOptionalState combine(ToOptionalState other) {
+      if (element == null) {
+        return other;
+      } else if (other.element == null) {
+        return this;
+      } else {
+        if (extras == null) {
+          extras = new ArrayList<>();
+        }
+        extras.add(other.element);
+        if (other.extras != null) {
+          this.extras.addAll(other.extras);
+        }
+        if (extras.size() > MAX_EXTRAS) {
+          extras.subList(MAX_EXTRAS, extras.size()).clear();
+          throw multiples(true);
+        }
+        return this;
+      }
+    }
+
+    Optional<Object> getOptional() {
+      if (extras == null) {
+        return Optional.ofNullable(element);
+      } else {
+        throw multiples(false);
+      }
+    }
+
+    Object getElement() {
+      if (element == null) {
+        throw new NoSuchElementException();
+      } else if (extras == null) {
+        return element;
+      } else {
+        throw multiples(false);
+      }
+    }
+  }
+
+  private DaggerCollectors() {}
+}

--- a/java/dagger/internal/codegen/kotlin/BUILD
+++ b/java/dagger/internal/codegen/kotlin/BUILD
@@ -24,6 +24,7 @@ java_library(
     tags = ["maven:merged"],
     deps = [
         "//java/dagger/internal/codegen/base",
+        "//java/dagger/internal/codegen/extension",
         "//java/dagger/internal/codegen/langmodel",
         "//java/dagger/internal/guava:annotations",
         "//java/dagger/internal/guava:base",

--- a/java/dagger/internal/codegen/kotlin/KotlinMetadata.java
+++ b/java/dagger/internal/codegen/kotlin/KotlinMetadata.java
@@ -28,7 +28,7 @@ import static dagger.internal.codegen.langmodel.DaggerElements.getFieldDescripto
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import com.google.common.collect.MoreCollectors;
+import dagger.internal.codegen.extension.DaggerCollectors;
 import dagger.internal.codegen.langmodel.DaggerElements;
 import java.util.ArrayList;
 import java.util.List;
@@ -118,7 +118,7 @@ final class KotlinMetadata {
       // Fallback to finding property by name, see: https://youtrack.jetbrains.com/issue/KT-35124
       return propertyDescriptors.values().stream()
           .filter(property -> field.getSimpleName().contentEquals(property.name))
-          .collect(MoreCollectors.onlyElement());
+          .collect(DaggerCollectors.onlyElement());
     }
   }
 

--- a/java/dagger/internal/codegen/writing/InjectionMethods.java
+++ b/java/dagger/internal/codegen/writing/InjectionMethods.java
@@ -19,7 +19,6 @@ package dagger.internal.codegen.writing;
 import static com.google.common.base.CaseFormat.LOWER_CAMEL;
 import static com.google.common.base.CaseFormat.UPPER_CAMEL;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.MoreCollectors.onlyElement;
 import static dagger.internal.codegen.base.RequestKinds.requestTypeName;
 import static dagger.internal.codegen.binding.ConfigurationAnnotations.getNullableType;
 import static dagger.internal.codegen.binding.SourceFiles.generatedClassNameForBinding;
@@ -48,6 +47,7 @@ import dagger.internal.Preconditions;
 import dagger.internal.codegen.binding.MembersInjectionBinding.InjectionSite;
 import dagger.internal.codegen.binding.ProvisionBinding;
 import dagger.internal.codegen.compileroption.CompilerOptions;
+import dagger.internal.codegen.extension.DaggerCollectors;
 import dagger.internal.codegen.javapoet.Expression;
 import dagger.internal.codegen.kotlin.KotlinMetadataUtil;
 import dagger.internal.codegen.langmodel.DaggerElements;
@@ -276,7 +276,8 @@ final class InjectionMethods {
         case FIELD:
           Optional<AnnotationMirror> qualifier =
               injectionSite.dependencies().stream()
-                  .collect(onlyElement()) // methods for fields have a single dependency request
+                  // methods for fields have a single dependency request
+                  .collect(DaggerCollectors.onlyElement())
                   .key()
                   .qualifier();
           return fieldProxy(

--- a/tools/maven.bzl
+++ b/tools/maven.bzl
@@ -84,11 +84,13 @@ def gen_maven_artifact(
       shaded_deps: The shaded deps for the jarjar.
       shaded_rules: The shaded rules for the jarjar
     """
+
     _validate_maven_deps(
         name = name + "-validation",
         target = artifact_target,
         deps = deps,
     )
+
 
     shaded_deps = shaded_deps or []
     shaded_rules = shaded_rules or []

--- a/util/run-local-tests.sh
+++ b/util/run-local-tests.sh
@@ -15,6 +15,7 @@ util/install-local-snapshot.sh
 ./$_SIMPLE_EXAMPLE_DIR/gradlew -p $_SIMPLE_EXAMPLE_DIR build --stacktrace
 ./$_ANDROID_EXAMPLE_DIR/gradlew -p $_ANDROID_EXAMPLE_DIR build --stacktrace
 
+
 verify_version_file() {
   local m2_repo=$1
   local group_path=com/google/dagger


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove usages of Guava APIs not available in the '-android' variant.

Even though Gradle has separate processor and app classpath it is
common for users to end up using the `-android` variant of Guava in
the processor part which causes Dagger to fail when using Guava APIs for
Java 8. To avoid we are adding the `-android` variant dependency in a
Gradle sample as a smoke test.

Fixes #1700

RELNOTES=Remove usages of Guava APIs not available in the '-android' variant.

b73e8f2db3e43b676b0bc00645faf7749f875004

-------

<p> Add Cloak gradle app and build test

RELNOTES=N/A

78a9d6e84eea15bc00ea0e3006c9a5452debb5cf