### PR TITLE
MOE Sync 2020-03-26

### DIFF
--- a/java/dagger/hilt/processor/internal/aggregateddeps/ComponentDependencies.java
+++ b/java/dagger/hilt/processor/internal/aggregateddeps/ComponentDependencies.java
@@ -120,17 +120,16 @@ public final class ComponentDependencies {
   }
 
   private final Dependencies modules;
-  // TODO(user): Migrate entry points to use Dependencies class.
-  private final ImmutableSetMultimap<ClassName, TypeElement> entryPoints;
-  private final ImmutableSetMultimap<ClassName, TypeElement> componentEntryPoints;
+  private final Dependencies entryPoints;
+  private final Dependencies componentEntryPoints;
 
   private ComponentDependencies(
       ImmutableSetMultimap<ClassName, TypeElement> modules,
       ImmutableSetMultimap<ClassName, TypeElement> entryPoints,
       ImmutableSetMultimap<ClassName, TypeElement> componentEntryPoints) {
     this.modules = Dependencies.of(modules);
-    this.entryPoints = entryPoints;
-    this.componentEntryPoints = componentEntryPoints;
+    this.entryPoints = Dependencies.of(entryPoints);
+    this.componentEntryPoints = Dependencies.of(componentEntryPoints);
   }
 
   /** Returns the modules for a component, without any filtering. */
@@ -139,13 +138,14 @@ public final class ComponentDependencies {
   }
 
   /** Returns the entry points associated with the given a component. */
-  public ImmutableSet<TypeElement> getEntryPoints(ClassName componentName) {
-    return entryPoints.get(componentName);
+  public ImmutableSet<TypeElement> getEntryPoints(ClassName componentName, ClassName rootName) {
+    return entryPoints.get(componentName, rootName);
   }
 
   /** Returns the component entry point associated with the given a component. */
-  public ImmutableSet<TypeElement> getComponentEntryPoints(ClassName componentName) {
-    return componentEntryPoints.get(componentName);
+  public ImmutableSet<TypeElement> getComponentEntryPoints(
+      ClassName componentName, ClassName rootName) {
+    return componentEntryPoints.get(componentName, rootName);
   }
 
   /**

--- a/java/dagger/hilt/processor/internal/root/RootGenerator.java
+++ b/java/dagger/hilt/processor/internal/root/RootGenerator.java
@@ -259,15 +259,16 @@ final class RootGenerator {
   }
 
   private ImmutableSet<TypeName> getEntryPoints(ComponentDescriptor componentDescriptor) {
+    ClassName componentName = componentDescriptor.component();
     ImmutableSet.Builder<TypeName> entryPointSet = ImmutableSet.builder();
     entryPointSet.add(ClassNames.GENERATED_COMPONENT);
-    for (TypeElement element : deps.getEntryPoints(componentDescriptor.component())) {
+    for (TypeElement element : deps.getEntryPoints(componentName, root.classname())) {
       entryPointSet.add(ClassName.get(element));
     }
 
     // TODO(user): move the creation of these EntryPoints to a separate processor?
     if (root.type().isTestRoot()) {
-      if (componentDescriptor.component().equals(ClassNames.APPLICATION_COMPONENT)) {
+      if (componentName.equals(ClassNames.APPLICATION_COMPONENT)) {
         entryPointSet.add(ParameterizedTypeName.get(ClassNames.TEST_INJECTOR, root.classname()));
       }
     }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> (Part 2) Enable multiple test roots in the same compilation

This CL enables:
 * Support test-specific @EntryPoint

Follow up CLs will enable:
  * Ignore global modules
  * Support test-specific @Module for non-nested modules
  * Support pkg-private @Module for non-nested modules
  * Support test-specific @AndroidEntryPoint

RELNOTES=N/A

f528e5c1bc91bad0885826629a826bd05fcd7357