### PR TITLE
Move dagger-android to androidx

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,9 +49,9 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(
     artifacts = [
-        "com.android.support:support-annotations:25.0.0",
-        "com.android.support:support-fragment:25.0.0",
-        "com.android.support:appcompat-v7:25.0.0",
+        "androidx.annotation:annotation:1.1.0",
+        "androidx.fragment:fragment:1.1.0",
+        "androidx.appcompat:appcompat:1.1.0",
         "org.jetbrains.kotlin:kotlin-stdlib:1.3.50",
         "org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0",
     ],

--- a/java/dagger/android/BUILD
+++ b/java/dagger/android/BUILD
@@ -48,7 +48,7 @@ android_library(
         "//:dagger_with_compiler",
         "@google_bazel_common//third_party/java/auto:value",
         "@google_bazel_common//third_party/java/error_prone:annotations",
-        "@maven//:com_android_support_support_annotations",
+        "@maven//:androidx_annotation_annotation",
     ],
 )
 

--- a/java/dagger/android/DaggerActivity.java
+++ b/java/dagger/android/DaggerActivity.java
@@ -19,7 +19,7 @@ package dagger.android;
 import android.app.Activity;
 import android.app.Fragment;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import dagger.internal.Beta;
 import javax.inject.Inject;
 

--- a/java/dagger/android/DaggerBroadcastReceiver.java
+++ b/java/dagger/android/DaggerBroadcastReceiver.java
@@ -19,7 +19,7 @@ package dagger.android;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.support.annotation.CallSuper;
+import androidx.annotation.CallSuper;
 import dagger.internal.Beta;
 
 /**

--- a/java/dagger/android/DaggerContentProvider.java
+++ b/java/dagger/android/DaggerContentProvider.java
@@ -17,7 +17,7 @@
 package dagger.android;
 
 import android.content.ContentProvider;
-import android.support.annotation.CallSuper;
+import androidx.annotation.CallSuper;
 import dagger.internal.Beta;
 
 /** A {@link ContentProvider} that injects its members in {@link #onCreate()}. */

--- a/java/dagger/android/support/AndroidSupportInjection.java
+++ b/java/dagger/android/support/AndroidSupportInjection.java
@@ -20,8 +20,8 @@ import static android.util.Log.DEBUG;
 import static dagger.internal.Preconditions.checkNotNull;
 
 import android.app.Activity;
-import android.support.v4.app.Fragment;
 import android.util.Log;
+import androidx.fragment.app.Fragment;
 import dagger.android.AndroidInjector;
 import dagger.android.HasAndroidInjector;
 import dagger.internal.Beta;

--- a/java/dagger/android/support/BUILD
+++ b/java/dagger/android/support/BUILD
@@ -36,9 +36,9 @@ android_library(
         "//:dagger_with_compiler",
         "//java/dagger/android",
         "@google_bazel_common//third_party/java/error_prone:annotations",
-        "@maven//:com_android_support_appcompat_v7",
-        "@maven//:com_android_support_support_annotations",
-        "@maven//:com_android_support_support_fragment",
+        "@maven//:androidx_appcompat_appcompat",
+        "@maven//:androidx_annotation_annotation",
+        "@maven//:androidx_fragment_fragment",
     ],
 )
 

--- a/java/dagger/android/support/DaggerAppCompatActivity.java
+++ b/java/dagger/android/support/DaggerAppCompatActivity.java
@@ -17,8 +17,8 @@
 package dagger.android.support;
 
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.v7.app.AppCompatActivity;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 import dagger.android.AndroidInjection;
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;

--- a/java/dagger/android/support/DaggerAppCompatDialogFragment.java
+++ b/java/dagger/android/support/DaggerAppCompatDialogFragment.java
@@ -17,8 +17,8 @@
 package dagger.android.support;
 
 import android.content.Context;
-import android.support.v4.app.Fragment;
-import android.support.v7.app.AppCompatDialogFragment;
+import androidx.fragment.app.Fragment;
+import androidx.appcompat.app.AppCompatDialogFragment;
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
 import dagger.android.HasAndroidInjector;

--- a/java/dagger/android/support/DaggerDialogFragment.java
+++ b/java/dagger/android/support/DaggerDialogFragment.java
@@ -17,8 +17,8 @@
 package dagger.android.support;
 
 import android.content.Context;
-import android.support.v4.app.DialogFragment;
-import android.support.v4.app.Fragment;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.Fragment;
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
 import dagger.android.HasAndroidInjector;

--- a/java/dagger/android/support/DaggerFragment.java
+++ b/java/dagger/android/support/DaggerFragment.java
@@ -17,7 +17,7 @@
 package dagger.android.support;
 
 import android.content.Context;
-import android.support.v4.app.Fragment;
+import androidx.fragment.app.Fragment;
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
 import dagger.android.HasAndroidInjector;

--- a/java/dagger/example/gradle/android/simple/BUILD
+++ b/java/dagger/example/gradle/android/simple/BUILD
@@ -27,6 +27,6 @@ android_binary(
         "//:android",
         "//:android-support",
         "//:dagger_with_compiler",
-        "@maven//:com_android_support_appcompat_v7",
+        "@maven//:androidx_appcompat_appcompat",
     ],
 )

--- a/javatests/dagger/android/processor/BUILD
+++ b/javatests/dagger/android/processor/BUILD
@@ -28,7 +28,7 @@ GenJavaTests(
     deps = [
         "//java/dagger/internal/guava:base",
         "//java/dagger/internal/guava:collect",
-        "@maven//:com_android_support_support_fragment",
+        "@maven//:androidx_fragment_fragment",
         # TODO(ronshapiro): create a common location to define the current Android version
         "@androidsdk//:platforms/android-29/android.jar",
         "@google_bazel_common//third_party/java/compile_testing",

--- a/javatests/dagger/android/support/functional/BUILD
+++ b/javatests/dagger/android/support/functional/BUILD
@@ -27,9 +27,9 @@ android_library(
     manifest = "AndroidManifest.xml",
     resource_files = glob(["res/**"]),
     deps = [
-        "@maven//:com_android_support_support_fragment",
-        "@maven//:com_android_support_appcompat_v7",
-        "@maven//:com_android_support_support_annotations",
+        "@maven//:androidx_fragment_fragment",
+        "@maven//:androidx_appcompat_appcompat",
+        "@maven//:androidx_annotation_annotation",
         "//java/dagger/internal/guava:collect",
         "//:dagger_with_compiler",
         "//:android",

--- a/javatests/dagger/android/support/functional/TestContentProvider.java
+++ b/javatests/dagger/android/support/functional/TestContentProvider.java
@@ -19,7 +19,7 @@ package dagger.android.support.functional;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import dagger.android.DaggerContentProvider;
 import java.util.Set;
 import javax.inject.Inject;


### PR DESCRIPTION
Resolves #1652
Resolves #1619
Resolves #1248
Resolves #1489
Resolves #1444
Resolves #1313
Resolves #1264

Enables better support for newer androidx subprojects like #1271.

I understand there have been a number of prior discussions about next steps, namely [this one](https://github.com/google/dagger/pull/1312#issuecomment-432685634). I worry that the argument that any move to androidx should either be completely split up artifacts or nothing has actively prevented progress on this front though, and think this is a positive first step. This unblocks that by making the initial move to androidx as a namespace, and then splitting up newer artifacts out of this (and progressively making dagger-android-support increasingly just a shim that delegates to them) is a possible healthy approach.

Also I believe the long term vision for dagger-android has changed significantly since those past discussions with the involvement of the androidx folks and the "Opinionated DI" talk from Android Dev Summit.