### PR TITLE
Upstream DoNotCallProvidersDetector

### DIFF
--- a/java/dagger/lint/DoNotCallProvidersDetector.kt
+++ b/java/dagger/lint/DoNotCallProvidersDetector.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dagger.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.getParentOfType
+import java.util.EnumSet
+
+/**
+ * A [Detector] that checks that user code does not manually call dagger provider code, as these
+ * methods are intended to only be called from generated Dagger code.
+ */
+@Suppress("UnstableApiUsage")
+class DoNotCallProvidersDetector : Detector(), SourceCodeScanner {
+
+  companion object {
+    // We use the overloaded constructor that takes a varargs of `Scope` as the last param.
+    // This is to enable on-the-fly IDE checks. We are telling lint to run on both
+    // JAVA and TEST_SOURCES in the `scope` parameter but by providing the `analysisScopes`
+    // params, we're indicating that this check can run on either JAVA or TEST_SOURCES and
+    // doesn't require both of them together.
+    // From discussion on lint-dev https://groups.google.com/d/msg/lint-dev/ULQMzW1ZlP0/1dG4Vj3-AQAJ
+    // This was supposed to be fixed in AS 3.4 but still required as recently as 3.6.
+    private val SCOPES = Implementation(
+        DoNotCallProvidersDetector::class.java,
+        EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES),
+        EnumSet.of(Scope.JAVA_FILE),
+        EnumSet.of(Scope.TEST_SOURCES)
+    )
+
+    val ISSUE: Issue = Issue.create(
+        "DoNotCallProviders",
+        "Dagger provider methods should not be called directly by user code.",
+        """
+          Dagger provider methods should not be called directly by user code. These are intended solely for use by 
+          Dagger-generated code and it is programmer error to call them from user code.
+        """.trimIndent(),
+        Category.CORRECTNESS,
+        6,
+        Severity.ERROR,
+        SCOPES
+    )
+
+    private val PROVIDER_ANNOTATIONS = setOf("dagger.Binds", "dagger.Provides", "dagger.producers.Produces")
+    private val GENERATED_ANNOTATIONS = setOf("javax.annotation.Generated", "javax.annotation.processing.Generated")
+  }
+
+  override fun getApplicableUastTypes() = listOf(UCallExpression::class.java)
+
+  override fun createUastHandler(context: JavaContext) = object : UElementHandler() {
+    override fun visitCallExpression(node: UCallExpression) {
+      val enclosingClass = node.getParentOfType<UClass>() ?: return
+      if (GENERATED_ANNOTATIONS.any(enclosingClass::hasAnnotation)) return
+      val method = node.resolve() ?: return
+      if (PROVIDER_ANNOTATIONS.any(method::hasAnnotation)) {
+        context.report(
+            ISSUE,
+            context.getLocation(node),
+            ISSUE.getBriefDescription(TextFormat.TEXT)
+        )
+      }
+    }
+  }
+}

--- a/javatests/dagger/lint/BUILD
+++ b/javatests/dagger/lint/BUILD
@@ -31,3 +31,16 @@ kt_jvm_test(
         "@maven//:org_jetbrains_kotlin_kotlin_stdlib",
     ],
 )
+
+kt_jvm_test(
+    name = "DoNotCallProvidersDetectorTest",
+    srcs = ["DoNotCallProvidersDetectorTest.kt"],
+    deps = [
+        "//java/dagger/lint:lint-artifact-lib",
+        "@google_bazel_common//third_party/java/junit",
+        "@maven//:com_android_tools_lint_lint_checks",
+        "@maven//:com_android_tools_lint_lint_tests",
+        "@maven//:com_android_tools_testutils",
+        "@maven//:org_jetbrains_kotlin_kotlin_stdlib",
+    ],
+)

--- a/javatests/dagger/lint/DoNotCallProvidersDetectorTest.kt
+++ b/javatests/dagger/lint/DoNotCallProvidersDetectorTest.kt
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2020 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dagger.lint
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+
+@Suppress("UnstableApiUsage")
+@RunWith(JUnit4::class)
+class DoNotCallProvidersDetectorTest : LintDetectorTest() {
+
+  private companion object {
+    private val javaxAnnotation = kotlin(
+        """
+        package javax.annotation
+    
+        annotation class Generated(val message: String)
+      """
+    ).indented()
+    private val daggerStubs = kotlin(
+        """
+        package dagger
+    
+        annotation class Binds
+        annotation class Provides
+        annotation class Module
+      """
+    ).indented()
+
+    private val daggerProducerStubs = kotlin(
+        """
+        package dagger.producers
+    
+        annotation class Produces
+      """
+    ).indented()
+  }
+
+  override fun getDetector() = DoNotCallProvidersDetector()
+  override fun getIssues() = listOf(DoNotCallProvidersDetector.ISSUE)
+
+  @Test
+  fun kotlin() {
+    lint()
+        .allowMissingSdk()
+        .files(
+            javaxAnnotation,
+            daggerStubs,
+            daggerProducerStubs,
+            kotlin(
+                """
+                  package foo
+                  import dagger.Binds
+                  import dagger.Module
+                  import dagger.Provides
+                  import dagger.producers.Produces
+                  import javax.annotation.Generated
+                  
+                  @Module
+                  abstract class MyModule {
+                    
+                    @Binds fun binds1(input: String): Comparable<String>
+                    @Binds fun String.binds2(): Comparable<String>
+                    
+                    fun badCode() {
+                      binds1("this is bad")
+                      "this is bad".binds2()
+                      provider()
+                      producer()
+                    }
+                    
+                    companion object {
+                      @Provides
+                      fun provider(): String {
+                        return ""
+                      }
+                      @Produces
+                      fun producer(): String {
+                        return ""
+                      }
+                    }
+                  }
+                  
+                  @Generated("Totes generated code")
+                  abstract class GeneratedCode {
+                    fun doStuff() {
+                      moduleInstance().binds1("this is technically fine but would never happen in dagger")
+                      MyModule.provider()
+                      MyModule.producer()
+                    }
+                    
+                    abstract fun moduleInstance(): MyModule
+                  }
+                """
+            ).indented()
+        )
+        .allowCompilationErrors(false)
+        .run()
+        .expect(
+            """
+              src/foo/MyModule.kt:15: Error: Dagger provider methods should not be called directly by user code. [DoNotCallProviders]
+                  binds1("this is bad")
+                  ~~~~~~~~~~~~~~~~~~~~~
+              src/foo/MyModule.kt:16: Error: Dagger provider methods should not be called directly by user code. [DoNotCallProviders]
+                  "this is bad".binds2()
+                   ~~~~~~~~~~~~~~~~~~~~~
+              src/foo/MyModule.kt:17: Error: Dagger provider methods should not be called directly by user code. [DoNotCallProviders]
+                  provider()
+                  ~~~~~~~~~~
+              src/foo/MyModule.kt:18: Error: Dagger provider methods should not be called directly by user code. [DoNotCallProviders]
+                  producer()
+                  ~~~~~~~~~~
+              4 errors, 0 warnings
+            """.trimIndent()
+        )
+  }
+
+  @Test
+  fun java() {
+    lint()
+        .allowMissingSdk()
+        .files(
+            javaxAnnotation,
+            daggerStubs,
+            daggerProducerStubs,
+            java(
+                """
+                  package foo;
+                  import dagger.Binds;
+                  import dagger.Module;
+                  import dagger.Provides;
+                  import dagger.producers.Produces;
+                  import javax.annotation.Generated;
+                  
+                  class Holder {
+                    @Module
+                    abstract class MyModule {
+                      
+                      @Binds Comparable<String> binds1(String input);
+                      
+                      void badCode() {
+                        binds1("this is bad");
+                        provider();
+                        producer();
+                      }
+                      
+                      @Provides
+                      static String provider() {
+                        return "";
+                      }
+                      @Produces
+                      static String producer() {
+                        return "";
+                      }
+                    }
+                    
+                    @Generated("Totes generated code")
+                    abstract class GeneratedCode {
+                      void doStuff() {
+                        moduleInstance().binds1("this is technically fine but would never happen in dagger");
+                        MyModule.provider();
+                        MyModule.producer();
+                      }
+                      
+                      abstract MyModule moduleInstance();
+                    }
+                  }
+                """
+            ).indented()
+        )
+        .allowCompilationErrors(false)
+        .run()
+        .expect(
+            """
+              src/foo/Holder.java:15: Error: Dagger provider methods should not be called directly by user code. [DoNotCallProviders]
+                    binds1("this is bad");
+                    ~~~~~~~~~~~~~~~~~~~~~
+              src/foo/Holder.java:16: Error: Dagger provider methods should not be called directly by user code. [DoNotCallProviders]
+                    provider();
+                    ~~~~~~~~~~
+              src/foo/Holder.java:17: Error: Dagger provider methods should not be called directly by user code. [DoNotCallProviders]
+                    producer();
+                    ~~~~~~~~~~
+              3 errors, 0 warnings
+            """.trimIndent()
+        )
+  }
+}


### PR DESCRIPTION
This adds a lint that detects user-code calls to Dagger provider methods, which are intended to just be called by generated dagger code. We currently run this as an error, but open to making it just a warning as a (likely) code smell. I'd recommend error and allow suppression as-needed.

CC @danysantiago @bcorso @Chang-Eric 