### PR TITLE
MOE Sync 2020-01-13

### DIFF
--- a/java/dagger/internal/codegen/validation/ModuleValidator.java
+++ b/java/dagger/internal/codegen/validation/ModuleValidator.java
@@ -677,10 +677,12 @@ public final class ModuleValidator {
         Multimaps.index(companionBindingMethods, ExecutableElement::getSimpleName);
     validateMethodsWithSameName(builder, bindingMethodsByName);
 
-    // Companion objects are composed by an inner class and a static field, it is not enough to
-    // check the visibility on the type element or the field, therefore we check the metadata.
-    if (metadataUtil.isVisibilityPrivate(companionModule)) {
-      builder.addError("Companion Module cannot be private.", companionModule);
+    // If there are provision methods, then check the visibility. Companion objects are composed by
+    // an inner class and a static field, it is not enough to check the visibility on the type
+    // element or the field, therefore we check the metadata.
+    if (!companionBindingMethods.isEmpty() && metadataUtil.isVisibilityPrivate(companionModule)) {
+      builder.addError(
+          "A Companion Module with binding methods cannot be private.", companionModule);
     }
   }
 

--- a/javatests/dagger/functional/kotlin/CompanionModuleTest.java
+++ b/javatests/dagger/functional/kotlin/CompanionModuleTest.java
@@ -33,7 +33,8 @@ public class CompanionModuleTest {
     assertThat(component.getDataB()).isNotNull();
     assertThat(component.getBoolean()).isTrue();
     assertThat(component.getStringType()).isNotNull();
-    assertThat(component.getNamedStringType()).isEqualTo("Cat");
+    assertThat(component.getCatNamedStringType()).isEqualTo("Cat");
+    assertThat(component.getDogNamedStringType()).isEqualTo("Dog");
     assertThat(component.getInterface()).isNotNull();
     assertThat(component.getLong()).isEqualTo(4L);
     assertThat(component.getDouble()).isEqualTo(1.0);

--- a/javatests/dagger/functional/kotlin/TestComponentWithCompanionModule.kt
+++ b/javatests/dagger/functional/kotlin/TestComponentWithCompanionModule.kt
@@ -11,7 +11,8 @@ import javax.inject.Named
     TestKotlinModuleWithCompanion::class,
     TestKotlinModuleWithNamedCompanion::class,
     TestKotlinAbstractModuleWithCompanion::class,
-    TestKotlinWorkaroundModuleWithCompanion::class
+    TestKotlinWorkaroundModuleWithCompanion::class,
+    TestKotlinModuleWithPrivateCompanion::class
   ]
 )
 interface TestKotlinComponentWithCompanionModule {
@@ -20,7 +21,9 @@ interface TestKotlinComponentWithCompanionModule {
   fun getBoolean(): Boolean
   fun getStringType(): String
   @Named("Cat")
-  fun getNamedStringType(): String
+  fun getCatNamedStringType(): String
+  @Named("Dog")
+  fun getDogNamedStringType(): String
 
   fun getInterface(): TestInterface
   fun getLong(): Long
@@ -78,5 +81,17 @@ class TestKotlinWorkaroundModuleWithCompanion {
     @Provides
     @JvmStatic
     fun provideInteger() = 2
+  }
+}
+
+@Module
+class TestKotlinModuleWithPrivateCompanion {
+
+  @Provides
+  @Named("Dog")
+  fun getNamedStringType() = "Dog"
+
+  private companion object {
+    fun randomFunction() = ""
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Allow private companion object modules if they have no binding methods.

Once a companion object in an enclosed Dagger module has a binding
method then the companion object cannot be private. However, if no
binding method is defined then allow the strict visibility since it can
be useful for hiding a handful of functions and constants related to
the module.

RELNOTES=N/A

26464ff0c5e5cd0b4dceafaf3fd2384affea4beb