### PR TITLE
MOE Sync 2020-03-27

### DIFF
--- a/java/dagger/hilt/android/BUILD
+++ b/java/dagger/hilt/android/BUILD
@@ -102,6 +102,7 @@ gen_maven_artifact(
         "//java/dagger/hilt/android/internal/modules",
         "//java/dagger/hilt/android/qualifiers",
         "//java/dagger/hilt/android/scopes",
+        "//java/dagger/hilt/android/scopes:activity_retained_scoped",
         "//java/dagger/hilt/internal:component_entry_point",
         "//java/dagger/hilt/internal:component_manager",
         "//java/dagger/hilt/internal:generated_component",

--- a/java/dagger/hilt/android/components/BUILD
+++ b/java/dagger/hilt/android/components/BUILD
@@ -23,6 +23,7 @@ android_library(
     deps = [
         "//java/dagger/hilt:define_component",
         "//java/dagger/hilt/android/scopes",
+        "//java/dagger/hilt/android/scopes:activity_retained_scoped",
         "@google_bazel_common//third_party/java/jsr330_inject",
     ],
 )

--- a/java/dagger/hilt/android/example/gradle/simple/app/build.gradle
+++ b/java/dagger/hilt/android/example/gradle/simple/app/build.gradle
@@ -47,6 +47,7 @@ dependencies {
   // TODO(bcorso): This multidex dep shouldn't be required -- it's a dep for the generated code.
   testImplementation 'androidx.multidex:multidex:2.0.0'
   testImplementation 'com.google.dagger:dagger:LOCAL-SNAPSHOT'
+  testImplementation 'com.google.dagger:hilt-android:LOCAL-SNAPSHOT'
   testImplementation 'com.google.dagger:hilt-android-testing:LOCAL-SNAPSHOT'
   testAnnotationProcessor 'com.google.dagger:dagger-compiler:LOCAL-SNAPSHOT'
   testAnnotationProcessor 'com.google.dagger:hilt-android-compiler:LOCAL-SNAPSHOT'

--- a/java/dagger/hilt/android/scopes/BUILD
+++ b/java/dagger/hilt/android/scopes/BUILD
@@ -19,6 +19,17 @@ package(default_visibility = ["//:src"])
 
 android_library(
     name = "scopes",
-    srcs = glob(["*.java"]),
+    srcs = [
+        "ActivityScoped.java",
+        "FragmentScoped.java",
+        "ServiceScoped.java",
+        "ViewScoped.java",
+    ],
+    deps = ["@google_bazel_common//third_party/java/jsr330_inject"],
+)
+
+android_library(
+    name = "activity_retained_scoped",
+    srcs = ["ActivityRetainedScoped.java"],
     deps = ["@google_bazel_common//third_party/java/jsr330_inject"],
 )

--- a/java/dagger/hilt/processor/internal/aggregateddeps/AggregatedDeps.java
+++ b/java/dagger/hilt/processor/internal/aggregateddeps/AggregatedDeps.java
@@ -20,10 +20,16 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 
 import java.lang.annotation.Retention;
 
+// TODO(user): Change this API to clearly represent that each AggeregatedDeps should only contain
+// a single module, entry point, or component entry point.
 /** Annotation for propagating dependency information through javac runs. */
 @Retention(CLASS)
 public @interface AggregatedDeps {
+  /** Returns the components that this dependency will be installed in. */
   String[] components();
+
+  /** Returns the test this dependency is associated with, otherwise an empty string. */
+  String test() default "";
 
   String[] modules() default {};
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update PkgPrivateModuleGenerator to use @Generated version based on jdk.

RELNOTES=N/A

c94366410a0280b5afc38b8b1aa7e79f19244346

-------

<p> Move enclosing test into AggregatedDeps rather than computing in ComponentDependencies

This moves the enclosing test check closer to the actual usage, and will avoid doing extra work at the RootProcessor when it can be done at the AggregatedDepsProcessor level.

RELNOTES=N/A

6469b19af2565cb210b0a3f5378a37eb7ebd8b2d

-------

<p> Separate @ActivityRetainedScoped into a separate build target.

b1adb776b10a963dac4cb57962ef86ab075b5cfc