### PR TITLE
MOE Sync 2020-04-15

### DIFF
--- a/java/dagger/hilt/android/plugin/src/main/kotlin/dagger/hilt/android/plugin/HiltGradlePlugin.kt
+++ b/java/dagger/hilt/android/plugin/src/main/kotlin/dagger/hilt/android/plugin/HiltGradlePlugin.kt
@@ -56,6 +56,10 @@ class HiltGradlePlugin : Plugin<Project> {
   }
 
   private fun verifyDependencies(project: Project) {
+    // If project is already failing, skip verification since dependencies might not be resolved.
+    if (project.state.failure != null) {
+      return
+    }
     val dependencies = project.configurations.flatMap { configuration ->
       configuration.dependencies.map { dependency -> dependency.group to dependency.name }
     }

--- a/java/dagger/hilt/processor/internal/aggregateddeps/BUILD
+++ b/java/dagger/hilt/processor/internal/aggregateddeps/BUILD
@@ -75,6 +75,7 @@ java_library(
         "//java/dagger/hilt/processor/internal:processor_errors",
         "//java/dagger/hilt/processor/internal:processors",
         "//java/dagger/hilt/processor/internal/definecomponent:define_components",
+        "//java/dagger/internal/codegen/extension",
         "//java/dagger/internal/guava:base",
         "//java/dagger/internal/guava:collect",
         "@google_bazel_common//third_party/java/auto:value",

--- a/java/dagger/hilt/processor/internal/aggregateddeps/ComponentDependencies.java
+++ b/java/dagger/hilt/processor/internal/aggregateddeps/ComponentDependencies.java
@@ -17,10 +17,10 @@
 package dagger.hilt.processor.internal.aggregateddeps;
 
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static dagger.hilt.processor.internal.aggregateddeps.AggregatedDepsGenerator.AGGREGATING_PACKAGE;
+import static dagger.internal.codegen.extension.DaggerStreams.toImmutableList;
+import static dagger.internal.codegen.extension.DaggerStreams.toImmutableMap;
+import static dagger.internal.codegen.extension.DaggerStreams.toImmutableSet;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.HashMultimap;
@@ -35,7 +35,6 @@ import dagger.hilt.processor.internal.ClassNames;
 import dagger.hilt.processor.internal.ComponentDescriptor;
 import dagger.hilt.processor.internal.ProcessorErrors;
 import dagger.hilt.processor.internal.Processors;
-import dagger.hilt.processor.internal.definecomponent.DefineComponents;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -174,13 +173,14 @@ public final class ComponentDependencies {
    *
    * }</pre>
    */
-  public static ComponentDependencies from(Elements elements) {
+  public static ComponentDependencies from(
+      ImmutableList<ComponentDescriptor> descriptors, Elements elements) {
     Dependencies.Builder moduleDeps = new Dependencies.Builder();
     Dependencies.Builder entryPointDeps = new Dependencies.Builder();
     Dependencies.Builder componentEntryPointDeps = new Dependencies.Builder();
     Map<String, TypeElement> testElements = new HashMap<>();
     ImmutableMap<String, ComponentDescriptor> descriptorLookup =
-        DefineComponents.componentDescriptors(elements).stream()
+        descriptors.stream()
             .collect(
                 toImmutableMap(
                     descriptor -> descriptor.component().toString(),

--- a/java/dagger/hilt/processor/internal/root/BUILD
+++ b/java/dagger/hilt/processor/internal/root/BUILD
@@ -32,6 +32,7 @@ java_library(
         "Root.java",
         "RootFileFormatter.java",
         "RootGenerator.java",
+        "RootMetadata.java",
         "RootProcessor.java",
     ],
     deps = [
@@ -49,6 +50,7 @@ java_library(
         "//java/dagger/hilt/processor/internal/aliasof:alias_ofs",
         "//java/dagger/hilt/processor/internal/definecomponent:define_components",
         "//java/dagger/hilt/processor/internal/generatesrootinput:generates_root_inputs",
+        "//java/dagger/internal/codegen/extension",
         "//java/dagger/internal/guava:base",
         "//java/dagger/internal/guava:collect",
         "@google_bazel_common//third_party/java/auto:common",

--- a/java/dagger/hilt/processor/internal/root/RootGenerator.java
+++ b/java/dagger/hilt/processor/internal/root/RootGenerator.java
@@ -16,124 +16,51 @@
 
 package dagger.hilt.processor.internal.root;
 
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static dagger.hilt.processor.internal.Processors.toClassNames;
+import static dagger.internal.codegen.extension.DaggerStreams.toImmutableSet;
 import static javax.lang.model.element.Modifier.ABSTRACT;
-import static javax.lang.model.element.Modifier.PRIVATE;
 import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.element.Modifier.STATIC;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
-import com.squareup.javapoet.ParameterizedTypeName;
-import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
-import dagger.hilt.android.processor.internal.testing.InternalTestRootMetadata;
-import dagger.hilt.android.processor.internal.testing.TestApplicationGenerator;
 import dagger.hilt.processor.internal.ClassNames;
 import dagger.hilt.processor.internal.ComponentDescriptor;
 import dagger.hilt.processor.internal.ComponentGenerator;
 import dagger.hilt.processor.internal.ComponentNames;
 import dagger.hilt.processor.internal.ComponentTree;
-import dagger.hilt.processor.internal.KotlinMetadata;
 import dagger.hilt.processor.internal.Processors;
-import dagger.hilt.processor.internal.aggregateddeps.ComponentDependencies;
-import dagger.hilt.processor.internal.aliasof.AliasOfs;
-import dagger.hilt.processor.internal.definecomponent.DefineComponents;
 import java.io.IOException;
-import java.util.List;
 import java.util.Optional;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.util.ElementFilter;
-import javax.lang.model.util.Elements;
-import javax.tools.Diagnostic;
 
 /** Generates components and any other classes needed for a root. */
 final class RootGenerator {
-  private static final ClassName APPLICATION_CONTEXT_MODULE =
-      ClassName.get("dagger.hilt.android.internal.modules", "ApplicationContextModule");
   private static final ClassName DAGGER_PROCESSING_OPTIONS =
       ClassName.get("dagger", "DaggerProcessingOptions");
 
-  static void generate(Root root, ProcessingEnvironment env) throws IOException {
-    new RootGenerator(root, env).generate();
+  static void generate(RootMetadata metadata, ProcessingEnvironment env) throws IOException {
+    new RootGenerator(metadata, env).generateComponents();
   }
 
-  private final Root root;
+  private final RootMetadata metadata;
   private final ProcessingEnvironment env;
-  private final Elements elements;
-  private final ComponentTree componentTree;
-  private final ComponentDependencies deps;
+  private final Root root;
 
-  private RootGenerator(Root root, ProcessingEnvironment env) {
-    this.root = root;
+  private RootGenerator(RootMetadata metadata, ProcessingEnvironment env) {
+    this.metadata = metadata;
     this.env = env;
-    this.elements = env.getElementUtils();
-    this.componentTree = ComponentTree.from(DefineComponents.componentDescriptors(elements));
-    this.deps = ComponentDependencies.from(elements);
+    this.root = metadata.root();
   }
 
-  private void generate() throws IOException {
-    validateRoot();
-    generateTestApplication();
-    generateComponentForEachScope();
-  }
-
-  private void generateTestApplication() throws IOException {
-    if (root.type().equals(RootType.TEST_ROOT)) {
-      ImmutableSet<TypeElement> modules = getModules(ClassNames.APPLICATION_COMPONENT);
-      new TestApplicationGenerator(
-              env,
-              InternalTestRootMetadata.of(env, root.element()),
-              modulesThatDaggerCannotConstruct(modules),
-              false)
-          .generate();
-    }
-  }
-
-  /**
-   * Validates that the {@link RootType} annotation is compatible with its {@link TypeElement} and
-   * {@link ComponentDependencies}. If not, throws exception.
-   */
-  private void validateRoot() {
-
-    // Only test modules in the application component can be missing default constructor
-    for (ComponentDescriptor componentDescriptor : componentTree.getComponentDescriptors()) {
-      ClassName componentName = componentDescriptor.component();
-      for (TypeElement extraModule : modulesThatDaggerCannotConstruct(getModules(componentName))) {
-        if (root.type().isTestRoot() && !componentName.equals(ClassNames.APPLICATION_COMPONENT)) {
-          env.getMessager()
-              .printMessage(
-                  Diagnostic.Kind.ERROR,
-                  "[Hilt] All test modules (unless installed in ApplicationComponent) must use "
-                      + "static provision methods or have a visible, no-arg constructor. Found: "
-                      + extraModule.getQualifiedName(),
-                  root.element());
-        } else if (!root.type().isTestRoot()) {
-          env.getMessager()
-              .printMessage(
-                  Diagnostic.Kind.ERROR,
-                  "[Hilt] All modules must be static and use static provision methods or have a "
-                      + "visible, no-arg constructor. Found: "
-                      + extraModule.getQualifiedName(),
-                  root.element());
-        }
-      }
-    }
-  }
-
-  private void generateComponentForEachScope() throws IOException {
-    // TODO(user): Should including modules for unsupported scopes be an error/warning?
-    ImmutableMultimap<ComponentDescriptor, ClassName> scopes = getScopes();
+  private void generateComponents() throws IOException {
 
     // TODO(user): Consider moving all of this logic into ComponentGenerator?
     TypeSpec.Builder componentsWrapper =
@@ -146,10 +73,11 @@ final class RootGenerator {
     ImmutableMap<ComponentDescriptor, ClassName> subcomponentBuilderModules =
         subcomponentBuilderModules(componentsWrapper);
 
+    ComponentTree componentTree = metadata.componentTree();
     for (ComponentDescriptor componentDescriptor : componentTree.getComponentDescriptors()) {
       ImmutableSet<ClassName> modules =
           ImmutableSet.<ClassName>builder()
-              .addAll(toClassNames(getModules(componentDescriptor.component())))
+              .addAll(toClassNames(metadata.modules(componentDescriptor.component())))
               .addAll(
                   componentTree.childrenOf(componentDescriptor).stream()
                       .map(subcomponentBuilderModules::get)
@@ -163,11 +91,8 @@ final class RootGenerator {
                   root.element(),
                   Optional.empty(),
                   modules,
-                  ImmutableSet.<TypeName>builder()
-                      .addAll(getEntryPoints(componentDescriptor))
-                      .add(componentDescriptor.component())
-                      .build(),
-                  scopes.get(componentDescriptor),
+                  metadata.entryPoints(componentDescriptor.component()),
+                  metadata.scopes(componentDescriptor.component()),
                   ImmutableList.of(),
                   componentAnnotation(componentDescriptor),
                   componentBuilder(componentDescriptor))
@@ -183,7 +108,7 @@ final class RootGenerator {
   private ImmutableMap<ComponentDescriptor, ClassName> subcomponentBuilderModules(
       TypeSpec.Builder componentsWrapper) throws IOException {
     ImmutableMap.Builder<ComponentDescriptor, ClassName> modules = ImmutableMap.builder();
-    for (ComponentDescriptor descriptor : componentTree.getComponentDescriptors()) {
+    for (ComponentDescriptor descriptor : metadata.componentTree().getComponentDescriptors()) {
       // Root component builders don't have subcomponent builder modules
       if (!descriptor.isRoot() && descriptor.creator().isPresent()) {
         ClassName component = getComponentClassName(descriptor);
@@ -254,47 +179,6 @@ final class RootGenerator {
     }
   }
 
-  private ImmutableSet<TypeElement> getModules(ClassName componentName) {
-    return deps.getModules(componentName, root.classname());
-  }
-
-  private ImmutableSet<TypeName> getEntryPoints(ComponentDescriptor componentDescriptor) {
-    ClassName componentName = componentDescriptor.component();
-    ImmutableSet.Builder<TypeName> entryPointSet = ImmutableSet.builder();
-    entryPointSet.add(ClassNames.GENERATED_COMPONENT);
-    for (TypeElement element : deps.getEntryPoints(componentName, root.classname())) {
-      entryPointSet.add(ClassName.get(element));
-    }
-
-    // TODO(user): move the creation of these EntryPoints to a separate processor?
-    if (root.type().isTestRoot()) {
-      if (componentName.equals(ClassNames.APPLICATION_COMPONENT)) {
-        entryPointSet.add(ParameterizedTypeName.get(ClassNames.TEST_INJECTOR, root.classname()));
-      }
-    }
-    return entryPointSet.build();
-  }
-
-  private ImmutableMultimap<ComponentDescriptor, ClassName> getScopes() {
-    ImmutableMultimap.Builder<ComponentDescriptor, ClassName> builder = ImmutableMultimap.builder();
-
-    ImmutableSet<ClassName> defineComponentScopes =
-        componentTree.getComponentDescriptors().stream()
-            .flatMap(descriptor -> descriptor.scopes().stream())
-            .collect(toImmutableSet());
-
-    AliasOfs aliasOfs = new AliasOfs(env, defineComponentScopes);
-
-    for (ComponentDescriptor componentDescriptor : componentTree.getComponentDescriptors()) {
-      for (ClassName scope : componentDescriptor.scopes()) {
-        builder.put(componentDescriptor, scope);
-        builder.putAll(componentDescriptor, aliasOfs.getAliasesFor(scope));
-      }
-    }
-
-    return builder.build();
-  }
-
   private ClassName getPartialRootModuleClassName() {
     return getComponentsWrapperClassName().nestedClass("PartialRootModule");
   }
@@ -307,61 +191,4 @@ final class RootGenerator {
     return ComponentNames.generatedComponent(root.classname(), componentDescriptor.component());
   }
 
-  /**
-   * Returns all modules in the given component that do not have accessible default constructors.
-   * Note that a non-static module nested in an outer class is considered to have no default
-   * constructors, since an instance of the outer class is needed to construct the module. This also
-   * filters out framework modules directly referenced by the codegen, since those are already known
-   * about and are specifically handled in the codegen.
-   */
-  private static ImmutableSet<TypeElement> modulesThatDaggerCannotConstruct(
-      ImmutableSet<TypeElement> modules) {
-    return modules.stream()
-        .filter(module -> !daggerCanConstruct(module))
-        .filter(module -> !APPLICATION_CONTEXT_MODULE.equals(ClassName.get(module)))
-        .collect(toImmutableSet());
-  }
-
-  private static boolean daggerCanConstruct(TypeElement type) {
-    Optional<KotlinMetadata> kotlinMetadata = KotlinMetadata.of(type);
-    boolean isKotlinObject =
-        kotlinMetadata
-            .map(metadata -> metadata.isObjectClass() || metadata.isCompanionObjectClass())
-            .orElse(false);
-    if (isKotlinObject) {
-      // Treat Kotlin object modules as if Dagger can construct them (it technically can't, but it
-      // doesn't need to as it can use them since all their provision methods are static).
-      return true;
-    }
-
-    return !isInnerClass(type)
-        && !hasNonDaggerAbstractMethod(type)
-        && (hasOnlyStaticProvides(type) || hasVisibleEmptyConstructor(type));
-  }
-
-  private static boolean isInnerClass(TypeElement type) {
-    return type.getNestingKind().isNested() && !type.getModifiers().contains(STATIC);
-  }
-
-  private static boolean hasNonDaggerAbstractMethod(TypeElement type) {
-    // TODO(user): Actually this isn't really supported b/28989613
-    return ElementFilter.methodsIn(type.getEnclosedElements()).stream()
-        .filter(method -> method.getModifiers().contains(ABSTRACT))
-        .anyMatch(method -> !Processors.hasDaggerAbstractMethodAnnotation(method));
-  }
-
-  private static boolean hasOnlyStaticProvides(TypeElement type) {
-    // TODO(user): Check for @Produces too when we have a producers story
-    return ElementFilter.methodsIn(type.getEnclosedElements()).stream()
-        .filter(method -> Processors.hasAnnotation(method, ClassNames.PROVIDES))
-        .allMatch(method -> method.getModifiers().contains(STATIC));
-  }
-
-  private static boolean hasVisibleEmptyConstructor(TypeElement type) {
-    List<ExecutableElement> constructors = ElementFilter.constructorsIn(type.getEnclosedElements());
-    return constructors.isEmpty()
-        || constructors.stream()
-            .filter(constructor -> constructor.getParameters().isEmpty())
-            .anyMatch(constructor -> !constructor.getModifiers().contains(PRIVATE));
-  }
 }

--- a/java/dagger/hilt/processor/internal/root/RootMetadata.java
+++ b/java/dagger/hilt/processor/internal/root/RootMetadata.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2020 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.hilt.processor.internal.root;
+
+import static com.google.common.base.Suppliers.memoize;
+import static dagger.internal.codegen.extension.DaggerStreams.toImmutableSet;
+import static javax.lang.model.element.Modifier.ABSTRACT;
+import static javax.lang.model.element.Modifier.PRIVATE;
+import static javax.lang.model.element.Modifier.STATIC;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import dagger.hilt.processor.internal.ClassNames;
+import dagger.hilt.processor.internal.ComponentDescriptor;
+import dagger.hilt.processor.internal.ComponentTree;
+import dagger.hilt.processor.internal.KotlinMetadata;
+import dagger.hilt.processor.internal.Processors;
+import dagger.hilt.processor.internal.aggregateddeps.ComponentDependencies;
+import dagger.hilt.processor.internal.aliasof.AliasOfs;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic;
+
+/** Contains metadata about the given hilt root. */
+final class RootMetadata {
+  private static final ClassName APPLICATION_CONTEXT_MODULE =
+      ClassName.get("dagger.hilt.android.internal.modules", "ApplicationContextModule");
+
+  static RootMetadata create(
+      Root root,
+      ComponentTree componentTree,
+      ComponentDependencies deps,
+      ProcessingEnvironment env) {
+    RootMetadata metadata = new RootMetadata(root, componentTree, deps, env);
+    metadata.validate();
+    return metadata;
+  }
+
+  private final Root root;
+  private final ProcessingEnvironment env;
+  private final Elements elements;
+  private final ComponentTree componentTree;
+  private final ComponentDependencies deps;
+  private final Supplier<ImmutableSetMultimap<ClassName, ClassName>> scopesByComponent =
+      memoize(this::getScopesByComponentUncached);
+
+  private RootMetadata(
+      Root root,
+      ComponentTree componentTree,
+      ComponentDependencies deps,
+      ProcessingEnvironment env) {
+    this.root = root;
+    this.env = env;
+    this.elements = env.getElementUtils();
+    this.componentTree = componentTree;
+    this.deps = deps;
+  }
+
+  public Root root() {
+    return root;
+  }
+
+  public ComponentTree componentTree() {
+    return componentTree;
+  }
+
+  public ComponentDependencies deps() {
+    return deps;
+  }
+
+  public ImmutableSet<TypeElement> modules(ClassName componentName) {
+    return deps.getModules(componentName, root.classname());
+  }
+
+  public ImmutableSet<TypeName> entryPoints(ClassName componentName) {
+    return ImmutableSet.<TypeName>builder()
+        .addAll(getUserDefinedEntryPoints(componentName))
+        .add(componentName)
+        .build();
+  }
+
+  public ImmutableSet<ClassName> scopes(ClassName componentName) {
+    return scopesByComponent.get().get(componentName);
+  }
+
+  /**
+   * Returns all modules in the given component that do not have accessible default constructors.
+   * Note that a non-static module nested in an outer class is considered to have no default
+   * constructors, since an instance of the outer class is needed to construct the module. This also
+   * filters out framework modules directly referenced by the codegen, since those are already known
+   * about and are specifically handled in the codegen.
+   */
+  public ImmutableSet<TypeElement> modulesThatDaggerCannotConstruct(ClassName componentName) {
+    return modules(componentName).stream()
+        .filter(module -> !daggerCanConstruct(module))
+        .filter(module -> !APPLICATION_CONTEXT_MODULE.equals(ClassName.get(module)))
+        .collect(toImmutableSet());
+  }
+
+  /**
+   * Validates that the {@link RootType} annotation is compatible with its {@link TypeElement} and
+   * {@link ComponentDependencies}. If not, throws exception.
+   */
+  private void validate() {
+
+    // Only test modules in the application component can be missing default constructor
+    for (ComponentDescriptor componentDescriptor : componentTree.getComponentDescriptors()) {
+      ClassName componentName = componentDescriptor.component();
+      for (TypeElement extraModule : modulesThatDaggerCannotConstruct(componentName)) {
+        if (root.type().isTestRoot() && !componentName.equals(ClassNames.APPLICATION_COMPONENT)) {
+          env.getMessager()
+              .printMessage(
+                  Diagnostic.Kind.ERROR,
+                  "[Hilt] All test modules (unless installed in ApplicationComponent) must use "
+                      + "static provision methods or have a visible, no-arg constructor. Found: "
+                      + extraModule.getQualifiedName(),
+                  root.element());
+        } else if (!root.type().isTestRoot()) {
+          env.getMessager()
+              .printMessage(
+                  Diagnostic.Kind.ERROR,
+                  "[Hilt] All modules must be static and use static provision methods or have a "
+                      + "visible, no-arg constructor. Found: "
+                      + extraModule.getQualifiedName(),
+                  root.element());
+        }
+      }
+    }
+  }
+
+  private ImmutableSet<TypeName> getUserDefinedEntryPoints(ClassName componentName) {
+    ImmutableSet.Builder<TypeName> entryPointSet = ImmutableSet.builder();
+    entryPointSet.add(ClassNames.GENERATED_COMPONENT);
+    for (TypeElement element : deps.getEntryPoints(componentName, root.classname())) {
+      entryPointSet.add(ClassName.get(element));
+    }
+
+    // TODO(user): move the creation of these EntryPoints to a separate processor?
+    if (root.type().isTestRoot()) {
+      if (componentName.equals(ClassNames.APPLICATION_COMPONENT)) {
+        entryPointSet.add(ParameterizedTypeName.get(ClassNames.TEST_INJECTOR, root.classname()));
+      }
+    }
+    return entryPointSet.build();
+  }
+
+  private ImmutableSetMultimap<ClassName, ClassName> getScopesByComponentUncached() {
+    ImmutableSetMultimap.Builder<ClassName, ClassName> builder = ImmutableSetMultimap.builder();
+
+    ImmutableSet<ClassName> defineComponentScopes =
+        componentTree.getComponentDescriptors().stream()
+            .flatMap(descriptor -> descriptor.scopes().stream())
+            .collect(toImmutableSet());
+
+    AliasOfs aliasOfs = new AliasOfs(env, defineComponentScopes);
+
+    for (ComponentDescriptor componentDescriptor : componentTree.getComponentDescriptors()) {
+      for (ClassName scope : componentDescriptor.scopes()) {
+        builder.put(componentDescriptor.component(), scope);
+        builder.putAll(componentDescriptor.component(), aliasOfs.getAliasesFor(scope));
+      }
+    }
+
+    return builder.build();
+  }
+
+  private static boolean daggerCanConstruct(TypeElement type) {
+    Optional<KotlinMetadata> kotlinMetadata = KotlinMetadata.of(type);
+    boolean isKotlinObject =
+        kotlinMetadata
+            .map(metadata -> metadata.isObjectClass() || metadata.isCompanionObjectClass())
+            .orElse(false);
+    if (isKotlinObject) {
+      // Treat Kotlin object modules as if Dagger can construct them (it technically can't, but it
+      // doesn't need to as it can use them since all their provision methods are static).
+      return true;
+    }
+
+    return !isInnerClass(type)
+        && !hasNonDaggerAbstractMethod(type)
+        && (hasOnlyStaticProvides(type) || hasVisibleEmptyConstructor(type));
+  }
+
+  private static boolean isInnerClass(TypeElement type) {
+    return type.getNestingKind().isNested() && !type.getModifiers().contains(STATIC);
+  }
+
+  private static boolean hasNonDaggerAbstractMethod(TypeElement type) {
+    // TODO(user): Actually this isn't really supported b/28989613
+    return ElementFilter.methodsIn(type.getEnclosedElements()).stream()
+        .filter(method -> method.getModifiers().contains(ABSTRACT))
+        .anyMatch(method -> !Processors.hasDaggerAbstractMethodAnnotation(method));
+  }
+
+  private static boolean hasOnlyStaticProvides(TypeElement type) {
+    // TODO(user): Check for @Produces too when we have a producers story
+    return ElementFilter.methodsIn(type.getEnclosedElements()).stream()
+        .filter(method -> Processors.hasAnnotation(method, ClassNames.PROVIDES))
+        .allMatch(method -> method.getModifiers().contains(STATIC));
+  }
+
+  private static boolean hasVisibleEmptyConstructor(TypeElement type) {
+    List<ExecutableElement> constructors = ElementFilter.constructorsIn(type.getEnclosedElements());
+    return constructors.isEmpty()
+        || constructors.stream()
+            .filter(constructor -> constructor.getParameters().isEmpty())
+            .anyMatch(constructor -> !constructor.getModifiers().contains(PRIVATE));
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Skip dependency verification if project is already failing.

When the Gradle project has a failure it might not have its dependencies
resolved, therefore we should skip verifying the dependencies or else we
might spam the error log with misleading error.

This can happen for example if a dependency is wrongly typed or a plugin
is misconfigured.

ab2ab0c558ccc580aa74c9a12180b776f20c9aa6

-------

<p> Refactor logic out of RootGenerator and into RootMetadata.

Our current root processing pipeline assumes that each root (e.g. test) can be processed independently. However, that's no longer the case if we want to support Gradle emulator tests with Hilt. The main issue is that there can only be a single application for all emulators in a given androidTest package. Thus, our generated application must now contain information about all roots.

This CL refactors our root processing pipeline to more easily support generating an application based on multiple roots by pulling much of the logic out of RootGenerator and into RootMetadata.

RELNOTES=N/A

0f6c9c0bddfd467f967c5d2d939c2b3fe5a13d72