### PR TITLE
MOE Sync 2020-03-13

### DIFF
--- a/java/dagger/internal/codegen/writing/MembersInjectorGenerator.java
+++ b/java/dagger/internal/codegen/writing/MembersInjectorGenerator.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.squareup.javapoet.MethodSpec.constructorBuilder;
 import static com.squareup.javapoet.MethodSpec.methodBuilder;
 import static com.squareup.javapoet.TypeSpec.classBuilder;
+import static dagger.internal.codegen.binding.InjectionAnnotations.injectedConstructors;
 import static dagger.internal.codegen.binding.SourceFiles.bindingTypeElementTypeVariableNames;
 import static dagger.internal.codegen.binding.SourceFiles.frameworkFieldUsages;
 import static dagger.internal.codegen.binding.SourceFiles.generateBindingFieldsForDependencies;
@@ -104,6 +105,13 @@ public final class MembersInjectorGenerator extends SourceFileGenerator<MembersI
   public Optional<TypeSpec.Builder> write(MembersInjectionBinding binding) {
     // Empty members injection bindings are special and don't need source files.
     if (binding.injectionSites().isEmpty()) {
+      return Optional.empty();
+    }
+
+    // Members injectors for classes with no local injection sites and no @Inject
+    // constructor are unused.
+    if (!binding.hasLocalInjectionSites()
+        && injectedConstructors(binding.membersInjectedType()).isEmpty()) {
       return Optional.empty();
     }
 

--- a/javatests/dagger/functional/membersinject/MembersInjectTest.java
+++ b/javatests/dagger/functional/membersinject/MembersInjectTest.java
@@ -18,12 +18,15 @@ package dagger.functional.membersinject;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import dagger.BindsInstance;
+import dagger.Component;
 import dagger.MembersInjector;
 import dagger.functional.multipackage.DaggerMembersInjectionVisibilityComponent;
 import dagger.functional.multipackage.MembersInjectionVisibilityComponent;
 import dagger.functional.multipackage.a.AGrandchild;
 import dagger.functional.multipackage.a.AParent;
 import dagger.functional.multipackage.b.BChild;
+import javax.inject.Inject;
 import javax.inject.Provider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -92,5 +95,36 @@ public class MembersInjectTest {
     MembersInjector<NonRequestedChild> injector = new NonRequestedChild_MembersInjector(provider);
     injector.injectMembers(child);
     assertThat(child.t).isEqualTo("field!");
+  }
+
+  public static final class A extends B {
+    // No injected members
+  }
+
+  public static class B extends C {
+    // No injected members
+  }
+
+  public static class C {
+    @Inject String value;
+  }
+
+  @Component
+  interface NonLocalMembersComponent {
+    MembersInjector<A> getAMembersInjector();
+
+    @Component.Factory
+    interface Factory {
+      NonLocalMembersComponent create(@BindsInstance String value);
+    }
+  }
+
+  @Test
+  public void testNonLocalMembersInjection() {
+    MembersInjector<A> membersInjector = DaggerMembersInjectTest_NonLocalMembersComponent.factory()
+        .create("test").getAMembersInjector();
+    A testA = new A();
+    membersInjector.injectMembers(testA);
+    assertThat(testA.value).isEqualTo("test");
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Stop generating members injectors for classes without local injection sites and without @Inject constructors.

Fixes https://github.com/google/dagger/issues/955

RELNOTES=Fixed issue with members injectors being created for types without @Inject fields/constructors.

f83dce7bc80e8b055e32094e480b41f290f42d2e

-------

<p> Make the compressed package name legend add spaces to create columns. Also remove java.lang and java.util classes from the legend.

75813a5d7f64aa3d3832b58796ccc2eb92d1c706