### PR TITLE
Add support constructor with content layout id for AndroidX

### DIFF
--- a/java/dagger/android/support/DaggerAppCompatActivity.java
+++ b/java/dagger/android/support/DaggerAppCompatActivity.java
@@ -17,6 +17,8 @@
 package dagger.android.support;
 
 import android.os.Bundle;
+import androidx.annotation.ContentView;
+import androidx.annotation.LayoutRes;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import dagger.android.AndroidInjection;
@@ -35,6 +37,15 @@ public abstract class DaggerAppCompatActivity extends AppCompatActivity
     implements HasAndroidInjector {
 
   @Inject DispatchingAndroidInjector<Object> androidInjector;
+
+  public DaggerAppCompatActivity() {
+    super();
+  }
+
+  @ContentView
+  public DaggerAppCompatActivity(@LayoutRes int contentLayoutId) {
+    super(contentLayoutId);
+  }
 
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {

--- a/java/dagger/android/support/DaggerFragment.java
+++ b/java/dagger/android/support/DaggerFragment.java
@@ -17,6 +17,8 @@
 package dagger.android.support;
 
 import android.content.Context;
+import androidx.annotation.ContentView;
+import androidx.annotation.LayoutRes;
 import androidx.fragment.app.Fragment;
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
@@ -33,6 +35,15 @@ import javax.inject.Inject;
 public abstract class DaggerFragment extends Fragment implements HasAndroidInjector {
 
   @Inject DispatchingAndroidInjector<Object> androidInjector;
+
+  public DaggerFragment() {
+    super();
+  }
+
+  @ContentView
+  public DaggerFragment(@LayoutRes int contentLayoutId) {
+    super(contentLayoutId);
+  }
 
   @Override
   public void onAttach(Context context) {


### PR DESCRIPTION
To resolve the issue #1734

This PR add constructor with content layout id for AndroidX version `DaggerAppCompatActivity` and `DaggerFragment`.