### PR TITLE
MOE Sync 2020-02-28

### DIFF
--- a/java/dagger/internal/codegen/javac/BUILD
+++ b/java/dagger/internal/codegen/javac/BUILD
@@ -15,6 +15,8 @@
 # Description:
 #   A library for javac the javac plugin module.
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//:src"])
 
 java_library(
@@ -34,6 +36,8 @@ java_library(
 )
 
 # buildifier: disable=no-effect
+load("@rules_java//java:defs.bzl", "java_import")
+
 # Replacement for @bazel_tools//third_party/java/jdk/langtools:javac, which seems to have gone away?
 java_import(
     name = "javac-import",

--- a/java/dagger/internal/codegen/kythe/BUILD
+++ b/java/dagger/internal/codegen/kythe/BUILD
@@ -15,6 +15,8 @@
 # Description:
 #   A library for the kythe plugin.
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//:src"])
 
 java_library(
@@ -37,6 +39,8 @@ java_library(
 )
 
 # buildifier: disable=no-effect
+load("@rules_java//java:defs.bzl", "java_import")
+
 # A _deploy.jar consisting of the java_librarys in https://github.com/kythe/kythe needed to build a
 # Kythe plugin
 # TODO(ronshapiro): replace this with a http_archive of the next release in

--- a/java/dagger/testing/compile/BUILD
+++ b/java/dagger/testing/compile/BUILD
@@ -15,6 +15,8 @@
 # Description:
 #   Helpers class for java compiler tests.
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//:src"])
 
 java_library(


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> A little more prep for --incompatible_load_java_rules_from_bzl.

Sorry for missing these in CL 297608393.

(But note that, even after this CL, there is still a breakage when building Dagger with --incompatible_load_java_rules_from_bzl. I'm trying to get to the bottom of it in https://github.com/bazelbuild/bazel/issues/10839.)

df20ca213250f9acd9ed44e396da6f79eec6cd6b