### PR TITLE
MOE Sync 2020-02-17

### DIFF
--- a/java/dagger/internal/codegen/base/ContributionType.java
+++ b/java/dagger/internal/codegen/base/ContributionType.java
@@ -56,6 +56,7 @@ public enum ContributionType {
    * own.
    */
   public static ContributionType fromBindingElement(Element element) {
+    // TODO(user): Replace these class references with ClassName.
     if (isAnnotationPresent(element, IntoMap.class)) {
       return ContributionType.MAP;
     } else if (isAnnotationPresent(element, IntoSet.class)) {

--- a/java/dagger/internal/codegen/base/DiagnosticFormatting.java
+++ b/java/dagger/internal/codegen/base/DiagnosticFormatting.java
@@ -38,6 +38,7 @@ public final class DiagnosticFormatting {
               + "|java[.]util"
               + "|javax[.]inject"
               + "|dagger"
+              + "|dagger[.]multibindings"
               + "|com[.]google[.]common[.]base"
               + "|com[.]google[.]common[.]collect"
               + ")[.])" // Always end with a literal .

--- a/java/dagger/internal/codegen/binding/ContributionBinding.java
+++ b/java/dagger/internal/codegen/binding/ContributionBinding.java
@@ -152,6 +152,8 @@ public abstract class ContributionBinding extends Binding implements HasContribu
     }
   }
 
+  public abstract Builder<?, ?> toBuilder();
+
   /**
    * Base builder for {@link com.google.auto.value.AutoValue @AutoValue} subclasses of {@link
    * ContributionBinding}.
@@ -169,6 +171,12 @@ public abstract class ContributionBinding extends Binding implements HasContribu
     public abstract B contributionType(ContributionType contributionType);
 
     public abstract B bindingElement(Element bindingElement);
+
+    abstract B bindingElement(Optional<Element> bindingElement);
+
+    public final B clearBindingElement() {
+      return bindingElement(Optional.empty());
+    };
 
     abstract B contributingModule(TypeElement contributingModule);
 

--- a/java/dagger/internal/codegen/binding/ProductionBinding.java
+++ b/java/dagger/internal/codegen/binding/ProductionBinding.java
@@ -113,6 +113,9 @@ public abstract class ProductionBinding extends ContributionBinding {
         .thrownTypes(ImmutableList.<TypeMirror>of());
   }
 
+  @Override
+  public abstract Builder toBuilder();
+
   @Memoized
   @Override
   public abstract int hashCode();

--- a/java/dagger/internal/codegen/binding/ProvisionBinding.java
+++ b/java/dagger/internal/codegen/binding/ProvisionBinding.java
@@ -84,6 +84,7 @@ public abstract class ProvisionBinding extends ContributionBinding {
         .injectionSites(ImmutableSortedSet.of());
   }
 
+  @Override
   public abstract Builder toBuilder();
 
   private static final ImmutableSet<BindingKind> KINDS_TO_CHECK_FOR_NULL =

--- a/java/dagger/internal/codegen/kotlin/KotlinMetadataUtil.java
+++ b/java/dagger/internal/codegen/kotlin/KotlinMetadataUtil.java
@@ -22,7 +22,7 @@ import static dagger.internal.codegen.langmodel.DaggerElements.closestEnclosingT
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.MoreCollectors;
+import dagger.internal.codegen.extension.DaggerCollectors;
 import java.lang.annotation.Annotation;
 import javax.inject.Inject;
 import javax.lang.model.element.AnnotationMirror;
@@ -102,7 +102,7 @@ public final class KotlinMetadataUtil {
                 ElementFilter.typesIn(typeElement.getEnclosedElements()).stream()
                     .filter(
                         innerType -> innerType.getSimpleName().contentEquals(companionObjectName))
-                    .collect(MoreCollectors.onlyElement()))
+                    .collect(DaggerCollectors.onlyElement()))
         .get();
   }
 

--- a/java/dagger/internal/codegen/validation/CompositeBindingGraphPlugin.java
+++ b/java/dagger/internal/codegen/validation/CompositeBindingGraphPlugin.java
@@ -147,7 +147,9 @@ public final class CompositeBindingGraphPlugin implements BindingGraphPlugin {
     void report() {
       if (mergedDiagnosticKind.isPresent()) {
         delegate.reportComponent(
-            mergedDiagnosticKind.get(), graph.rootComponentNode(), messageBuilder.toString());
+            mergedDiagnosticKind.get(),
+            graph.rootComponentNode(),
+            PackageNameCompressor.compressPackagesInMessage(messageBuilder.toString()));
       }
     }
 
@@ -251,7 +253,8 @@ public final class CompositeBindingGraphPlugin implements BindingGraphPlugin {
       }
 
       mergeDiagnosticKind(diagnosticKind);
-      messageBuilder.append(String.format("[%s] ", currentPluginName));
+      // Adds brackets as well as special color strings to make the string red and bold.
+      messageBuilder.append(String.format("\033[1;31m[%s]\033[0m ", currentPluginName));
       messageBuilder.append(message);
     }
 

--- a/java/dagger/internal/codegen/validation/PackageNameCompressor.java
+++ b/java/dagger/internal/codegen/validation/PackageNameCompressor.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2020 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen.validation;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Iterables;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Munges an error message to remove/shorten package names and adds a legend at the end.
+ */
+final class PackageNameCompressor {
+
+  static final String LEGEND_HEADER =
+      "\n\n======================\nFull classname legend:\n======================\n";
+  static final String LEGEND_FOOTER =
+      "========================\nEnd of classname legend:\n========================\n";
+
+  private static final Splitter PACKAGE_SPLITTER = Splitter.on('.');
+
+  private static final Joiner PACKAGE_JOINER = Joiner.on('.');
+
+  // TODO(user): Consider validating this regex by also passing in all of the known types from
+  // keys, module names, component names, etc and checking against that list. This may have some
+  // extra complications with taking apart types like List<Foo> to get the inner class names.
+  private static final Pattern CLASSNAME_PATTERN =
+      // Match lowercase package names with trailing dots. Start with a non-word character so we
+      // don't match substrings in like Bar.Foo and match the ar.Foo. Start a group to not include
+      // the non-word character.
+      Pattern.compile("[\\W](([a-z_0-9]++[.])++"
+          // Then match a name starting with an uppercase letter. This is the outer class name.
+          + "[A-Z][\\w$]++)");
+
+  /**
+   * Compresses an error message by stripping the packages out of class names and adding them
+   * to a legend at the bottom of the error.
+   */
+  static String compressPackagesInMessage(String input) {
+    Matcher matcher = CLASSNAME_PATTERN.matcher(input);
+
+    Set<String> names = new HashSet<>();
+    // Find all classnames in the error. Note that if our regex isn't complete, it just means the
+    // classname is left in the full form, which is a fine fallback.
+    while (matcher.find()) {
+      String name = matcher.group(1);
+      names.add(name);
+    }
+    // Now dedupe any conflicts. Use a TreeMap since we're going to need the legend sorted anyway.
+    // This map is from short name to full name.
+    Map<String, String> replacementMap = shortenNames(names);
+
+    // If we have nothing to replace, just return the original.
+    if (replacementMap.isEmpty()) {
+      return input;
+    }
+
+    String replacedString = input;
+    StringBuilder legendBuilder = new StringBuilder(LEGEND_HEADER);
+    for (Map.Entry<String, String> entry : replacementMap.entrySet()) {
+      replacedString = replacedString.replace(entry.getValue(), entry.getKey());
+      legendBuilder.append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
+    }
+
+    legendBuilder.append(LEGEND_FOOTER);
+    return replacedString + legendBuilder;
+  }
+
+  /**
+   * Returns a map from short name to full name after resolving conflicts. This resolves conflicts
+   * by adding on segments of the package name until they are unique. For example, com.foo.Baz and
+   * com.bar.Baz will conflict on Baz and then resolve with foo.Baz and bar.Baz as replacements.
+   */
+  private static Map<String, String> shortenNames(Collection<String> names) {
+    HashMultimap<String, List<String>> shortNameToPartsMap = HashMultimap.create();
+    for (String name : names) {
+      List<String> parts = new ArrayList<>(PACKAGE_SPLITTER.splitToList(name));
+      // Start with the just the class name as the simple name
+      String className = parts.remove(parts.size() - 1);
+      shortNameToPartsMap.put(className, parts);
+    }
+
+    // Iterate through looking for conflicts adding the next part of the package until there are no
+    // more conflicts
+    while (true) {
+      // Save the keys with conflicts to avoid concurrent modification issues
+      List<String> conflictingShortNames = new ArrayList<>();
+      for (Map.Entry<String, Collection<List<String>>> entry
+          : shortNameToPartsMap.asMap().entrySet()) {
+        if (entry.getValue().size() > 1) {
+          conflictingShortNames.add(entry.getKey());
+        }
+      }
+
+      if (conflictingShortNames.isEmpty()) {
+        break;
+      }
+
+      // For all conflicts, add in the next part of the package
+      for (String conflictingShortName : conflictingShortNames) {
+        Set<List<String>> partsCollection = shortNameToPartsMap.removeAll(conflictingShortName);
+        for (List<String> parts : partsCollection) {
+          String newShortName = parts.remove(parts.size() - 1) + "." + conflictingShortName;
+          // If we've removed the last part of the package, then just skip it entirely because
+          // now we're not shortening it at all.
+          if (!parts.isEmpty()) {
+            shortNameToPartsMap.put(newShortName, parts);
+          }
+        }
+      }
+    }
+
+    // Turn the multimap into a regular map now that conflicts have been resolved. Use a TreeMap
+    // since we're going to need the legend sorted anyway. This map is from short name to full name.
+    Map<String, String> replacementMap = new TreeMap<>();
+    for (Map.Entry<String, Collection<List<String>>> entry
+        : shortNameToPartsMap.asMap().entrySet()) {
+      replacementMap.put(
+          entry.getKey(),
+          PACKAGE_JOINER.join(Iterables.getOnlyElement(entry.getValue())) + "." + entry.getKey());
+    }
+    return replacementMap;
+  }
+
+  private PackageNameCompressor() {}
+}

--- a/javatests/dagger/functional/ComponentDependenciesTest.java
+++ b/javatests/dagger/functional/ComponentDependenciesTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2020 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import dagger.Component;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests component dependencies.
+ */
+@RunWith(JUnit4.class)
+public final class ComponentDependenciesTest {
+  public interface One {
+    String getString();
+  }
+
+  public interface Two {
+    String getString();
+  }
+
+  public interface Merged extends One, Two {
+  }
+
+  @Component(dependencies = Merged.class)
+  interface TestComponent {
+    String getString();
+
+    @Component.Builder
+    interface Builder {
+      Builder dep(Merged dep);
+
+      TestComponent build();
+    }
+  }
+
+  @Test
+  public void testSameMethodTwice() throws Exception {
+    TestComponent component =
+        DaggerComponentDependenciesTest_TestComponent.builder().dep(() -> "test").build();
+    assertThat(component.getString()).isEqualTo("test");
+  }
+
+  public interface OneOverride {
+    Object getString();
+  }
+
+  public interface TwoOverride {
+    Object getString();
+  }
+
+  public interface MergedOverride extends OneOverride, TwoOverride {
+    @Override
+    String getString();
+  }
+
+  @Component(dependencies = MergedOverride.class)
+  interface TestOverrideComponent {
+    String getString();
+
+    @Component.Builder
+    interface Builder {
+      Builder dep(MergedOverride dep);
+
+      TestOverrideComponent build();
+    }
+  }
+
+  @Test
+  public void testPolymorphicOverridesStillCompiles() throws Exception {
+    TestOverrideComponent component =
+        DaggerComponentDependenciesTest_TestOverrideComponent.builder().dep(() -> "test").build();
+    assertThat(component.getString()).isEqualTo("test");
+  }
+}

--- a/javatests/dagger/functional/producers/BUILD
+++ b/javatests/dagger/functional/producers/BUILD
@@ -28,7 +28,8 @@ load("//:test_defs.bzl", "GenJavaTests")
 GenJavaTests(
     name = "producers-functional-tests",
     srcs = glob(["**/*.java"]),
-    javacopts = SOURCE_7_TARGET_7 + DOCLINT_HTML_AND_SYNTAX + DOCLINT_REFERENCES,
+    javacopts = DOCLINT_HTML_AND_SYNTAX + DOCLINT_REFERENCES,
+    lib_javacopts = SOURCE_7_TARGET_7,
     deps = [
         "//:producers_with_compiler",
         "//java/dagger/internal/guava:base",

--- a/javatests/dagger/functional/producers/ComponentDependenciesTest.java
+++ b/javatests/dagger/functional/producers/ComponentDependenciesTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2020 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.functional.producers;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import dagger.producers.ProductionComponent;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests component dependencies.
+ */
+@RunWith(JUnit4.class)
+public final class ComponentDependenciesTest {
+  public interface One {
+    ListenableFuture<String> getString();
+  }
+
+  public interface Two {
+    ListenableFuture<String> getString();
+  }
+
+  public interface Merged extends One, Two {
+  }
+
+  @ProductionComponent(dependencies = Merged.class)
+  interface TestProductionComponent {
+    ListenableFuture<String> getString();
+
+    @ProductionComponent.Builder
+    interface Builder {
+      Builder dep(Merged dep);
+
+      TestProductionComponent build();
+    }
+  }
+
+  @Test
+  public void testSameMethodTwiceProduction() throws Exception {
+    TestProductionComponent component =
+        DaggerComponentDependenciesTest_TestProductionComponent.builder().dep(
+            () -> Futures.immediateFuture("test")).build();
+    assertThat(component.getString().get()).isEqualTo("test");
+  }
+
+  public interface OneOverride {
+    ListenableFuture<?> getString();
+  }
+
+  public interface TwoOverride {
+    ListenableFuture<?> getString();
+  }
+
+  public interface MergedOverride extends OneOverride, TwoOverride {
+    @Override
+    ListenableFuture<String> getString();
+  }
+
+  @ProductionComponent(dependencies = MergedOverride.class)
+  interface TestOverrideComponent {
+    ListenableFuture<String> getString();
+
+    @ProductionComponent.Builder
+    interface Builder {
+      Builder dep(MergedOverride dep);
+
+      TestOverrideComponent build();
+    }
+  }
+
+  @Test
+  public void testPolymorphicOverridesStillCompiles() throws Exception {
+    TestOverrideComponent component =
+        DaggerComponentDependenciesTest_TestOverrideComponent.builder().dep(
+            () -> Futures.immediateFuture("test")).build();
+    assertThat(component.getString().get()).isEqualTo("test");
+  }
+}

--- a/javatests/dagger/internal/codegen/BUILD
+++ b/javatests/dagger/internal/codegen/BUILD
@@ -22,8 +22,11 @@ load("//:test_defs.bzl", "GenJavaTests")
 package(default_visibility = ["//:src"])
 
 kt_jvm_library(
-    name = "kotlin_injected_qualifier",
-    srcs = ["KotlinInjectedQualifier.kt"],
+    name = "kotlin_sources",
+    srcs = [
+        "KotlinInjectedQualifier.kt",
+        "KotlinObjectWithMemberInjection.kt",
+    ],
     deps = [
         "//java/dagger:core",
     ],
@@ -36,7 +39,7 @@ GenJavaTests(
     javacopts = DOCLINT_HTML_AND_SYNTAX,
     plugins = ["//java/dagger/internal/codegen/bootstrap"],
     deps = [
-        ":kotlin_injected_qualifier",
+        ":kotlin_sources",
         "//java/dagger:core",
         "//java/dagger/internal/codegen:package_info",
         "//java/dagger/internal/codegen:processor",

--- a/javatests/dagger/internal/codegen/ComponentDependenciesTest.java
+++ b/javatests/dagger/internal/codegen/ComponentDependenciesTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2020 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static dagger.internal.codegen.Compilers.daggerCompiler;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class ComponentDependenciesTest {
+  @Test
+  public void dependenciesWithTwoOfSameMethodOnDifferentInterfaces_fail() {
+    JavaFileObject interfaceOne = JavaFileObjects.forSourceLines("test.One",
+        "package test;",
+        "",
+        "interface One {",
+        "  String getOne();",
+        "}");
+    JavaFileObject interfaceTwo = JavaFileObjects.forSourceLines("test.Two",
+        "package test;",
+        "",
+        "interface Two {",
+        "  String getTwo();",
+        "}");
+    JavaFileObject mergedInterface = JavaFileObjects.forSourceLines("test.Merged",
+        "package test;",
+        "",
+        "interface Merged extends One, Two {}");
+    JavaFileObject componentFile = JavaFileObjects.forSourceLines("test.TestComponent",
+        "package test;",
+        "",
+        "import dagger.Component;",
+        "",
+        "@Component(dependencies = Merged.class)",
+        "interface TestComponent {",
+        "  String getString();",
+        "}");
+    Compilation compilation = daggerCompiler().compile(
+        interfaceOne, interfaceTwo, mergedInterface, componentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining("DuplicateBindings");
+  }
+
+  @Test
+  public void dependenciesWithTwoOfSameMethodOnDifferentInterfaces_producers_fail() {
+    JavaFileObject interfaceOne = JavaFileObjects.forSourceLines("test.One",
+        "package test;",
+        "",
+        "import com.google.common.util.concurrent.ListenableFuture;",
+        "",
+        "interface One {",
+        "  ListenableFuture<String> getOne();",
+        "}");
+    JavaFileObject interfaceTwo = JavaFileObjects.forSourceLines("test.Two",
+        "package test;",
+        "",
+        "import com.google.common.util.concurrent.ListenableFuture;",
+        "",
+        "interface Two {",
+        "  ListenableFuture<String> getTwo();",
+        "}");
+    JavaFileObject mergedInterface = JavaFileObjects.forSourceLines("test.Merged",
+        "package test;",
+        "",
+        "interface Merged extends One, Two {}");
+    JavaFileObject componentFile = JavaFileObjects.forSourceLines("test.TestComponent",
+        "package test;",
+        "",
+        "import com.google.common.util.concurrent.ListenableFuture;",
+        "import dagger.producers.ProductionComponent;",
+        "",
+        "@ProductionComponent(dependencies = Merged.class)",
+        "interface TestComponent {",
+        "  ListenableFuture<String> getString();",
+        "}");
+    Compilation compilation = daggerCompiler().compile(
+        interfaceOne, interfaceTwo, mergedInterface, componentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining("DuplicateBindings");
+  }
+
+  @Test
+  public void dependenciesWithTwoOfSameMethodButDifferentNullability_fail() {
+    JavaFileObject interfaceOne = JavaFileObjects.forSourceLines("test.One",
+        "package test;",
+        "",
+        "interface One {",
+        "  String getString();",
+        "}");
+    JavaFileObject interfaceTwo = JavaFileObjects.forSourceLines("test.Two",
+        "package test;",
+        "import javax.annotation.Nullable;",
+        "",
+        "interface Two {",
+        "  @Nullable String getString();",
+        "}");
+    JavaFileObject mergedInterface = JavaFileObjects.forSourceLines("test.Merged",
+        "package test;",
+        "",
+        "interface Merged extends One, Two {}");
+    JavaFileObject componentFile = JavaFileObjects.forSourceLines("test.TestComponent",
+        "package test;",
+        "",
+        "import dagger.Component;",
+        "",
+        "@Component(dependencies = Merged.class)",
+        "interface TestComponent {",
+        "  String getString();",
+        "}");
+    Compilation compilation = daggerCompiler().compile(
+        interfaceOne, interfaceTwo, mergedInterface, componentFile);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorContaining("DuplicateBindings");
+  }
+
+}

--- a/javatests/dagger/internal/codegen/DuplicateBindingsValidationTest.java
+++ b/javatests/dagger/internal/codegen/DuplicateBindingsValidationTest.java
@@ -287,10 +287,10 @@ public class DuplicateBindingsValidationTest {
             message(
                 "java.util.Set<java.lang.String> has incompatible bindings or declarations:",
                 "    Set bindings and declarations:",
-                "        @Binds @dagger.multibindings.IntoSet String "
+                "        @Binds @IntoSet String "
                     + "test.Outer.TestModule1.bindStringSetElement(@test.Outer.SomeQualifier "
                     + "String)",
-                "        @Provides @dagger.multibindings.IntoSet String "
+                "        @Provides @IntoSet String "
                     + "test.Outer.TestModule1.stringSetElement()",
                 "    Unique bindings and declarations:",
                 "        @Provides Set<String> test.Outer.TestModule2.stringSet()"))
@@ -360,12 +360,10 @@ public class DuplicateBindingsValidationTest {
                 "java.util.Map<java.lang.String,java.lang.String> has incompatible bindings "
                     + "or declarations:",
                 "    Map bindings and declarations:",
-                "        @Binds @dagger.multibindings.IntoMap "
-                    + "@dagger.multibindings.StringKey(\"bar\") String"
+                "        @Binds @IntoMap @StringKey(\"bar\") String"
                     + " test.Outer.TestModule1.bindStringMapEntry(@test.Outer.SomeQualifier "
                     + "String)",
-                "        @Provides @dagger.multibindings.IntoMap "
-                    + "@dagger.multibindings.StringKey(\"foo\") String"
+                "        @Provides @IntoMap @StringKey(\"foo\") String"
                     + " test.Outer.TestModule1.stringMapEntry()",
                 "    Unique bindings and declarations:",
                 "        @Provides Map<String,String> test.Outer.TestModule2.stringMap()"))
@@ -419,7 +417,7 @@ public class DuplicateBindingsValidationTest {
             message(
                 "java.util.Set<java.lang.String> has incompatible bindings or declarations:",
                 "    Set bindings and declarations:",
-                "        @dagger.multibindings.Multibinds Set<String> "
+                "        @Multibinds Set<String> "
                     + "test.Outer.TestModule1.stringSet()",
                 "    Unique bindings and declarations:",
                 "        @Provides Set<String> test.Outer.TestModule2.stringSet()"))
@@ -476,7 +474,7 @@ public class DuplicateBindingsValidationTest {
                 "java.util.Map<java.lang.String,java.lang.String> has incompatible bindings "
                     + "or declarations:",
                 "    Map bindings and declarations:",
-                "        @dagger.multibindings.Multibinds Map<String,String> "
+                "        @Multibinds Map<String,String> "
                     + "test.Outer.TestModule1.stringMap()",
                 "    Unique bindings and declarations:",
                 "        @Provides Map<String,String> test.Outer.TestModule2.stringMap()"))

--- a/javatests/dagger/internal/codegen/KotlinObjectWithMemberInjection.kt
+++ b/javatests/dagger/internal/codegen/KotlinObjectWithMemberInjection.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen
+
+import javax.inject.Inject
+
+object KotlinObjectWithMemberInjection {
+  @set:Inject
+  lateinit var someProperty: String
+}
+
+class KotlinClassWithMemberInjectedCompanion {
+  companion object {
+    @set:Inject
+    lateinit var someProperty: String
+  }
+}
+
+class KotlinClassWithMemberInjectedNamedCompanion {
+  companion object TheCompanion {
+    @set:Inject
+    lateinit var someProperty: String
+  }
+}

--- a/javatests/dagger/internal/codegen/MapMultibindingValidationTest.java
+++ b/javatests/dagger/internal/codegen/MapMultibindingValidationTest.java
@@ -201,11 +201,9 @@ public class MapMultibindingValidationTest {
             message(
                 "[Dagger/MapKeys] The same map key is bound more than once for "
                     + "java.util.Map<test.MapModule.WrappedMapKey,java.lang.String>",
-                "    @Provides @dagger.multibindings.IntoMap "
-                    + "@test.MapModule.WrappedMapKey(\"foo\") String "
+                "    @Provides @IntoMap @test.MapModule.WrappedMapKey(\"foo\") String "
                     + "test.MapModule.stringMapEntry1()",
-                "    @Provides @dagger.multibindings.IntoMap "
-                    + "@test.MapModule.WrappedMapKey(\"foo\") String "
+                "    @Provides @IntoMap @test.MapModule.WrappedMapKey(\"foo\") String "
                     + "test.MapModule.stringMapEntry2()"))
         .inFile(component)
         .onLineContaining("interface TestComponent");

--- a/javatests/dagger/internal/codegen/MembersInjectionValidationTest.java
+++ b/javatests/dagger/internal/codegen/MembersInjectionValidationTest.java
@@ -271,4 +271,103 @@ public class MembersInjectionValidationTest {
     assertThat(compilation)
         .hadErrorContaining("Unable to read annotations on an injected Kotlin property.");
   }
+
+  @Test
+  public void memberInjectionForKotlinObjectFails() {
+    JavaFileObject component =
+        JavaFileObjects.forSourceLines(
+            "test.TestComponent",
+            "package test;",
+            "",
+            "import dagger.Component;",
+            "import dagger.internal.codegen.KotlinObjectWithMemberInjection;",
+            "",
+            "@Component(modules = TestModule.class)",
+            "interface TestComponent {",
+            "  void inject(KotlinObjectWithMemberInjection injected);",
+            "}");
+    JavaFileObject module =
+        JavaFileObjects.forSourceLines(
+            "test.TestModule",
+            "package test;",
+            "",
+            "import dagger.Module;",
+            "import dagger.Provides;",
+            "",
+            "@Module",
+            "class TestModule {",
+            "  @Provides",
+            "  String theString() { return \"\"; }",
+            "}");
+    Compilation compilation = daggerCompiler().compile(component, module);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining("Dagger does not support injection into Kotlin objects");
+  }
+
+  @Test
+  public void memberInjectionForKotlinClassWithCompanionObjectFails() {
+    JavaFileObject component =
+        JavaFileObjects.forSourceLines(
+            "test.TestComponent",
+            "package test;",
+            "",
+            "import dagger.Component;",
+            "import dagger.internal.codegen.KotlinClassWithMemberInjectedCompanion;",
+            "",
+            "@Component(modules = TestModule.class)",
+            "interface TestComponent {",
+            "  void inject(KotlinClassWithMemberInjectedCompanion.Companion injected);",
+            "}");
+    JavaFileObject module =
+        JavaFileObjects.forSourceLines(
+            "test.TestModule",
+            "package test;",
+            "",
+            "import dagger.Module;",
+            "import dagger.Provides;",
+            "",
+            "@Module",
+            "class TestModule {",
+            "  @Provides",
+            "  String theString() { return \"\"; }",
+            "}");
+    Compilation compilation = daggerCompiler().compile(component, module);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining("Dagger does not support injection into Kotlin objects");
+  }
+
+  @Test
+  public void memberInjectionForKotlinClassWithNamedCompanionObjectFails() {
+    JavaFileObject component =
+        JavaFileObjects.forSourceLines(
+            "test.TestComponent",
+            "package test;",
+            "",
+            "import dagger.Component;",
+            "import dagger.internal.codegen.KotlinClassWithMemberInjectedNamedCompanion;",
+            "",
+            "@Component(modules = TestModule.class)",
+            "interface TestComponent {",
+            "  void inject(KotlinClassWithMemberInjectedNamedCompanion.TheCompanion injected);",
+            "}");
+    JavaFileObject module =
+        JavaFileObjects.forSourceLines(
+            "test.TestModule",
+            "package test;",
+            "",
+            "import dagger.Module;",
+            "import dagger.Provides;",
+            "",
+            "@Module",
+            "class TestModule {",
+            "  @Provides",
+            "  String theString() { return \"\"; }",
+            "}");
+    Compilation compilation = daggerCompiler().compile(component, module);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining("Dagger does not support injection into Kotlin objects");
+  }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix duplicate binding error for component dependencies that extend two interfaces with the same method.

Fixes #1612.

RELNOTES=Fixed #1612

c5d85b3beb2b7ac8012f7884f333172f3436eef4

-------

<p> Fix up duplicate binding errors. Also always shorten dagger.multibindings annotations in messages.

Behind the flag:
  -Report the component of the duplicate binding
  -Remove the dependency trace

bbff03a9669278b15a1decaa4ca24c06559dda7f

-------

<p> Add explicit check to prevent member injection in Kotlin objects.

Fixes https://github.com/google/dagger/issues/1665
Closes https://github.com/google/dagger/pull/1739

RELNOTES=Disallow member injection of Kotlin object classes.

fd99302d54c96bc21d21f92ffcd9cc47f7309ea8

-------

<p> Add a class to compress error messages by stripping out the package names and adding to a legend at the bottom of errors. Also, make the main error tags red and bold to be more visible.

All of these changes are behind the existing experimentalDaggerErrorMessages flag.

RELNOTES=Added package name compressing to errors behind the experimentalDaggerErrorMessages flag.

f0d678a46aa122633ed33d87cb0f06e56b2c8253

-------

<p> Use DaggerCollectors instead of MoreCollectors

Fixes https://github.com/google/dagger/issues/1740

RELNOTES=Remove a usage of Guava API not available in the '-android' variant.

769af9794eb538b280f6cb5be9e2ca9fcca95d5a

-------

<p> Use AnnotationMirror rather than Annotation to get the ContributionType from Provides.

This allows the internal processor to run over external code without failing.

RELNOTES=N/A

aab2765bc91c9b64031035b6dcf2dfbe75af06dd