### PR TITLE
MOE Sync 2020-04-28

### DIFF
--- a/java/dagger/hilt/android/example/gradle/simple/app/build.gradle
+++ b/java/dagger/hilt/android/example/gradle/simple/app/build.gradle
@@ -47,6 +47,8 @@ dependencies {
   testImplementation 'com.google.truth:truth:1.0.1'
   testImplementation 'junit:junit:4.13'
   testImplementation 'org.robolectric:robolectric:4.3'
+  testImplementation 'androidx.test.ext:junit:1.1.1'
+  testImplementation 'androidx.test:runner:1.2.0'
   // TODO(bcorso): This multidex dep shouldn't be required -- it's a dep for the generated code.
   testImplementation 'androidx.multidex:multidex:2.0.0'
   testImplementation 'com.google.dagger:hilt-android-testing:LOCAL-SNAPSHOT'
@@ -54,6 +56,7 @@ dependencies {
   testAnnotationProcessor 'com.google.dagger:hilt-android-compiler:LOCAL-SNAPSHOT'
 
   androidTestImplementation 'com.google.truth:truth:1.0.1'
+  androidTestImplementation 'androidx.test.ext:junit:1.1.1'
   androidTestImplementation 'androidx.test:runner:1.2.0'
   androidTestImplementation 'com.google.dagger:hilt-android-testing:LOCAL-SNAPSHOT'
   androidTestAnnotationProcessor 'com.google.dagger:dagger-compiler:LOCAL-SNAPSHOT'

--- a/java/dagger/hilt/android/example/gradle/simple/app/src/androidTest/java/dagger/hilt/android/example/gradle/simple/SimpleActivityEmulatorTest.java
+++ b/java/dagger/hilt/android/example/gradle/simple/app/src/androidTest/java/dagger/hilt/android/example/gradle/simple/SimpleActivityEmulatorTest.java
@@ -18,59 +18,35 @@ package dagger.hilt.android.example.gradle.simple;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import androidx.test.runner.AndroidJUnit4;
-import dagger.Module;
-import dagger.Provides;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import dagger.hilt.GenerateComponents;
-import dagger.hilt.InstallIn;
-import dagger.hilt.android.components.ApplicationComponent;
 import dagger.hilt.android.testing.AndroidEmulatorEntryPoint;
+import dagger.hilt.android.testing.BindValue;
 import dagger.hilt.android.testing.HiltEmulatorTestRule;
-import javax.inject.Inject;
+import dagger.hilt.android.testing.UninstallModules;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /** A simple test using Hilt. */
+@UninstallModules(UserNameModule.class)
 @GenerateComponents
 @AndroidEmulatorEntryPoint
 @RunWith(AndroidJUnit4.class)
-public final class SimpleEmulatorTest {
-  private static final int TEST_VALUE = 9;
-
-  @Module
-  @InstallIn(ApplicationComponent.class)
-  interface TestModule {
-    @Provides
-    static int provideInt() {
-      return TEST_VALUE;
-    }
-  }
-
-  static class Foo {
-    final int value;
-
-    @Inject
-    Foo(int value) {
-      this.value = value;
-    }
-  }
+public final class SimpleActivityEmulatorTest {
 
   @Rule public HiltEmulatorTestRule rule = new HiltEmulatorTestRule(this);
 
-  @Inject @Model String model;
-  @Inject Foo foo;
-
-  // TODO(user): Add @BindValue
+  @BindValue @UserName String fakeUserName = "FakeUser";
 
   @Test
-  public void testInject() throws Exception {
-    assertThat(model).isNull();
-
-    SimpleEmulatorTest_Application.get().inject(this);
-
-    assertThat(model).isNotNull();
-    assertThat(model).isEqualTo(android.os.Build.MODEL);
+  public void testActivityInject() throws Exception {
+    try (ActivityScenario<SimpleActivity> scenario =
+        ActivityScenario.launch(SimpleActivity.class)) {
+      scenario.onActivity(
+          activity -> assertThat(activity.greeter.greet()).isEqualTo("Hello, FakeUser!"));
+    }
   }
 
   // TODO(user): Add multiple test cases. Currently, we can't because the test rule will be set

--- a/java/dagger/hilt/android/example/gradle/simple/app/src/androidTest/java/dagger/hilt/android/example/gradle/simple/SimpleEmulatorTestRunner.java
+++ b/java/dagger/hilt/android/example/gradle/simple/app/src/androidTest/java/dagger/hilt/android/example/gradle/simple/SimpleEmulatorTestRunner.java
@@ -27,6 +27,7 @@ public final class SimpleEmulatorTestRunner extends AndroidJUnitRunner {
   public Application newApplication(ClassLoader cl, String className, Context context)
       throws ClassNotFoundException, IllegalAccessException, InstantiationException {
     // TODO(user): Update this to support multiple emulator tests.
-    return super.newApplication(cl, SimpleEmulatorTest_Application.class.getName(), context);
+    return super.newApplication(
+        cl, SimpleActivityEmulatorTest_Application.class.getName(), context);
   }
 }

--- a/java/dagger/hilt/android/example/gradle/simple/app/src/debug/AndroidManifest.xml
+++ b/java/dagger/hilt/android/example/gradle/simple/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright (C) 2017 The Dagger Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="dagger.hilt.android.example.gradle.simple">
+
+  <application>
+    <activity
+        android:name=".Injection1Test$TestActivity"
+        android:theme="@style/Theme.AppCompat.Light"
+        android:exported="false" />
+    <activity
+        android:name=".Injection2Test$TestActivity"
+        android:theme="@style/Theme.AppCompat.Light"
+        android:exported="false"/>
+  </application>
+</manifest>

--- a/java/dagger/hilt/android/example/gradle/simple/app/src/test/java/dagger/hilt/android/example/gradle/simple/BindValueTest.java
+++ b/java/dagger/hilt/android/example/gradle/simple/app/src/test/java/dagger/hilt/android/example/gradle/simple/BindValueTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2020 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.hilt.android.example.gradle.simple;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.os.Build;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.common.collect.ImmutableSet;
+import dagger.MapKey;
+import dagger.hilt.EntryPoint;
+import dagger.hilt.EntryPoints;
+import dagger.hilt.GenerateComponents;
+import dagger.hilt.InstallIn;
+import dagger.hilt.android.components.ApplicationComponent;
+import dagger.hilt.android.testing.AndroidRobolectricEntryPoint;
+import dagger.hilt.android.testing.BindElementsIntoSet;
+import dagger.hilt.android.testing.BindValue;
+import dagger.hilt.android.testing.BindValueIntoMap;
+import dagger.hilt.android.testing.BindValueIntoSet;
+import dagger.hilt.android.testing.HiltRobolectricTestRule;
+import java.util.Map;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+/** A simple test using Hilt. */
+@GenerateComponents
+@AndroidRobolectricEntryPoint
+@RunWith(AndroidJUnit4.class)
+// Robolectric requires Java9 to run API 29 and above, so use API 28 instead
+@Config(sdk = Build.VERSION_CODES.P, application = BindValueTest_Application.class)
+public final class BindValueTest {
+  private static final String BIND_VALUE_STRING = "BIND_VALUE_STRING";
+  private static final String TEST_QUALIFIER = "TEST_QUALIFIER";
+
+  private static final String SET_STRING_1 = "SetString1";
+  private static final String SET_STRING_2 = "SetString2";
+  private static final String SET_STRING_3 = "SetString3";
+
+  private static final String KEY_1 = "Key1";
+  private static final String KEY_2 = "Key2";
+  private static final String VALUE_1 = "Value1";
+  private static final String VALUE_2 = "Value2";
+  private static final String VALUE_3 = "Value3";
+
+  private static final Integer SET_INT_1 = 1;
+  private static final Integer SET_INT_2 = 2;
+  private static final Integer SET_INT_3 = 3;
+
+  @EntryPoint
+  @InstallIn(ApplicationComponent.class)
+  interface BindValueEntryPoint {
+    @Named(TEST_QUALIFIER)
+    String bindValueString();
+
+    Set<String> getStringSet();
+  }
+
+  @Rule public HiltRobolectricTestRule rule = new HiltRobolectricTestRule(this);
+
+  @BindValue
+  @Named(TEST_QUALIFIER)
+  String bindValueString = BIND_VALUE_STRING;
+
+  @BindElementsIntoSet Set<String> bindElementsSet1 = ImmutableSet.of(SET_STRING_1);
+  @BindElementsIntoSet Set<String> bindElementsSet2 = ImmutableSet.of(SET_STRING_2);
+
+  @BindValueIntoMap
+  @MyMapKey(KEY_1)
+  String boundValue1 = VALUE_1;
+
+  @BindValueIntoMap
+  @MyMapKey(KEY_2)
+  String boundValue2 = VALUE_2;
+
+  @BindValueIntoSet Integer bindValueSetInt1 = SET_INT_1;
+  @BindValueIntoSet Integer bindValueSetInt2 = SET_INT_2;
+
+  @Inject Set<String> stringSet;
+  @Inject Provider<Set<String>> providedStringSet;
+  @Inject Provider<Map<String, String>> mapProvider;
+  @Inject Set<Integer> intSet;
+  @Inject Provider<Set<Integer>> providedIntSet;
+
+  @Test
+  public void testBindValueFieldIsProvided() throws Exception {
+    assertThat(bindValueString).isEqualTo(BIND_VALUE_STRING);
+    assertThat(getBinding()).isEqualTo(BIND_VALUE_STRING);
+  }
+
+  @Test
+  public void testBindValueIsMutable() throws Exception {
+    bindValueString = "newValue";
+    assertThat(getBinding()).isEqualTo("newValue");
+  }
+
+  @Test
+  public void testElementsIntoSet() throws Exception {
+    BindValueTest_Application.get().inject(this);
+    // basic check that initial/default values are properly injected
+    assertThat(providedStringSet.get()).containsExactly(SET_STRING_1, SET_STRING_2);
+    // Test empty sets (something that cannot be done with @BindValueIntoSet)
+    bindElementsSet1 = ImmutableSet.of();
+    bindElementsSet2 = ImmutableSet.of();
+    assertThat(providedStringSet.get()).isEmpty();
+    // Test multiple elements in set.
+    bindElementsSet1 = ImmutableSet.of(SET_STRING_1, SET_STRING_2, SET_STRING_3);
+    assertThat(providedStringSet.get()).containsExactly(SET_STRING_1, SET_STRING_2, SET_STRING_3);
+  }
+
+  @Test
+  public void testBindValueIntoMap() throws Exception {
+    BindValueTest_Application.get().inject(this);
+    Map<String, String> oldMap = mapProvider.get();
+    assertThat(oldMap).containsExactly(KEY_1, VALUE_1, KEY_2, VALUE_2);
+    boundValue1 = VALUE_3;
+    Map<String, String> newMap = mapProvider.get();
+    assertThat(oldMap).containsExactly(KEY_1, VALUE_1, KEY_2, VALUE_2);
+    assertThat(newMap).containsExactly(KEY_1, VALUE_3, KEY_2, VALUE_2);
+  }
+
+  @Test
+  public void testBindValueIntoSet() throws Exception {
+    BindValueTest_Application.get().inject(this);
+    // basic check that initial/default values are properly injected
+    assertThat(providedIntSet.get()).containsExactly(SET_INT_1, SET_INT_2);
+    bindValueSetInt1 = SET_INT_3;
+    // change the value for bindValueSetString from 1 to 3
+    assertThat(providedIntSet.get()).containsExactly(SET_INT_2, SET_INT_3);
+  }
+
+  @MapKey
+  @interface MyMapKey {
+    String value();
+  }
+
+  private static String getBinding() {
+    return EntryPoints.get(BindValueTest_Application.get(), BindValueEntryPoint.class)
+        .bindValueString();
+  }
+}

--- a/java/dagger/hilt/android/example/gradle/simple/app/src/test/java/dagger/hilt/android/example/gradle/simple/Injection1Test.java
+++ b/java/dagger/hilt/android/example/gradle/simple/app/src/test/java/dagger/hilt/android/example/gradle/simple/Injection1Test.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2020 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.hilt.android.example.gradle.simple;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.os.Build;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import dagger.Module;
+import dagger.Provides;
+import dagger.hilt.GenerateComponents;
+import dagger.hilt.InstallIn;
+import dagger.hilt.android.AndroidEntryPoint;
+import dagger.hilt.android.components.ActivityComponent;
+import dagger.hilt.android.components.ApplicationComponent;
+import dagger.hilt.android.testing.AndroidRobolectricEntryPoint;
+import dagger.hilt.android.testing.HiltRobolectricTestRule;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+/** Tests basic injection APIs, and that bindings don't conflict with {@link Injection2Test}. */
+@GenerateComponents
+@AndroidRobolectricEntryPoint
+@RunWith(AndroidJUnit4.class)
+// Robolectric requires Java9 to run API 29 and above, so use API 28 instead
+@Config(sdk = Build.VERSION_CODES.P, application = Injection1Test_Application.class)
+public final class Injection1Test {
+  private static final String APPLICATION_QUALIFIER = "APPLICATION_QUALIFIER";
+  private static final String ACTIVITY_QUALIFIER = "ACTIVITY_QUALIFIER";
+  private static final String APPLICATION_VALUE = "Injection1Test_ApplicationValue";
+  private static final String ACTIVITY_VALUE = "Injection1Test_ActivityValue";
+
+  @Module
+  @InstallIn(ApplicationComponent.class)
+  interface TestApplicationModule {
+    @Provides
+    @Named(APPLICATION_QUALIFIER)
+    static String provideString() {
+      return APPLICATION_VALUE;
+    }
+  }
+
+  @Module
+  @InstallIn(ActivityComponent.class)
+  interface TestActivityModule {
+    @Provides
+    @Named(ACTIVITY_QUALIFIER)
+    static String provideString() {
+      return ACTIVITY_VALUE;
+    }
+  }
+
+  /** Test activity used to test activity injection */
+  @AndroidEntryPoint(AppCompatActivity.class)
+  public static final class TestActivity extends Hilt_Injection1Test_TestActivity {
+    @Inject @Named(ACTIVITY_QUALIFIER) String activityValue;
+  }
+
+  @Rule public HiltRobolectricTestRule rule = new HiltRobolectricTestRule(this);
+
+  @Inject @Named(APPLICATION_QUALIFIER) String applicationValue;
+
+  @Test
+  public void testApplicationInjection() throws Exception {
+    assertThat(applicationValue).isNull();
+    Injection1Test_Application.get().inject(this);
+    assertThat(applicationValue).isEqualTo(APPLICATION_VALUE);
+  }
+
+  @Test
+  public void testActivityInjection() throws Exception {
+    try (ActivityScenario<TestActivity> scenario =
+        ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(activity -> assertThat(activity.activityValue).isEqualTo(ACTIVITY_VALUE));
+    }
+  }
+}

--- a/java/dagger/hilt/android/example/gradle/simple/app/src/test/java/dagger/hilt/android/example/gradle/simple/Injection2Test.java
+++ b/java/dagger/hilt/android/example/gradle/simple/app/src/test/java/dagger/hilt/android/example/gradle/simple/Injection2Test.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2020 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.hilt.android.example.gradle.simple;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.os.Build;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import dagger.Module;
+import dagger.Provides;
+import dagger.hilt.GenerateComponents;
+import dagger.hilt.InstallIn;
+import dagger.hilt.android.AndroidEntryPoint;
+import dagger.hilt.android.components.ActivityComponent;
+import dagger.hilt.android.components.ApplicationComponent;
+import dagger.hilt.android.testing.AndroidRobolectricEntryPoint;
+import dagger.hilt.android.testing.HiltRobolectricTestRule;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+/** Tests basic injection APIs, and that bindings don't conflict with {@link Injection1Test}. */
+@GenerateComponents
+@AndroidRobolectricEntryPoint
+@RunWith(AndroidJUnit4.class)
+// Robolectric requires Java9 to run API 29 and above, so use API 28 instead
+@Config(sdk = Build.VERSION_CODES.P, application = Injection2Test_Application.class)
+public final class Injection2Test {
+  private static final String APPLICATION_QUALIFIER = "APPLICATION_QUALIFIER";
+  private static final String ACTIVITY_QUALIFIER = "ACTIVITY_QUALIFIER";
+  private static final String APPLICATION_VALUE = "Injection2Test_ApplicationValue";
+  private static final String ACTIVITY_VALUE = "Injection2Test_ActivityValue";
+
+  @Module
+  @InstallIn(ApplicationComponent.class)
+  interface TestApplicationModule {
+    @Provides
+    @Named(APPLICATION_QUALIFIER)
+    static String provideString() {
+      return APPLICATION_VALUE;
+    }
+  }
+
+  @Module
+  @InstallIn(ActivityComponent.class)
+  interface TestActivityModule {
+    @Provides
+    @Named(ACTIVITY_QUALIFIER)
+    static String provideString() {
+      return ACTIVITY_VALUE;
+    }
+  }
+
+  /** Test activity used to test activity injection */
+  @AndroidEntryPoint(AppCompatActivity.class)
+  public static final class TestActivity extends Hilt_Injection2Test_TestActivity {
+    @Inject @Named(ACTIVITY_QUALIFIER) String activityValue;
+  }
+
+  @Rule public HiltRobolectricTestRule rule = new HiltRobolectricTestRule(this);
+
+  @Inject @Named(APPLICATION_QUALIFIER) String applicationValue;
+
+  @Test
+  public void testApplicationInjection() throws Exception {
+    assertThat(applicationValue).isNull();
+    Injection2Test_Application.get().inject(this);
+    assertThat(applicationValue).isEqualTo(APPLICATION_VALUE);
+  }
+
+  @Test
+  public void testActivityInjection() throws Exception {
+    try (ActivityScenario<TestActivity> scenario =
+        ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(activity -> assertThat(activity.activityValue).isEqualTo(ACTIVITY_VALUE));
+    }
+  }
+}

--- a/java/dagger/hilt/android/example/gradle/simple/app/src/test/java/dagger/hilt/android/example/gradle/simple/SettingsActivityTest.java
+++ b/java/dagger/hilt/android/example/gradle/simple/app/src/test/java/dagger/hilt/android/example/gradle/simple/SettingsActivityTest.java
@@ -19,101 +19,48 @@ package dagger.hilt.android.example.gradle.simple;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.os.Build;
-import dagger.Module;
-import dagger.Provides;
-import dagger.hilt.EntryPoint;
-import dagger.hilt.EntryPoints;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import dagger.hilt.GenerateComponents;
-import dagger.hilt.InstallIn;
-import dagger.hilt.android.components.ApplicationComponent;
 import dagger.hilt.android.testing.AndroidRobolectricEntryPoint;
 import dagger.hilt.android.testing.BindValue;
 import dagger.hilt.android.testing.HiltRobolectricTestRule;
 import dagger.hilt.android.testing.UninstallModules;
 import javax.inject.Inject;
-import javax.inject.Named;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 /** A simple test using Hilt. */
 @UninstallModules(ModelModule.class)
 @GenerateComponents
 @AndroidRobolectricEntryPoint
-@RunWith(RobolectricTestRunner.class)
+@RunWith(AndroidJUnit4.class)
 // Robolectric requires Java9 to run API 29 and above, so use API 28 instead
 @Config(sdk = Build.VERSION_CODES.P, application = SettingsActivityTest_Application.class)
 public final class SettingsActivityTest {
-  private static final String FAKE_MODEL = "FakeModel";
-  private static final int TEST_VALUE = 11;
-
-  private static final String BIND_VALUE_STRING = "BIND_VALUE_STRING";
-  private static final String TEST_QUALIFIER = "TEST_QUALIFIER";
-
-  @Module
-  @InstallIn(ApplicationComponent.class)
-  interface TestModule {
-    @Provides
-    @Model
-    static String provideFakeModel() {
-      return FAKE_MODEL;
-    }
-
-    @Provides
-    static int provideInt() {
-      return TEST_VALUE;
-    }
-  }
-
-  @EntryPoint
-  @InstallIn(ApplicationComponent.class)
-  interface BindValueEntryPoint {
-    @Named(TEST_QUALIFIER)
-    String bindValueString();
-  }
-
   @Rule public HiltRobolectricTestRule rule = new HiltRobolectricTestRule(this);
 
-  @Inject Integer intValue;
+  @BindValue @Model String fakeModel = "FakeModel";
 
-  @BindValue
-  @Named(TEST_QUALIFIER)
-  String bindValueString = BIND_VALUE_STRING;
+  @Inject @Model String injectedModel;
 
   @Test
-  public void testInject() throws Exception {
-    assertThat(intValue).isNull();
-
+  public void testInjectedModel() throws Exception {
+    assertThat(injectedModel).isNull();
     SettingsActivityTest_Application.get().inject(this);
-
-    assertThat(intValue).isNotNull();
-    assertThat(intValue).isEqualTo(TEST_VALUE);
+    assertThat(injectedModel).isEqualTo("FakeModel");
   }
 
   @Test
   public void testActivityInject() throws Exception {
-    SettingsActivity activity = Robolectric.setupActivity(SettingsActivity.class);
-    assertThat(activity.greeter.greet())
-        .isEqualTo("ProdUser, you are on build FakeModel.");
-  }
-
-  @Test
-  public void testBindValueIsMutable() throws Exception {
-    bindValueString = "newValue";
-    assertThat(getBinding()).isEqualTo("newValue");
-  }
-
-  @Test
-  public void testBindValueFieldIsProvided() throws Exception {
-    assertThat(bindValueString).isEqualTo(BIND_VALUE_STRING);
-    assertThat(getBinding()).isEqualTo(BIND_VALUE_STRING);
-  }
-
-  private static String getBinding() {
-    return EntryPoints.get(SettingsActivityTest_Application.get(), BindValueEntryPoint.class)
-        .bindValueString();
+    try (ActivityScenario<SettingsActivity> scenario =
+        ActivityScenario.launch(SettingsActivity.class)) {
+      scenario.onActivity(
+          activity ->
+              assertThat(activity.greeter.greet())
+                  .isEqualTo("ProdUser, you are on build FakeModel."));
+    }
   }
 }

--- a/java/dagger/hilt/android/example/gradle/simple/app/src/test/java/dagger/hilt/android/example/gradle/simple/SimpleActivityTest.java
+++ b/java/dagger/hilt/android/example/gradle/simple/app/src/test/java/dagger/hilt/android/example/gradle/simple/SimpleActivityTest.java
@@ -19,187 +19,47 @@ package dagger.hilt.android.example.gradle.simple;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.os.Build;
-import com.google.common.collect.ImmutableSet;
-import dagger.MapKey;
-import dagger.Module;
-import dagger.Provides;
-import dagger.hilt.EntryPoint;
-import dagger.hilt.EntryPoints;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import dagger.hilt.GenerateComponents;
-import dagger.hilt.InstallIn;
-import dagger.hilt.android.components.ApplicationComponent;
 import dagger.hilt.android.testing.AndroidRobolectricEntryPoint;
-import dagger.hilt.android.testing.BindElementsIntoSet;
 import dagger.hilt.android.testing.BindValue;
-import dagger.hilt.android.testing.BindValueIntoMap;
-import dagger.hilt.android.testing.BindValueIntoSet;
 import dagger.hilt.android.testing.HiltRobolectricTestRule;
 import dagger.hilt.android.testing.UninstallModules;
-import java.util.Map;
-import java.util.Set;
 import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Provider;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 /** A simple test using Hilt. */
 @UninstallModules(UserNameModule.class)
 @GenerateComponents
 @AndroidRobolectricEntryPoint
-@RunWith(RobolectricTestRunner.class)
+@RunWith(AndroidJUnit4.class)
 // Robolectric requires Java9 to run API 29 and above, so use API 28 instead
 @Config(sdk = Build.VERSION_CODES.P, application = SimpleActivityTest_Application.class)
 public final class SimpleActivityTest {
-  private static final String FAKE_USER_NAME = "FakeUser";
-  private static final int TEST_VALUE = 9;
-
-  private static final String BIND_VALUE_STRING = "BIND_VALUE_STRING";
-  private static final String TEST_QUALIFIER = "TEST_QUALIFIER";
-
-  private static final String SET_STRING_1 = "SetString1";
-  private static final String SET_STRING_2 = "SetString2";
-  private static final String SET_STRING_3 = "SetString3";
-
-  private static final String KEY_1 = "Key1";
-  private static final String KEY_2 = "Key2";
-  private static final String VALUE_1 = "Value1";
-  private static final String VALUE_2 = "Value2";
-  private static final String VALUE_3 = "Value3";
-
-  private static final Integer SET_INT_1 = 1;
-  private static final Integer SET_INT_2 = 2;
-  private static final Integer SET_INT_3 = 3;
-
-  @Module
-  @InstallIn(ApplicationComponent.class)
-  interface TestModule {
-    @Provides
-    @UserName
-    static String provideFakeUserName() {
-      return FAKE_USER_NAME;
-    }
-
-    @Provides
-    static int provideInt() {
-      return TEST_VALUE;
-    }
-  }
-
-  @EntryPoint
-  @InstallIn(ApplicationComponent.class)
-  interface BindValueEntryPoint {
-    @Named(TEST_QUALIFIER)
-    String bindValueString();
-
-    Set<String> getStringSet();
-  }
-
   @Rule public HiltRobolectricTestRule rule = new HiltRobolectricTestRule(this);
 
-  @BindValue
-  @Named(TEST_QUALIFIER)
-  String bindValueString = BIND_VALUE_STRING;
+  @BindValue @UserName String fakeUserName = "FakeUser";
 
-  @BindElementsIntoSet Set<String> bindElementsSet1 = ImmutableSet.of(SET_STRING_1);
-  @BindElementsIntoSet Set<String> bindElementsSet2 = ImmutableSet.of(SET_STRING_2);
-
-  @BindValueIntoMap
-  @MyMapKey(KEY_1)
-  String boundValue1 = VALUE_1;
-
-  @BindValueIntoMap
-  @MyMapKey(KEY_2)
-  String boundValue2 = VALUE_2;
-
-  @BindValueIntoSet Integer bindValueSetInt1 = SET_INT_1;
-  @BindValueIntoSet Integer bindValueSetInt2 = SET_INT_2;
-
-  @Inject Integer intValue;
-
-  @Inject Set<String> stringSet;
-  @Inject Provider<Set<String>> providedStringSet;
-
-  @Inject Provider<Map<String, String>> mapProvider;
-
-  @Inject Set<Integer> intSet;
-  @Inject Provider<Set<Integer>> providedIntSet;
+  @Inject @UserName String injectedUserName;
 
   @Test
-  public void testInject() throws Exception {
-    assertThat(intValue).isNull();
-
+  public void testInjectedUserName() throws Exception {
+    assertThat(injectedUserName).isNull();
     SimpleActivityTest_Application.get().inject(this);
-
-    assertThat(intValue).isNotNull();
-    assertThat(intValue).isEqualTo(TEST_VALUE);
+    assertThat(injectedUserName).isEqualTo("FakeUser");
   }
 
   @Test
   public void testActivityInject() throws Exception {
-    SimpleActivity activity = Robolectric.setupActivity(SimpleActivity.class);
-    assertThat(activity.greeter.greet())
-        .isEqualTo("Hello, FakeUser!");
-  }
-
-  @Test
-  public void testBindValueFieldIsProvided() throws Exception {
-    assertThat(bindValueString).isEqualTo(BIND_VALUE_STRING);
-    assertThat(getBinding()).isEqualTo(BIND_VALUE_STRING);
-  }
-
-  @Test
-  public void testBindValueIsMutable() throws Exception {
-    bindValueString = "newValue";
-    assertThat(getBinding()).isEqualTo("newValue");
-  }
-
-  @Test
-  public void testElementsIntoSet() throws Exception {
-    SimpleActivityTest_Application.get().inject(this);
-    // basic check that initial/default values are properly injected
-    assertThat(providedStringSet.get()).containsExactly(SET_STRING_1, SET_STRING_2);
-    // Test empty sets (something that cannot be done with @BindValueIntoSet)
-    bindElementsSet1 = ImmutableSet.of();
-    bindElementsSet2 = ImmutableSet.of();
-    assertThat(providedStringSet.get()).isEmpty();
-    // Test multiple elements in set.
-    bindElementsSet1 = ImmutableSet.of(SET_STRING_1, SET_STRING_2, SET_STRING_3);
-    assertThat(providedStringSet.get()).containsExactly(SET_STRING_1, SET_STRING_2, SET_STRING_3);
-  }
-
-  @Test
-  public void testBindValueIntoMap() throws Exception {
-    SimpleActivityTest_Application.get().inject(this);
-    Map<String, String> oldMap = mapProvider.get();
-    assertThat(oldMap).containsExactly(KEY_1, VALUE_1, KEY_2, VALUE_2);
-    boundValue1 = VALUE_3;
-    Map<String, String> newMap = mapProvider.get();
-    assertThat(oldMap).containsExactly(KEY_1, VALUE_1, KEY_2, VALUE_2);
-    assertThat(newMap).containsExactly(KEY_1, VALUE_3, KEY_2, VALUE_2);
-  }
-
-  @Test
-  public void testBindValueIntoSet() throws Exception {
-    SimpleActivityTest_Application.get().inject(this);
-    // basic check that initial/default values are properly injected
-    assertThat(providedIntSet.get()).containsExactly(SET_INT_1, SET_INT_2);
-    bindValueSetInt1 = SET_INT_3;
-    // change the value for bindValueSetString from 1 to 3
-    assertThat(providedIntSet.get()).containsExactly(SET_INT_2, SET_INT_3);
-  }
-
-  @MapKey
-  @interface MyMapKey {
-    String value();
-  }
-
-  private static String getBinding() {
-    return EntryPoints.get(SimpleActivityTest_Application.get(), BindValueEntryPoint.class)
-        .bindValueString();
+    try (ActivityScenario<SimpleActivity> scenario =
+        ActivityScenario.launch(SimpleActivity.class)) {
+      scenario.onActivity(
+          activity -> assertThat(activity.greeter.greet())
+              .isEqualTo("Hello, FakeUser!"));
+    }
   }
 }

--- a/java/dagger/hilt/android/processor/internal/bindvalue/BindValueGenerator.java
+++ b/java/dagger/hilt/android/processor/internal/bindvalue/BindValueGenerator.java
@@ -51,14 +51,12 @@ final class BindValueGenerator {
   private final BindValueMetadata metadata;
   private final ClassName testClassName;
   private final ClassName className;
-  private final ClassName appClassName;
 
   BindValueGenerator(ProcessingEnvironment env, BindValueMetadata metadata) {
     this.env = env;
     this.metadata = metadata;
     testClassName = ClassName.get(metadata.testElement());
     className = Processors.append(testClassName, SUFFIX);
-    appClassName = Processors.append(testClassName, "_Application");
   }
 
   //  @Module
@@ -94,7 +92,7 @@ final class BindValueGenerator {
 
   // @Provides
   // static FooTest providesFooTest(@ApplicationContext Context context) {
-  //   return (FooTest)((FooTest_Application) context).getTestInstance();
+  //   return (FooTest)((TestInstanceHolder) context).getTestInstance();
   // }
   private MethodSpec providesTestMethod() {
     String methodName = "provides" + testClassName.simpleName();
@@ -108,7 +106,9 @@ final class BindValueGenerator {
                     .build())
             .returns(testClassName)
             .addStatement(
-                "return ($T)(($T) context).getTestInstance()", testClassName, appClassName);
+                "return ($T)(($T) context).getTestInstance()",
+                testClassName,
+                ClassNames.TEST_INSTANCE_HOLDER);
     return builder.build();
   }
 

--- a/java/dagger/hilt/android/processor/internal/testing/TestApplicationGenerator.java
+++ b/java/dagger/hilt/android/processor/internal/testing/TestApplicationGenerator.java
@@ -324,7 +324,7 @@ public final class TestApplicationGenerator {
         .returns(appName)
         .addParameter(testName, varName)
         .addStatement("testInstance = $L", varName)
-        .addStatement("componentManager.setBindValueCalled()")
+        .addStatement("componentManager.setBindValueCalled(testInstance)")
         .addStatement("return this")
         .build();
   }

--- a/java/dagger/hilt/android/testing/BUILD
+++ b/java/dagger/hilt/android/testing/BUILD
@@ -103,7 +103,7 @@ android_library(
         "//java/dagger/hilt/android/internal/testing:test_instance_holder",
         "//java/dagger/hilt/internal:preconditions",
         "@google_bazel_common//third_party/java/junit",
-        "@maven//:androidx_test_monitor",
+        "@maven//:androidx_test_core",
     ],
 )
 

--- a/java/dagger/hilt/android/testing/HiltEmulatorTestRule.java
+++ b/java/dagger/hilt/android/testing/HiltEmulatorTestRule.java
@@ -17,7 +17,7 @@
 package dagger.hilt.android.testing;
 
 import android.content.Context;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import dagger.hilt.android.internal.testing.TestApplicationComponentManager;
 import dagger.hilt.android.internal.testing.TestApplicationComponentManagerHolder;
 import dagger.hilt.android.internal.testing.TestInstanceHolder;
@@ -40,7 +40,7 @@ public final class HiltEmulatorTestRule implements TestRule {
   public HiltEmulatorTestRule(Object testClassInstance) {
     this.testClassInstance = testClassInstance;
 
-    Context applicationContext = InstrumentationRegistry.getTargetContext();
+    Context applicationContext = ApplicationProvider.getApplicationContext();
     rules = RuleChain.outerRule(new MarkThatRulesRanRule(applicationContext));
 
     if (applicationContext instanceof TestInstanceHolder) {
@@ -51,7 +51,7 @@ public final class HiltEmulatorTestRule implements TestRule {
       Object componentManager =
           ((TestApplicationComponentManagerHolder) applicationContext).componentManager();
       Preconditions.checkState(componentManager instanceof TestApplicationComponentManager, "");
-      ((TestApplicationComponentManager) componentManager).setBindValueCalled();
+      ((TestApplicationComponentManager) componentManager).setBindValueCalled(testClassInstance);
     }
   }
 

--- a/java/dagger/hilt/android/testing/HiltRobolectricTestRule.java
+++ b/java/dagger/hilt/android/testing/HiltRobolectricTestRule.java
@@ -16,6 +16,7 @@
 
 package dagger.hilt.android.testing;
 
+import static dagger.hilt.internal.Preconditions.checkNotNull;
 import static dagger.hilt.internal.Preconditions.checkState;
 
 import android.content.Context;
@@ -43,6 +44,7 @@ public final class HiltRobolectricTestRule implements TestRule {
   }
 
   public HiltRobolectricTestRule(Object testClassInstance) {
+    checkNotNull(testClassInstance);
     this.testClassInstance = testClassInstance;
 
     Context applicationContext = ApplicationProvider.getApplicationContext();
@@ -57,7 +59,7 @@ public final class HiltRobolectricTestRule implements TestRule {
           componentManager instanceof TestApplicationComponentManager,
           "Expected TestApplicationComponentManagerHolder to return an instance of"
               + "TestApplicationComponentManager");
-      ((TestApplicationComponentManager) componentManager).setBindValueCalled();
+      ((TestApplicationComponentManager) componentManager).setBindValueCalled(testClassInstance);
     }
   }
 

--- a/util/run-local-tests.sh
+++ b/util/run-local-tests.sh
@@ -18,8 +18,8 @@ util/install-local-snapshot.sh
 readonly _HILT_GRADLE_PLUGIN_DIR=java/dagger/hilt/android/plugin
 readonly _HILT_ANDROID_EXAMPLE_DIR=java/dagger/hilt/android/example/gradle/simple
 ./$_HILT_GRADLE_PLUGIN_DIR/gradlew -p $_HILT_GRADLE_PLUGIN_DIR test --no-daemon --stacktrace
-./$_HILT_ANDROID_EXAMPLE_DIR/gradlew -p $_HILT_ANDROID_EXAMPLE_DIR build --no-daemon --stacktrace
-./$_HILT_ANDROID_EXAMPLE_DIR/gradlew -p $_HILT_ANDROID_EXAMPLE_DIR test --no-daemon --stacktrace
+./$_HILT_ANDROID_EXAMPLE_DIR/gradlew -p $_HILT_ANDROID_EXAMPLE_DIR buildDebug --no-daemon --stacktrace
+./$_HILT_ANDROID_EXAMPLE_DIR/gradlew -p $_HILT_ANDROID_EXAMPLE_DIR testDebug --no-daemon --stacktrace
 
 verify_version_file() {
   local m2_repo=$1


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Roll forward (try 2): Organize Hilt gradle example tests and update to use ActivityScenario.

New: The issue was a deadlock with the synchronization. To fix, I've removed the synchronization completely, since it was an unrelated change to the rest of the CL. I filed a bug and it will be address separately from this CL (see b/154964957).

*** Original change description ***

Roll forward: Organize Hilt gradle example tests and update to use ActivityScenario.

New: Allow TestApplicationComponentMa...

***

RELNOTES=N/A

4a45681faf9a9aa7e3deb829f7f9999fe8757aa0

-------

<p> Change BindValueProcessor generated modules to reference TestInstanceHolder rather than referencing the generated application.

This makes the code a bit more robust to changes to the application name.

RELNOTES=N/A

4024aa5403b811ed6c5637a40176ad4045dfaaf2