### PR TITLE
Avoid kapt plugin ordering concern in HiltGradlePlugin

### DIFF
--- a/java/dagger/hilt/android/plugin/src/main/kotlin/dagger/hilt/android/plugin/HiltGradlePlugin.kt
+++ b/java/dagger/hilt/android/plugin/src/main/kotlin/dagger/hilt/android/plugin/HiltGradlePlugin.kt
@@ -17,8 +17,10 @@
 package dagger.hilt.android.plugin
 
 import com.android.build.gradle.BaseExtension
+import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.plugins.AppliedPlugin
 import org.jetbrains.kotlin.gradle.plugin.KaptExtension
 
 /**
@@ -44,11 +46,15 @@ class HiltGradlePlugin : Plugin<Project> {
       }
     }
     // If project has KAPT also pass the processor flag to disable superclass validation.
-    project.extensions.findByType(KaptExtension::class.java)?.let { kaptExtension ->
-      kaptExtension.arguments {
-        PROCESSOR_OPTIONS.forEach { (key, value) -> arg(key, value) }
+    val configureKapt = Action<AppliedPlugin> {
+      project.extensions.findByType(KaptExtension::class.java)?.let { kaptExtension ->
+        kaptExtension.arguments {
+          PROCESSOR_OPTIONS.forEach { (key, value) -> arg(key, value) }
+        }
       }
     }
+    project.pluginManager.withPlugin("kotlin-kapt", configureKapt)
+    project.pluginManager.withPlugin("org.jetbrains.kotlin.kapt", configureKapt)
 
     project.afterEvaluate {
       verifyDependencies(it)

--- a/java/dagger/hilt/android/plugin/src/main/kotlin/dagger/hilt/android/plugin/HiltGradlePlugin.kt
+++ b/java/dagger/hilt/android/plugin/src/main/kotlin/dagger/hilt/android/plugin/HiltGradlePlugin.kt
@@ -25,8 +25,8 @@ import org.jetbrains.kotlin.gradle.plugin.KaptExtension
  * A Gradle plugin that checks if the project is an Android project and if so, registers a
  * bytecode transformation.
  *
- * <p>The plugin also passes an annotation processor option to disable superclass validation for
- * classes annotated with @AndroidEntryPoint since the registered transform by this plugin will
+ * The plugin also passes an annotation processor option to disable superclass validation for
+ * classes annotated with `@AndroidEntryPoint` since the registered transform by this plugin will
  * update the superclass.
  */
 class HiltGradlePlugin : Plugin<Project> {


### PR DESCRIPTION
By using the `withPlugin` API, hilt doesn't need to be applied strictly after kapt to work with it