### PR TITLE
MOE Sync 2020-02-27

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_java//java:defs.bzl", "java_library")
+load("@google_bazel_common//tools/javadoc:javadoc.bzl", "javadoc_library")
+load("@google_bazel_common//tools/jarjar:jarjar.bzl", "jarjar_library")
+
 package(default_visibility = ["//visibility:public"])
 
 package_group(
     name = "src",
     packages = ["//..."],
 )
-
-load("@google_bazel_common//tools/javadoc:javadoc.bzl", "javadoc_library")
 
 java_library(
     name = "dagger_with_compiler",
@@ -48,8 +50,6 @@ android_library(
         "//java/dagger/android/support",
     ],
 )
-
-load("@google_bazel_common//tools/jarjar:jarjar.bzl", "jarjar_library")
 
 SHADE_RULES = ["rule com.google.auto.common.** dagger.shaded.auto.common.@1"]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,11 +33,19 @@ Dagger is built with [`bazel`](https://bazel.build).
 *   [Install Bazel](https://docs.bazel.build/versions/master/install.html)
 *   Build the Dagger project with `bazel build <target>`
     *   Learn more about Bazel targets [here][bazel targets].
-    *   If you see an error similar to `ERROR: missing input file
-        '@androidsdk//:build-tools/29.0.2/aapt'`, install the missing build
-        tools version with the android `sdkmanager` tool.
+    *   Building Dagger's Android targets requires additional setup:
+        *   Set the `ANDROID_HOME` environment variable to point to a directory
+            containing the Android SDK. If you do not have the Android SDK
+            installed, you'll have to
+            [download](https://developer.android.com/studio#command-tools)
+            and unzip it first.
+        *   Install the necessary components. For example, under Linux, run:
+            `$ANDROID_HOME/tools/bin/sdkmanager "platforms;android-29" "build-tools;29.0.2"`
+            *   If you skip this step, you will see an error similar to
+                `ERROR: missing input file '@androidsdk//:build-tools/29.0.2/aapt'`.
+            *   You may also need to run `bazel sync`.
 *   Run tests with `bazel test <target>`, or `bazel test //...` to run all
-    tests
+    tests.
 *   You can install the Dagger libraries in your **local maven repository** by
     running the `./util/install-local-snapshot.sh` script.
     *   It will build the libraries and install them with a `LOCAL-SNAPSHOT`

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,23 +16,14 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "google_bazel_common",
-    sha256 = "84e037b54bd7685447365295b47764340ca2f1db2f8cffcf6786667439631e7f",
-    strip_prefix = "bazel-common-bf87eb1a4ddbfc95e215b0897f3edc89b2254a1a",
-    urls = ["https://github.com/google/bazel-common/archive/bf87eb1a4ddbfc95e215b0897f3edc89b2254a1a.zip"],
+    sha256 = "18f266d921db1daa2ee9837343938e37fa21e0a8b6a0e43a67eda4c30f62b812",
+    strip_prefix = "bazel-common-eb5c7e5d6d2c724fe410792c8be9f59130437e4a",
+    urls = ["https://github.com/google/bazel-common/archive/eb5c7e5d6d2c724fe410792c8be9f59130437e4a.zip"],
 )
 
 load("@google_bazel_common//:workspace_defs.bzl", "google_common_workspace_rules")
 
 google_common_workspace_rules()
-
-# This fixes an issue with protobuf starting to use zlib by default in 3.7.0.
-# TODO(ronshapiro): Figure out if this is in fact necessary, or if proto can depend on the
-# @bazel_tools library directly. See discussion in
-# https://github.com/protocolbuffers/protobuf/pull/5389#issuecomment-481785716
-bind(
-    name = "zlib",
-    actual = "@bazel_tools//third_party/zlib",
-)
 
 RULES_JVM_EXTERNAL_TAG = "2.7"
 
@@ -43,6 +34,28 @@ http_archive(
     sha256 = RULES_JVM_EXTERNAL_SHA,
     strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
     url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
+)
+
+# rules_python and zlib are required by protobuf.
+# TODO(ronshapiro): Figure out if zlib is in fact necessary, or if proto can depend on the
+# @bazel_tools library directly. See discussion in
+# https://github.com/protocolbuffers/protobuf/pull/5389#issuecomment-481785716
+# TODO(cpovirk): Should we eventually get rules_python from "Bazel Federation?"
+# https://github.com/bazelbuild/rules_python#getting-started
+
+http_archive(
+    name = "rules_python",
+    sha256 = "e5470e92a18aa51830db99a4d9c492cc613761d5bdb7131c04bd92b9834380f6",
+    strip_prefix = "rules_python-4b84ad270387a7c439ebdccfd530e2339601ef27",
+    urls = ["https://github.com/bazelbuild/rules_python/archive/4b84ad270387a7c439ebdccfd530e2339601ef27.tar.gz"],
+)
+
+http_archive(
+    name = "zlib",
+    build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
+    sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
+    strip_prefix = "zlib-1.2.11",
+    urls = ["https://github.com/madler/zlib/archive/v1.2.11.tar.gz"],
 )
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
@@ -70,11 +83,9 @@ maven_install(
 )
 
 # TODO(user): Remove once Google publishes internal Kotlin rules.
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+RULES_KOTLIN_VERSION = "186c1e1e27d699a8953b75461f2de7c295987cfb"
 
-RULES_KOTLIN_VERSION = "legacy-1.3.0-rc1"
-
-RULES_KOTLIN_SHA = "9de078258235ea48021830b1669bbbb678d7c3bdffd3435f4c0817c921a88e42"
+RULES_KOTLIN_SHA = "ef2f9cfb724b1f1eaf0ede2636515969eb4c6e10b75a71d1850f6e692a7d5f06"
 
 http_archive(
     name = "io_bazel_rules_kotlin",

--- a/gwt/BUILD
+++ b/gwt/BUILD
@@ -15,9 +15,10 @@
 # Description:
 #   GWT-specific files for Dagger
 
-package(default_visibility = ["//:src"])
-
+load("@rules_java//java:defs.bzl", "java_library")
 load("//tools:maven.bzl", "POM_VERSION", "pom_file")
+
+package(default_visibility = ["//:src"])
 
 java_library(
     name = "gwt",

--- a/java/dagger/BUILD
+++ b/java/dagger/BUILD
@@ -15,6 +15,7 @@
 # Description:
 #   A JSR-330 compliant dependency injection system for android and java
 
+load("@rules_java//java:defs.bzl", "java_library")
 load(
     "//:build_defs.bzl",
     "DOCLINT_HTML_AND_SYNTAX",

--- a/java/dagger/android/internal/proguard/BUILD
+++ b/java/dagger/android/internal/proguard/BUILD
@@ -15,6 +15,7 @@
 # Description:
 #   Internal Proguard Processor
 
+load("@rules_java//java:defs.bzl", "java_library", "java_plugin")
 load("//:build_defs.bzl", "DOCLINT_HTML_AND_SYNTAX", "DOCLINT_REFERENCES")
 
 package(default_visibility = ["//:src"])

--- a/java/dagger/android/processor/BUILD
+++ b/java/dagger/android/processor/BUILD
@@ -15,14 +15,16 @@
 # Description:
 #   Public Dagger API for Android
 
-package(default_visibility = ["//:src"])
-
+load("@rules_java//java:defs.bzl", "java_import", "java_library", "java_plugin")
 load(
     "//:build_defs.bzl",
     "DOCLINT_HTML_AND_SYNTAX",
     "DOCLINT_REFERENCES",
 )
 load("//tools:maven.bzl", "POM_VERSION", "pom_file")
+load("@google_bazel_common//tools/javadoc:javadoc.bzl", "javadoc_library")
+
+package(default_visibility = ["//:src"])
 
 filegroup(
     name = "srcs",
@@ -77,8 +79,6 @@ java_plugin(
     processor_class = "dagger.android.processor.AndroidProcessor",
     deps = [":processor"],
 )
-
-load("@google_bazel_common//tools/javadoc:javadoc.bzl", "javadoc_library")
 
 javadoc_library(
     name = "processor-javadoc",

--- a/java/dagger/errorprone/BUILD
+++ b/java/dagger/errorprone/BUILD
@@ -1,6 +1,8 @@
 # Description:
 #   ErrorProne refactorings and static analysis for Dagger
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//:src"])
 
 java_library(

--- a/java/dagger/example/atm/BUILD
+++ b/java/dagger/example/atm/BUILD
@@ -16,6 +16,8 @@
 #   An example of using dagger in a computerized fake ATM. The User's Guide (https://dagger.dev/users-guide)
 #   is a walkthrough that ultimately builds this example.
 
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 package(default_visibility = ["//:src"])
 
 java_library(

--- a/java/dagger/example/gradle/simple/BUILD
+++ b/java/dagger/example/gradle/simple/BUILD
@@ -15,6 +15,8 @@
 # Description:
 #   A skeleton example that uses gradle to test the LOCAL-SNAPSHOTs.
 
+load("@rules_java//java:defs.bzl", "java_binary")
+
 package(default_visibility = ["//:src"])
 
 java_binary(

--- a/java/dagger/example/spi/BUILD
+++ b/java/dagger/example/spi/BUILD
@@ -15,6 +15,8 @@
 # Description:
 #   An example of the dagger.spi.BindingGraphPlugin usage
 
+load("@rules_java//java:defs.bzl", "java_plugin")
+
 package(default_visibility = ["//:src"])
 
 java_plugin(

--- a/java/dagger/grpc/server/BUILD
+++ b/java/dagger/grpc/server/BUILD
@@ -1,5 +1,6 @@
 # A framework supporting Dagger-injected gRPC servers.
 
+load("@rules_java//java:defs.bzl", "java_library")
 load("//:build_defs.bzl", "DOCLINT_HTML_AND_SYNTAX", "DOCLINT_REFERENCES")
 load("//tools:maven.bzl", "POM_VERSION", "pom_file")
 load("@google_bazel_common//tools/javadoc:javadoc.bzl", "javadoc_library")

--- a/java/dagger/grpc/server/processor/BUILD
+++ b/java/dagger/grpc/server/processor/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_plugin")
 load("//:build_defs.bzl", "DOCLINT_HTML_AND_SYNTAX")
 load("//tools:maven.bzl", "POM_VERSION", "pom_file")
 load("@google_bazel_common//tools/javadoc:javadoc.bzl", "javadoc_library")

--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -15,6 +15,7 @@
 # Description:
 #   A JSR-330 compliant dependency injection system for android and java
 
+load("@rules_java//java:defs.bzl", "java_library", "java_plugin")
 load("//tools:maven.bzl", "POM_VERSION", "gen_maven_artifact")
 
 package(default_visibility = ["//:src"])

--- a/java/dagger/internal/codegen/base/BUILD
+++ b/java/dagger/internal/codegen/base/BUILD
@@ -15,6 +15,8 @@
 # Description:
 #   Sources related to compiler options.
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//:src"])
 
 java_library(

--- a/java/dagger/internal/codegen/binding/BUILD
+++ b/java/dagger/internal/codegen/binding/BUILD
@@ -15,6 +15,8 @@
 # Description:
 #   JavaPoet extensions for use in Dagger
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//:src"])
 
 java_library(

--- a/java/dagger/internal/codegen/bindinggraphvalidation/BUILD
+++ b/java/dagger/internal/codegen/bindinggraphvalidation/BUILD
@@ -15,6 +15,8 @@
 # Description:
 #   Classes related to BindingGraph validation.
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//:src"])
 
 java_library(

--- a/java/dagger/internal/codegen/bootstrap/BUILD
+++ b/java/dagger/internal/codegen/bootstrap/BUILD
@@ -15,6 +15,8 @@
 # Description:
 #   Bootstrap libraries for building Dagger with Dagger.
 
+load("@rules_java//java:defs.bzl", "java_import", "java_plugin")
+
 package(default_visibility = ["//:src"])
 
 java_plugin(

--- a/java/dagger/internal/codegen/compileroption/BUILD
+++ b/java/dagger/internal/codegen/compileroption/BUILD
@@ -15,6 +15,8 @@
 # Description:
 #   Sources related to compiler options.
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//:src"])
 
 java_library(

--- a/java/dagger/internal/codegen/extension/BUILD
+++ b/java/dagger/internal/codegen/extension/BUILD
@@ -16,6 +16,8 @@
 #   Extra features for the JDK and Guava. This code is merged into both
 #   the dagger-compiler and dagger-spi artifacts that are sent to Maven
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//:src"])
 
 java_library(

--- a/java/dagger/internal/codegen/javapoet/BUILD
+++ b/java/dagger/internal/codegen/javapoet/BUILD
@@ -15,6 +15,8 @@
 # Description:
 #   JavaPoet extensions for use in Dagger
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//:src"])
 
 java_library(

--- a/java/dagger/internal/codegen/kotlin/BUILD
+++ b/java/dagger/internal/codegen/kotlin/BUILD
@@ -15,6 +15,8 @@
 # Description:
 #   Sources related to Kotlin metadata.
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//:src"])
 
 java_library(

--- a/java/dagger/internal/codegen/langmodel/BUILD
+++ b/java/dagger/internal/codegen/langmodel/BUILD
@@ -15,6 +15,8 @@
 # Description:
 #   Dagger-specific extensions to the javax.lang.model APIs
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//:src"])
 
 java_library(

--- a/java/dagger/internal/codegen/statistics/BUILD
+++ b/java/dagger/internal/codegen/statistics/BUILD
@@ -15,6 +15,8 @@
 # Description:
 #   Dagger-specific extensions for statistics.
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//:src"])
 
 java_library(

--- a/java/dagger/internal/codegen/validation/BUILD
+++ b/java/dagger/internal/codegen/validation/BUILD
@@ -15,6 +15,8 @@
 # Description:
 #   Code related to validating the user-written Dagger code
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//:src"])
 
 java_library(

--- a/java/dagger/internal/codegen/writing/BUILD
+++ b/java/dagger/internal/codegen/writing/BUILD
@@ -15,6 +15,8 @@
 # Description:
 #   Classes that assemble the model of the generated code and write to the Filer
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//:src"])
 
 java_library(

--- a/java/dagger/model/BUILD
+++ b/java/dagger/model/BUILD
@@ -15,6 +15,13 @@
 # Description:
 #   Dagger's core APIs exposed for plugins
 
+load("@rules_java//java:defs.bzl", "java_library")
+load(
+    "//:build_defs.bzl",
+    "DOCLINT_HTML_AND_SYNTAX",
+    "DOCLINT_REFERENCES",
+)
+
 package(
     default_visibility = [
         # The dagger/spi should be the only direct dependent on this target.
@@ -23,12 +30,6 @@ package(
         # TODO(user): Consider if :model should have its own maven coordinates.
         "//java/dagger/spi:__pkg__",
     ],
-)
-
-load(
-    "//:build_defs.bzl",
-    "DOCLINT_HTML_AND_SYNTAX",
-    "DOCLINT_REFERENCES",
 )
 
 INTERNAL_PROXIES = ["BindingGraphProxies.java"]

--- a/java/dagger/model/testing/BUILD
+++ b/java/dagger/model/testing/BUILD
@@ -15,13 +15,14 @@
 # Description:
 #   Test utilities for the Dagger model
 
-package(default_visibility = ["//:src"])
-
+load("@rules_java//java:defs.bzl", "java_library")
 load(
     "//:build_defs.bzl",
     "DOCLINT_HTML_AND_SYNTAX",
     "DOCLINT_REFERENCES",
 )
+
+package(default_visibility = ["//:src"])
 
 java_library(
     name = "testing",

--- a/java/dagger/producers/BUILD
+++ b/java/dagger/producers/BUILD
@@ -15,6 +15,7 @@
 # Description:
 #   An asynchronous dependency injection system that extends JSR-330.
 
+load("@rules_java//java:defs.bzl", "java_library")
 load(
     "//:build_defs.bzl",
     "DOCLINT_HTML_AND_SYNTAX",

--- a/java/dagger/spi/BUILD
+++ b/java/dagger/spi/BUILD
@@ -15,14 +15,15 @@
 # Description:
 #   The Service Provider Interface for Dagger's binding graph model
 
-package(default_visibility = ["//:src"])
-
+load("@rules_java//java:defs.bzl", "java_library")
 load(
     "//:build_defs.bzl",
     "DOCLINT_HTML_AND_SYNTAX",
     "DOCLINT_REFERENCES",
 )
 load("//tools:maven.bzl", "POM_VERSION", "gen_maven_artifact")
+
+package(default_visibility = ["//:src"])
 
 filegroup(
     name = "spi-srcs",

--- a/javatests/dagger/android/AndroidInjectionTest.java
+++ b/javatests/dagger/android/AndroidInjectionTest.java
@@ -18,6 +18,7 @@ package dagger.android;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
+import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
 
 import android.app.Activity;
 import android.app.Application;
@@ -27,8 +28,10 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.util.FragmentTestUtil;
 
+@LooperMode(LEGACY)
 @RunWith(RobolectricTestRunner.class)
 public final class AndroidInjectionTest {
 

--- a/javatests/dagger/functional/kotlin/BUILD
+++ b/javatests/dagger/functional/kotlin/BUILD
@@ -15,6 +15,7 @@
 # Description:
 #   Functional test code for Dagger-Android
 
+load("@rules_java//java:defs.bzl", "java_library")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 load("//:test_defs.bzl", "GenJavaTests")
 

--- a/javatests/dagger/functional/spi/BUILD
+++ b/javatests/dagger/functional/spi/BUILD
@@ -15,9 +15,10 @@
 # Description:
 #   Functional tests for the experimental Dagger SPI
 
-package(default_visibility = ["//:src"])
-
+load("@rules_java//java:defs.bzl", "java_library", "java_plugin")
 load("//:test_defs.bzl", "GenJavaTests")
+
+package(default_visibility = ["//:src"])
 
 java_plugin(
     name = "test_plugin",

--- a/javatests/dagger/grpc/functional/server/BUILD
+++ b/javatests/dagger/grpc/functional/server/BUILD
@@ -1,9 +1,10 @@
 # Functional tests for Dagger-gRPC
 
-package(default_visibility = ["//:src"])
-
+load("@rules_java//java:defs.bzl", "java_proto_library")
 load("//:build_defs.bzl", "DOCLINT_HTML_AND_SYNTAX", "DOCLINT_REFERENCES")
 load("//:test_defs.bzl", "GenJavaTests")
+
+package(default_visibility = ["//:src"])
 
 # TODO(dpb): enable tests once java_grpc_library is ready in bazel:
 # https://github.com/grpc/grpc-java/issues/2756

--- a/test_defs.bzl
+++ b/test_defs.bzl
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 
 # Defines a set of build variants and the list of extra javacopts to build with.
 # The key will be appended to the generated test names to ensure uniqueness.
@@ -32,8 +34,8 @@ def GenJavaTests(
         test_javacopts = None,
         functional = True):
     _GenTests(
-        native.java_library,
-        native.java_test,
+        java_library,
+        java_test,
         name,
         srcs,
         deps,


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add more detail to Android instructions.

https://github.com/google/dagger/issues/1487

c19274ed5886ae09f3100f1d9fd386da2beda7e1

-------

<p> Annotate tests to use Robolectric's LEGACY LooperMode.

The default Robolectric Looper simulation mode is changing to PAUSED from LEGACY.
The following tests fail in this new mode, and are thus being defaulted to LEGACY.

07c93cdee643d360d7717a1c60dd914cec233cce

-------

<p> Prepare for external Bazel change --incompatible_load_java_rules_from_bzl.

...by load()-ing java_library and other rules wherever we use them.

Compare to CL 297412705 for Flogger.

This CL includes updating to a new version of bazel_common to avoid --incompatible_load_java_rules_from_bzl errors in bazel_common. See https://github.com/google/bazel-common/pull/104.

Note that this CL also changes the way we get zlib() (a dependency of protobuf) from bind() to http_archive().
http_archive() seems to be the more recommended pattern:
- https://docs.bazel.build/versions/master/external.html#repository-rules
- https://github.com/bazelbuild/bazel/issues/1952
But my immediate motivation was that bind() wasn't working with the new version of protobuf. (The new version of protobuf is necessary to avoid --incompatible_load_java_rules_from_bzl errors inside protobuf. It comes with the new version of bazel_common.)

3ca9e81721ff768e82c73f3bedd651e724145561