### PR TITLE
MOE Sync 2020-01-28

### DIFF
--- a/tutorial/04-depending-on-interface.md
+++ b/tutorial/04-depending-on-interface.md
@@ -60,10 +60,10 @@ interface CommandRouterFactory {
 > answer is that Dagger already knows to look at those types because they appear
 > somewhere in a component or module that Dagger is using. In the case of
 > `CommandRouter`, it's the return type of the `CommandRouterFactory`'s entry
-> point method. And in the case of `HelloWorldModule`, it's the parameter type
-> of the [`@Binds`] method we just wrote. And before that, it appeared as a
-> constructor parameter to `CommandRouter`, so Dagger learned about it
-> transitively when looking at `CommandRouter`.
+> point method. And in the case of `HelloWorldCommand`, it's the parameter type
+> of the [`@Binds`] method we just wrote in `HelloWorldModule`. And before that,
+> it appeared as a constructor parameter to `CommandRouter`, so Dagger learned
+> about it transitively when looking at `CommandRouter`.
 
 Now when Dagger looks to create a `CommandRouter` and sees that it needs a
 `Command`, it will use the instructions in `HelloWorldModule` to create one.


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix error in Dagger tutorial

The aside is talking about the Inject-annotated classes,
like CommandRouter and HelloWorldCommand but references
HelloWorldModule instead.

Closes https://github.com/google/dagger/pull/1574

56b10fb5ecfebafb3417e49d1a1d7e764fe338d2