### PR TITLE
MOE Sync 2020-03-10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
     rouge (2.2.1)
     ruby-enum (0.7.1)
       i18n
-    rubyzip (1.2.1)
+    rubyzip (2.1.0)
     safe_yaml (1.0.4)
     sass (3.5.5)
       sass-listen (~> 4.0.0)


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Bump rubyzip from 1.2.1 to 2.1.0 to address https://github.com/advisories/GHSA-5m2v-hc64-56h6.

Fixes https://github.com/google/flogger/pull/130.

f05d5804b5fd0b142124b29c74212345ece7fd0b