### PR TITLE
MOE Sync 2020-01-09

### DIFF
--- a/java/dagger/internal/codegen/ModuleProcessingStep.java
+++ b/java/dagger/internal/codegen/ModuleProcessingStep.java
@@ -35,6 +35,7 @@ import dagger.internal.codegen.binding.DelegateDeclaration;
 import dagger.internal.codegen.binding.DelegateDeclaration.Factory;
 import dagger.internal.codegen.binding.ProductionBinding;
 import dagger.internal.codegen.binding.ProvisionBinding;
+import dagger.internal.codegen.kotlin.KotlinMetadataUtil;
 import dagger.internal.codegen.validation.ModuleValidator;
 import dagger.internal.codegen.validation.TypeCheckingProcessingStep;
 import dagger.internal.codegen.validation.ValidationReport;
@@ -64,6 +65,7 @@ final class ModuleProcessingStep extends TypeCheckingProcessingStep<TypeElement>
   private final SourceFileGenerator<TypeElement> moduleConstructorProxyGenerator;
   private final InaccessibleMapKeyProxyGenerator inaccessibleMapKeyProxyGenerator;
   private final DelegateDeclaration.Factory delegateDeclarationFactory;
+  private final KotlinMetadataUtil metadataUtil;
   private final Set<TypeElement> processedModuleElements = Sets.newLinkedHashSet();
 
   @Inject
@@ -75,7 +77,8 @@ final class ModuleProcessingStep extends TypeCheckingProcessingStep<TypeElement>
       SourceFileGenerator<ProductionBinding> producerFactoryGenerator,
       @ModuleGenerator SourceFileGenerator<TypeElement> moduleConstructorProxyGenerator,
       InaccessibleMapKeyProxyGenerator inaccessibleMapKeyProxyGenerator,
-      Factory delegateDeclarationFactory) {
+      Factory delegateDeclarationFactory,
+      KotlinMetadataUtil metadataUtil) {
     super(MoreElements::asType);
     this.messager = messager;
     this.moduleValidator = moduleValidator;
@@ -85,6 +88,7 @@ final class ModuleProcessingStep extends TypeCheckingProcessingStep<TypeElement>
     this.moduleConstructorProxyGenerator = moduleConstructorProxyGenerator;
     this.inaccessibleMapKeyProxyGenerator = inaccessibleMapKeyProxyGenerator;
     this.delegateDeclarationFactory = delegateDeclarationFactory;
+    this.metadataUtil = metadataUtil;
   }
 
   @Override
@@ -106,21 +110,36 @@ final class ModuleProcessingStep extends TypeCheckingProcessingStep<TypeElement>
     if (processedModuleElements.contains(module)) {
       return;
     }
+    // For backwards compatibility, we allow a companion object to be annotated with @Module even
+    // though it's no longer required. However, we skip processing the companion object itself
+    // because it will now be processed when processing the companion object's enclosing class.
+    if (metadataUtil.isCompanionObjectClass(module)) {
+      // TODO(user): Be strict about annotating companion objects with @Module,
+      //  i.e. tell user to annotate parent instead.
+      return;
+    }
     ValidationReport<TypeElement> report = moduleValidator.validate(module);
     report.printMessagesTo(messager);
     if (report.isClean()) {
-      for (ExecutableElement method : methodsIn(module.getEnclosedElements())) {
-        if (isAnnotationPresent(method, Provides.class)) {
-          generate(factoryGenerator, bindingFactory.providesMethodBinding(method, module));
-        } else if (isAnnotationPresent(method, Produces.class)) {
-          generate(producerFactoryGenerator, bindingFactory.producesMethodBinding(method, module));
-        } else if (isAnnotationPresent(method, Binds.class)) {
-          inaccessibleMapKeyProxyGenerator.generate(bindsMethodBinding(module, method), messager);
-        }
+      generateForMethodsIn(module);
+      if (metadataUtil.hasEnclosedCompanionObject(module)) {
+        generateForMethodsIn(metadataUtil.getEnclosedCompanionObject(module));
       }
-      moduleConstructorProxyGenerator.generate(module, messager);
     }
     processedModuleElements.add(module);
+  }
+
+  private void generateForMethodsIn(TypeElement module) {
+    for (ExecutableElement method : methodsIn(module.getEnclosedElements())) {
+      if (isAnnotationPresent(method, Provides.class)) {
+        generate(factoryGenerator, bindingFactory.providesMethodBinding(method, module));
+      } else if (isAnnotationPresent(method, Produces.class)) {
+        generate(producerFactoryGenerator, bindingFactory.producesMethodBinding(method, module));
+      } else if (isAnnotationPresent(method, Binds.class)) {
+        inaccessibleMapKeyProxyGenerator.generate(bindsMethodBinding(module, method), messager);
+      }
+    }
+    moduleConstructorProxyGenerator.generate(module, messager);
   }
 
   private <B extends ContributionBinding> void generate(

--- a/java/dagger/internal/codegen/base/RequestKinds.java
+++ b/java/dagger/internal/codegen/base/RequestKinds.java
@@ -104,7 +104,9 @@ public final class RequestKinds {
   /** Returns the {@link RequestKind} that matches the wrapping types (if any) of {@code type}. */
   public static RequestKind getRequestKind(TypeMirror type) {
     checkTypePresent(type);
-    if (!type.getKind().equals(DECLARED) || asDeclared(type).getTypeArguments().isEmpty()) {
+    if (!isType(type) // TODO(b/147320669): isType check can be removed once this bug is fixed.
+            || !type.getKind().equals(DECLARED)
+            || asDeclared(type).getTypeArguments().isEmpty()) {
       // If the type is not a declared type (i.e. class or interface) with type arguments, then we
       // know it can't be a parameterized type of one of the framework classes, so return INSTANCE.
       return RequestKind.INSTANCE;

--- a/java/dagger/internal/codegen/binding/BindingFactory.java
+++ b/java/dagger/internal/codegen/binding/BindingFactory.java
@@ -214,11 +214,14 @@ public final class BindingFactory {
     if (!types.isSameType(methodType, method.asType())) {
       builder.unresolved(create.apply(method, MoreElements.asType(method.getEnclosingElement())));
     }
+    boolean isKotlinObject =
+        metadataUtil.isObjectClass(contributedBy)
+            || metadataUtil.isCompanionObjectClass(contributedBy);
     return builder
         .contributionType(ContributionType.fromBindingElement(method))
         .bindingElement(method)
         .contributingModule(contributedBy)
-        .isModuleKotlinObject(metadataUtil.isObjectClass(contributedBy))
+        .isContributingModuleKotlinObject(isKotlinObject)
         .key(key)
         .dependencies(
             dependencyRequestFactory.forRequiredResolvedVariables(
@@ -420,12 +423,14 @@ public final class BindingFactory {
       ContributionBinding.Builder<?, ?> builder,
       DelegateDeclaration delegateDeclaration,
       Class<?> frameworkType) {
+    boolean isKotlinObject =
+        metadataUtil.isObjectClass(delegateDeclaration.contributingModule().get())
+            || metadataUtil.isCompanionObjectClass(delegateDeclaration.contributingModule().get());
     return builder
         .contributionType(delegateDeclaration.contributionType())
         .bindingElement(delegateDeclaration.bindingElement().get())
         .contributingModule(delegateDeclaration.contributingModule().get())
-        .isModuleKotlinObject(
-            metadataUtil.isObjectClass(delegateDeclaration.contributingModule().get()))
+        .isContributingModuleKotlinObject(isKotlinObject)
         .key(keyFactory.forDelegateBinding(delegateDeclaration, frameworkType))
         .dependencies(delegateDeclaration.delegateRequest())
         .wrappedMapKeyAnnotation(delegateDeclaration.wrappedMapKey())

--- a/java/dagger/internal/codegen/binding/ComponentRequirement.java
+++ b/java/dagger/internal/codegen/binding/ComponentRequirement.java
@@ -166,13 +166,19 @@ public abstract class ComponentRequirement {
    */
   private boolean requiresModuleInstance(
       DaggerElements elements, DaggerTypes types, KotlinMetadataUtil metadataUtil) {
+    boolean isKotlinObject =
+        metadataUtil.isObjectClass(typeElement())
+            || metadataUtil.isCompanionObjectClass(typeElement());
+    if (isKotlinObject) {
+      return false;
+    }
+
     ImmutableSet<ExecutableElement> methods =
         getLocalAndInheritedMethods(typeElement(), types, elements);
-    return !metadataUtil.isObjectClass(typeElement())
-        && methods.stream()
-            .filter(this::isBindingMethod)
-            .map(ExecutableElement::getModifiers)
-            .anyMatch(modifiers -> !modifiers.contains(ABSTRACT) && !modifiers.contains(STATIC));
+    return methods.stream()
+        .filter(this::isBindingMethod)
+        .map(ExecutableElement::getModifiers)
+        .anyMatch(modifiers -> !modifiers.contains(ABSTRACT) && !modifiers.contains(STATIC));
   }
 
   private boolean isBindingMethod(ExecutableElement method) {
@@ -261,7 +267,8 @@ public abstract class ComponentRequirement {
       return false;
     }
 
-    if (metadataUtil.isObjectClass(typeElement)) {
+    if (metadataUtil.isObjectClass(typeElement)
+        || metadataUtil.isCompanionObjectClass(typeElement)) {
       return false;
     }
 

--- a/java/dagger/internal/codegen/binding/ContributionBinding.java
+++ b/java/dagger/internal/codegen/binding/ContributionBinding.java
@@ -67,7 +67,7 @@ public abstract class ContributionBinding extends Binding implements HasContribu
 
   @Override
   public boolean requiresModuleInstance() {
-    return !isModuleKotlinObject().orElse(false) && super.requiresModuleInstance();
+    return !isContributingModuleKotlinObject().orElse(false) && super.requiresModuleInstance();
   }
 
   @Override
@@ -75,7 +75,11 @@ public abstract class ContributionBinding extends Binding implements HasContribu
     return nullableType().isPresent();
   }
 
-  abstract Optional<Boolean> isModuleKotlinObject();
+  /**
+   * Returns {@code true} if the contributing module is a Kotlin object. Note that a companion
+   * object is also considered a Kotlin object.
+   */
+  abstract Optional<Boolean> isContributingModuleKotlinObject();
 
   /** The strategy for getting an instance of a factory for a {@link ContributionBinding}. */
   public enum FactoryCreationStrategy {
@@ -168,7 +172,7 @@ public abstract class ContributionBinding extends Binding implements HasContribu
 
     abstract B contributingModule(TypeElement contributingModule);
 
-    abstract B isModuleKotlinObject(boolean isModuleKotlinObject);
+    abstract B isContributingModuleKotlinObject(boolean isModuleKotlinObject);
 
     public abstract B key(Key key);
 
@@ -186,7 +190,8 @@ public abstract class ContributionBinding extends Binding implements HasContribu
     public C build() {
       C binding = autoBuild();
       Preconditions.checkState(
-          binding.contributingModule().isPresent() == binding.isModuleKotlinObject().isPresent(),
+          binding.contributingModule().isPresent()
+              == binding.isContributingModuleKotlinObject().isPresent(),
           "The contributionModule and isModuleKotlinObject must both be set together.");
       return binding;
     }

--- a/java/dagger/internal/codegen/binding/ModuleKind.java
+++ b/java/dagger/internal/codegen/binding/ModuleKind.java
@@ -16,6 +16,7 @@
 
 package dagger.internal.codegen.binding;
 
+import static com.google.auto.common.MoreElements.asType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static dagger.internal.codegen.extension.DaggerStreams.toImmutableSet;
 import static dagger.internal.codegen.langmodel.DaggerElements.getAnnotationMirror;
@@ -24,6 +25,7 @@ import com.google.auto.common.MoreElements;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import dagger.Module;
+import dagger.internal.codegen.kotlin.KotlinMetadataUtil;
 import dagger.producers.ProducerModule;
 import java.lang.annotation.Annotation;
 import java.util.EnumSet;
@@ -67,8 +69,14 @@ public enum ModuleKind {
     return kinds.stream().findAny();
   }
 
-  public static void checkIsModule(TypeElement moduleElement) {
-    checkArgument(forAnnotatedElement(moduleElement).isPresent());
+  public static void checkIsModule(TypeElement moduleElement, KotlinMetadataUtil metadataUtil) {
+    // If the type element is a Kotlin companion object, then assert it is a module if its enclosing
+    // type is a module.
+    if (metadataUtil.isCompanionObjectClass(moduleElement)) {
+      checkArgument(forAnnotatedElement(asType(moduleElement.getEnclosingElement())).isPresent());
+    } else {
+      checkArgument(forAnnotatedElement(moduleElement).isPresent());
+    }
   }
 
   private final Class<? extends Annotation> moduleAnnotation;

--- a/java/dagger/internal/codegen/kotlin/BUILD
+++ b/java/dagger/internal/codegen/kotlin/BUILD
@@ -30,6 +30,7 @@ java_library(
         "//java/dagger/internal/guava:base",
         "//java/dagger/internal/guava:collect",
         "@google_bazel_common//third_party/java/auto:common",
+        "@google_bazel_common//third_party/java/jsr305_annotations",
         "@google_bazel_common//third_party/java/jsr330_inject",
         "@maven//:org_jetbrains_kotlin_kotlin_stdlib",
         "@maven//:org_jetbrains_kotlinx_kotlinx_metadata_jvm",

--- a/java/dagger/internal/codegen/kotlin/KotlinMetadataUtil.java
+++ b/java/dagger/internal/codegen/kotlin/KotlinMetadataUtil.java
@@ -22,13 +22,17 @@ import static dagger.internal.codegen.langmodel.DaggerElements.closestEnclosingT
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.MoreCollectors;
 import java.lang.annotation.Annotation;
 import javax.inject.Inject;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.util.ElementFilter;
 import kotlin.Metadata;
+import kotlin.jvm.JvmStatic;
 
 /** Utility class for interacting with Kotlin Metadata. */
 public final class KotlinMetadataUtil {
@@ -41,8 +45,8 @@ public final class KotlinMetadataUtil {
   }
 
   /**
-   * Returns true if this element has the Kotlin Metadata annotation or if it is enclosed in an
-   * element that does.
+   * Returns {@code true} if this element has the Kotlin Metadata annotation or if it is enclosed in
+   * an element that does.
    */
   public boolean hasMetadata(Element element) {
     return isAnnotationPresent(closestEnclosingTypeElement(element), Metadata.class);
@@ -64,16 +68,56 @@ public final class KotlinMetadataUtil {
   }
 
   /**
-   * Returns true if the synthetic method for annotations is missing. This can occur when the Kotlin
-   * metadata of the property reports that it contains a synthetic method for annotations but such
-   * method is not found since it is synthetic and ignored by the processor.
+   * Returns {@code true} if the synthetic method for annotations is missing. This can occur when
+   * the Kotlin metadata of the property reports that it contains a synthetic method for annotations
+   * but such method is not found since it is synthetic and ignored by the processor.
    */
   public boolean isMissingSyntheticPropertyForAnnotations(VariableElement fieldElement) {
     return metadataFactory.create(fieldElement).isMissingSyntheticAnnotationMethod(fieldElement);
   }
 
-  /** Returns true if this type element is a Kotlin Object. */
+  /** Returns {@code true} if this type element is a Kotlin Object. */
   public boolean isObjectClass(TypeElement typeElement) {
     return hasMetadata(typeElement) && metadataFactory.create(typeElement).isObjectClass();
+  }
+
+  /* Returns {@code true} if this type element is a Kotlin Companion Object. */
+  public boolean isCompanionObjectClass(TypeElement typeElement) {
+    return hasMetadata(typeElement) && metadataFactory.create(typeElement).isCompanionObjectClass();
+  }
+
+  /* Returns {@code true} if this type element has a Kotlin Companion Object. */
+  public boolean hasEnclosedCompanionObject(TypeElement typeElement) {
+    return hasMetadata(typeElement)
+        && metadataFactory.create(typeElement).getCompanionObjectName().isPresent();
+  }
+
+  /* Returns the Companion Object element enclosed by the given type element. */
+  public TypeElement getEnclosedCompanionObject(TypeElement typeElement) {
+    return metadataFactory
+        .create(typeElement)
+        .getCompanionObjectName()
+        .map(
+            companionObjectName ->
+                ElementFilter.typesIn(typeElement.getEnclosedElements()).stream()
+                    .filter(
+                        innerType -> innerType.getSimpleName().contentEquals(companionObjectName))
+                    .collect(MoreCollectors.onlyElement()))
+        .get();
+  }
+
+  /**
+   * Returns {@code true} if the given type element was declared <code>private</code> in its Kotlin
+   * source.
+   */
+  public boolean isVisibilityPrivate(TypeElement typeElement) {
+    return hasMetadata(typeElement) && metadataFactory.create(typeElement).isPrivate();
+  }
+
+  /**
+   * Returns {@code true} if the <code>@JvmStatic</code> annotation is present in the given element.
+   */
+  public static boolean isJvmStaticPresent(ExecutableElement element) {
+    return isAnnotationPresent(element, JvmStatic.class);
   }
 }

--- a/java/dagger/internal/codegen/validation/BindsMethodValidator.java
+++ b/java/dagger/internal/codegen/validation/BindsMethodValidator.java
@@ -29,6 +29,7 @@ import dagger.internal.codegen.base.ContributionType;
 import dagger.internal.codegen.base.SetType;
 import dagger.internal.codegen.binding.BindsTypeChecker;
 import dagger.internal.codegen.binding.InjectionAnnotations;
+import dagger.internal.codegen.kotlin.KotlinMetadataUtil;
 import dagger.internal.codegen.langmodel.DaggerElements;
 import dagger.internal.codegen.langmodel.DaggerTypes;
 import dagger.producers.ProducerModule;
@@ -46,12 +47,14 @@ final class BindsMethodValidator extends BindingMethodValidator {
   BindsMethodValidator(
       DaggerElements elements,
       DaggerTypes types,
+      KotlinMetadataUtil kotlinMetadataUtil,
       BindsTypeChecker bindsTypeChecker,
       DependencyRequestValidator dependencyRequestValidator,
       InjectionAnnotations injectionAnnotations) {
     super(
         elements,
         types,
+        kotlinMetadataUtil,
         Binds.class,
         ImmutableSet.of(Module.class, ProducerModule.class),
         dependencyRequestValidator,

--- a/java/dagger/internal/codegen/validation/BindsOptionalOfMethodValidator.java
+++ b/java/dagger/internal/codegen/validation/BindsOptionalOfMethodValidator.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableSet;
 import dagger.BindsOptionalOf;
 import dagger.Module;
 import dagger.internal.codegen.binding.InjectionAnnotations;
+import dagger.internal.codegen.kotlin.KotlinMetadataUtil;
 import dagger.internal.codegen.langmodel.DaggerElements;
 import dagger.internal.codegen.langmodel.DaggerTypes;
 import dagger.producers.ProducerModule;
@@ -46,11 +47,13 @@ final class BindsOptionalOfMethodValidator extends BindingMethodValidator {
   BindsOptionalOfMethodValidator(
       DaggerElements elements,
       DaggerTypes types,
+      KotlinMetadataUtil kotlinMetadataUtil,
       DependencyRequestValidator dependencyRequestValidator,
       InjectionAnnotations injectionAnnotations) {
     super(
         elements,
         types,
+        kotlinMetadataUtil,
         BindsOptionalOf.class,
         ImmutableSet.of(Module.class, ProducerModule.class),
         dependencyRequestValidator,

--- a/java/dagger/internal/codegen/validation/MultibindsMethodValidator.java
+++ b/java/dagger/internal/codegen/validation/MultibindsMethodValidator.java
@@ -28,6 +28,7 @@ import dagger.Module;
 import dagger.internal.codegen.base.MapType;
 import dagger.internal.codegen.base.SetType;
 import dagger.internal.codegen.binding.InjectionAnnotations;
+import dagger.internal.codegen.kotlin.KotlinMetadataUtil;
 import dagger.internal.codegen.langmodel.DaggerElements;
 import dagger.internal.codegen.langmodel.DaggerTypes;
 import dagger.multibindings.Multibinds;
@@ -44,11 +45,13 @@ class MultibindsMethodValidator extends BindingMethodValidator {
   MultibindsMethodValidator(
       DaggerElements elements,
       DaggerTypes types,
+      KotlinMetadataUtil kotlinMetadataUtil,
       DependencyRequestValidator dependencyRequestValidator,
       InjectionAnnotations injectionAnnotations) {
     super(
         elements,
         types,
+        kotlinMetadataUtil,
         Multibinds.class,
         ImmutableSet.of(Module.class, ProducerModule.class),
         dependencyRequestValidator,

--- a/java/dagger/internal/codegen/validation/ProducesMethodValidator.java
+++ b/java/dagger/internal/codegen/validation/ProducesMethodValidator.java
@@ -26,6 +26,7 @@ import com.google.auto.common.MoreTypes;
 import com.google.common.util.concurrent.ListenableFuture;
 import dagger.internal.codegen.binding.ConfigurationAnnotations;
 import dagger.internal.codegen.binding.InjectionAnnotations;
+import dagger.internal.codegen.kotlin.KotlinMetadataUtil;
 import dagger.internal.codegen.langmodel.DaggerElements;
 import dagger.internal.codegen.langmodel.DaggerTypes;
 import dagger.multibindings.ElementsIntoSet;
@@ -45,11 +46,13 @@ final class ProducesMethodValidator extends BindingMethodValidator {
   ProducesMethodValidator(
       DaggerElements elements,
       DaggerTypes types,
+      KotlinMetadataUtil kotlinMetadataUtil,
       DependencyRequestValidator dependencyRequestValidator,
       InjectionAnnotations injectionAnnotations) {
     super(
         elements,
         types,
+        kotlinMetadataUtil,
         dependencyRequestValidator,
         Produces.class,
         ProducerModule.class,

--- a/java/dagger/internal/codegen/validation/ProvidesMethodValidator.java
+++ b/java/dagger/internal/codegen/validation/ProvidesMethodValidator.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableSet;
 import dagger.Module;
 import dagger.Provides;
 import dagger.internal.codegen.binding.InjectionAnnotations;
+import dagger.internal.codegen.kotlin.KotlinMetadataUtil;
 import dagger.internal.codegen.langmodel.DaggerElements;
 import dagger.internal.codegen.langmodel.DaggerTypes;
 import dagger.producers.ProducerModule;
@@ -41,11 +42,13 @@ final class ProvidesMethodValidator extends BindingMethodValidator {
   ProvidesMethodValidator(
       DaggerElements elements,
       DaggerTypes types,
+      KotlinMetadataUtil kotlinMetadataUtil,
       DependencyRequestValidator dependencyRequestValidator,
       InjectionAnnotations injectionAnnotations) {
     super(
         elements,
         types,
+        kotlinMetadataUtil,
         Provides.class,
         ImmutableSet.of(Module.class, ProducerModule.class),
         dependencyRequestValidator,

--- a/java/dagger/internal/codegen/writing/SimpleMethodBindingExpression.java
+++ b/java/dagger/internal/codegen/writing/SimpleMethodBindingExpression.java
@@ -17,13 +17,13 @@
 package dagger.internal.codegen.writing;
 
 import static com.google.auto.common.MoreElements.asExecutable;
+import static com.google.auto.common.MoreElements.asType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static dagger.internal.codegen.javapoet.CodeBlocks.toParametersCodeBlock;
 import static dagger.internal.codegen.javapoet.TypeNames.rawTypeName;
 import static dagger.internal.codegen.langmodel.Accessibility.isTypeAccessibleFrom;
 import static dagger.internal.codegen.writing.InjectionMethods.ProvisionMethod.requiresInjectionMethod;
 
-import com.google.auto.common.MoreElements;
 import com.google.auto.common.MoreTypes;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -127,7 +127,7 @@ final class SimpleMethodBindingExpression extends SimpleInvocationBindingExpress
         Optional<CodeBlock> requiredModuleInstance = moduleReference(requestingClass);
         if (requiredModuleInstance.isPresent()) {
           module = requiredModuleInstance.get();
-        } else if (metadataUtil.isObjectClass(MoreElements.asType(method.getEnclosingElement()))) {
+        } else if (metadataUtil.isObjectClass(asType(method.getEnclosingElement()))) {
           // Call through the singleton instance.
           // See: https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html#static-methods
           module = CodeBlock.of("$T.INSTANCE", provisionBinding.bindingTypeElement().get());

--- a/javatests/dagger/functional/kotlin/CompanionModuleTest.java
+++ b/javatests/dagger/functional/kotlin/CompanionModuleTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.kotlin;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class CompanionModuleTest {
+
+  @Test
+  public void verifyCompanionModule() {
+    TestKotlinComponentWithCompanionModule component =
+        DaggerTestKotlinComponentWithCompanionModule.create();
+    assertThat(component.getDataA()).isNotNull();
+    assertThat(component.getDataB()).isNotNull();
+    assertThat(component.getBoolean()).isTrue();
+    assertThat(component.getStringType()).isNotNull();
+    assertThat(component.getNamedStringType()).isEqualTo("Cat");
+    assertThat(component.getInterface()).isNotNull();
+    assertThat(component.getLong()).isEqualTo(4L);
+    assertThat(component.getDouble()).isEqualTo(1.0);
+    assertThat(component.getInteger()).isEqualTo(2);
+  }
+}

--- a/javatests/dagger/functional/kotlin/TestComponentWithCompanionModule.kt
+++ b/javatests/dagger/functional/kotlin/TestComponentWithCompanionModule.kt
@@ -1,0 +1,82 @@
+package dagger.functional.kotlin
+
+import dagger.Binds
+import dagger.Component
+import dagger.Module
+import dagger.Provides
+import javax.inject.Named
+
+@Component(
+  modules = [
+    TestKotlinModuleWithCompanion::class,
+    TestKotlinModuleWithNamedCompanion::class,
+    TestKotlinAbstractModuleWithCompanion::class,
+    TestKotlinWorkaroundModuleWithCompanion::class
+  ]
+)
+interface TestKotlinComponentWithCompanionModule {
+  fun getDataA(): TestDataA
+  fun getDataB(): TestDataB
+  fun getBoolean(): Boolean
+  fun getStringType(): String
+  @Named("Cat")
+  fun getNamedStringType(): String
+
+  fun getInterface(): TestInterface
+  fun getLong(): Long
+  fun getDouble(): Double
+  fun getInteger(): Int
+}
+
+@Module
+class TestKotlinModuleWithCompanion {
+  @Provides
+  fun provideDataA() = TestDataA("test")
+
+  companion object {
+    @Provides
+    fun provideDataB() = TestDataB("test")
+
+    @Provides
+    fun provideBoolean(): Boolean = true
+  }
+}
+
+@Module
+class TestKotlinModuleWithNamedCompanion {
+
+  @Provides
+  @Named("Cat")
+  fun provideNamedString() = "Cat"
+
+  companion object Foo {
+    @Provides
+    fun provideStringType(): String = ""
+  }
+}
+
+@Module
+abstract class TestKotlinAbstractModuleWithCompanion {
+
+  @Binds
+  abstract fun bindInterface(injectable: TestInjectable): TestInterface
+
+  companion object {
+    @Provides
+    fun provideLong() = 4L
+  }
+}
+
+@Module
+class TestKotlinWorkaroundModuleWithCompanion {
+
+  @Provides
+  fun provideDouble() = 1.0
+
+  @Module
+  companion object {
+    @Provides
+    @JvmStatic
+    fun provideInteger() = 2
+  }
+}

--- a/javatests/dagger/functional/kotlin/TestKotlinClasses.kt
+++ b/javatests/dagger/functional/kotlin/TestKotlinClasses.kt
@@ -16,10 +16,14 @@
 
 package dagger.functional.kotlin
 
+import javax.inject.Inject
 import javax.inject.Qualifier
 
 data class TestDataA(val data: String)
 data class TestDataB(val data: String)
+
+interface TestInterface
+class TestInjectable @Inject constructor() : TestInterface
 
 @Qualifier
 @Retention(AnnotationRetention.RUNTIME)


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Discover companion object bindings of @Module annotated classes.

If a Kotlin class annotated with @Module has a companion object, then
the functions in it are considered as part of the bindings declared by
the module. The bindings are effectively static and don't require an
instance. For backwards compatibility, it is OK to still annotated the
companion object with @Module and its functions with @JvmStatic, but
this is no longer needed.

RELNOTES=Support binding declarations in Kotlin companion objects of @Module annotated classes.

c68a9416f020006805ea5b8665c5925e53537ee8

-------

<p> Workaround for issue with missing annotation values.

RELNOTES=N/A

623e472f13343e92e86bfb3e54e254f6a729926d