### PR TITLE
MOE Sync 2020-05-14

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -74,12 +74,14 @@ jarjar_library(
 # coalesced javadocs used for the gh-pages site
 javadoc_library(
     name = "user-docs",
+    testonly = 1,
     srcs = [
         "//java/dagger:javadoc-srcs",
         "//java/dagger/android:android-srcs",
         "//java/dagger/android/support:support-srcs",
         "//java/dagger/grpc/server:javadoc-srcs",
         "//java/dagger/grpc/server/processor:javadoc-srcs",
+        "//java/dagger/hilt:javadoc-srcs",
         "//java/dagger/producers:producers-srcs",
         "//java/dagger/spi:spi-srcs",
     ],
@@ -87,6 +89,8 @@ javadoc_library(
     # TODO(ronshapiro): figure out how to specify the version number for release builds
     doctitle = "Dagger Dependency Injection API",
     exclude_packages = [
+        "dagger.hilt.android.internal",
+        "dagger.hilt.internal",
         "dagger.internal",
         "dagger.producers.internal",
         "dagger.producers.monitoring.internal",
@@ -98,6 +102,8 @@ javadoc_library(
         "//java/dagger/android/support",
         "//java/dagger/grpc/server",
         "//java/dagger/grpc/server/processor",
+        "//java/dagger/hilt/android:artifact-lib",
+        "//java/dagger/hilt/android/testing:artifact-lib",
         "//java/dagger/producers",
         "//java/dagger/spi",
     ],

--- a/java/dagger/android/support/AndroidSupportInjection.java
+++ b/java/dagger/android/support/AndroidSupportInjection.java
@@ -67,6 +67,14 @@ public final class AndroidSupportInjection {
     inject(fragment, hasAndroidInjector);
   }
 
+  private static void inject(Object target, HasAndroidInjector hasAndroidInjector) {
+    AndroidInjector<Object> androidInjector = hasAndroidInjector.androidInjector();
+    checkNotNull(
+        androidInjector, "%s.androidInjector() returned null", hasAndroidInjector.getClass());
+
+    androidInjector.inject(target);
+  }
+
   private static HasAndroidInjector findHasAndroidInjectorForFragment(Fragment fragment) {
     Fragment parentFragment = fragment;
     while ((parentFragment = parentFragment.getParentFragment()) != null) {
@@ -83,14 +91,6 @@ public final class AndroidSupportInjection {
     }
     throw new IllegalArgumentException(
         String.format("No injector was found for %s", fragment.getClass().getCanonicalName()));
-  }
-
-  private static void inject(Object target, HasAndroidInjector hasAndroidInjector) {
-    AndroidInjector<Object> androidInjector = hasAndroidInjector.androidInjector();
-    checkNotNull(
-        androidInjector, "%s.androidInjector() returned null", hasAndroidInjector.getClass());
-
-    androidInjector.inject(target);
   }
 
   private AndroidSupportInjection() {}

--- a/java/dagger/hilt/BUILD
+++ b/java/dagger/hilt/BUILD
@@ -95,3 +95,63 @@ java_library(
         "//java/dagger/hilt/internal/definecomponent",
     ],
 )
+
+filegroup(
+    name = "javadoc-srcs",
+    srcs = [
+        ":hilt_filegroup",
+        ":hilt_testing_filegroup",
+    ],
+)
+
+filegroup(
+    name = "hilt_filegroup",
+    srcs = glob(["*"]) + [
+        "//java/dagger/hilt/codegen:srcs_filegroup",
+        "//java/dagger/hilt/migration:srcs_filegroup",
+        "//java/dagger/hilt/internal:srcs_filegroup",
+        "//java/dagger/hilt/internal/aliasof:srcs_filegroup",
+        "//java/dagger/hilt/internal/definecomponent:srcs_filegroup",
+        "//java/dagger/hilt/internal/generatesrootinput:srcs_filegroup",
+        "//java/dagger/hilt/android:srcs_filegroup",
+        "//java/dagger/hilt/android/components:srcs_filegroup",
+        "//java/dagger/hilt/android/qualifiers:srcs_filegroup",
+        "//java/dagger/hilt/android/internal/builders:srcs_filegroup",
+        "//java/dagger/hilt/android/internal/lifecycle:srcs_filegroup",
+        "//java/dagger/hilt/android/internal/managers:srcs_filegroup",
+        "//java/dagger/hilt/android/internal/migration:srcs_filegroup",
+        "//java/dagger/hilt/android/internal/modules:srcs_filegroup",
+        "//java/dagger/hilt/android/migration:srcs_filegroup",
+        "//java/dagger/hilt/android/scopes:srcs_filegroup",
+        "//java/dagger/hilt/android/plugin:srcs_filegroup",
+    ],
+)
+
+filegroup(
+    name = "hilt_testing_filegroup",
+    srcs = [
+        "//java/dagger/hilt/android/internal/testing:srcs_filegroup",
+        "//java/dagger/hilt/android/testing:srcs_filegroup",
+    ],
+)
+
+filegroup(
+    name = "hilt_processing_filegroup",
+    srcs = [
+        "//java/dagger/hilt/android/processor:srcs_filegroup",
+        "//java/dagger/hilt/android/processor/internal:srcs_filegroup",
+        "//java/dagger/hilt/android/processor/internal/androidentrypoint:srcs_filegroup",
+        "//java/dagger/hilt/android/processor/internal/bindvalue:srcs_filegroup",
+        "//java/dagger/hilt/android/processor/internal/testapplicationvalidation:srcs_filegroup",
+        "//java/dagger/hilt/android/processor/internal/testroot:srcs_filegroup",
+        "//java/dagger/hilt/android/processor/internal/uninstallmodules:srcs_filegroup",
+        "//java/dagger/hilt/processor/internal:srcs_filegroup",
+        "//java/dagger/hilt/processor/internal/aggregateddeps:srcs_filegroup",
+        "//java/dagger/hilt/processor/internal/aliasof:srcs_filegroup",
+        "//java/dagger/hilt/processor/internal/definecomponent:srcs_filegroup",
+        "//java/dagger/hilt/processor/internal/disableinstallincheck:srcs_filegroup",
+        "//java/dagger/hilt/processor/internal/generatesrootinput:srcs_filegroup",
+        "//java/dagger/hilt/processor/internal/originatingelement:srcs_filegroup",
+        "//java/dagger/hilt/processor/internal/root:srcs_filegroup",
+    ],
+)

--- a/java/dagger/hilt/android/BUILD
+++ b/java/dagger/hilt/android/BUILD
@@ -87,9 +87,6 @@ android_library(
 android_library(
     name = "artifact-lib",
     tags = ["maven_coordinates=com.google.dagger:hilt-android:" + POM_VERSION],
-    visibility = [
-        "//java/dagger/hilt/android/testing:__pkg__",
-    ],
     exports = [
         ":entry_point_accessors",
         "//java/dagger/hilt:entry_point",
@@ -117,7 +114,9 @@ gen_maven_artifact(
     javadoc_root_packages = [
         "dagger.hilt",
     ],
-    javadoc_srcs = glob(["*.java"]),  # TODO(user): Fix these srcs.
+    javadoc_srcs = [
+        "//java/dagger/hilt:hilt_filegroup",
+    ],
     manifest = "AndroidManifest.xml",
     packaging = "aar",
     shaded_deps = ["@com_google_auto_auto_common//jar"],
@@ -155,4 +154,9 @@ gen_maven_artifact(
         "//java/dagger/hilt/migration:disable_install_in_check",
         "//java/dagger/hilt/processor/internal/aggregateddeps:annotation",
     ],
+)
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
 )

--- a/java/dagger/hilt/android/BUILD
+++ b/java/dagger/hilt/android/BUILD
@@ -93,7 +93,6 @@ android_library(
     exports = [
         ":entry_point_accessors",
         "//java/dagger/hilt:entry_point",
-        "//java/dagger/hilt:generate_components",
         "//java/dagger/hilt:generates_root_input",
         "//java/dagger/hilt:install_in",
         "//java/dagger/hilt/android:android_entry_point",
@@ -127,7 +126,6 @@ gen_maven_artifact(
         ":entry_point_accessors",
         "//java/dagger/hilt:define_component",
         "//java/dagger/hilt:entry_point",
-        "//java/dagger/hilt:generate_components",
         "//java/dagger/hilt:generates_root_input",
         "//java/dagger/hilt:install_in",
         "//java/dagger/hilt/android:android_entry_point",

--- a/java/dagger/hilt/android/components/BUILD
+++ b/java/dagger/hilt/android/components/BUILD
@@ -27,3 +27,8 @@ android_library(
         "@google_bazel_common//third_party/java/jsr330_inject",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/android/example/gradle/simple/BUILD
+++ b/java/dagger/hilt/android/example/gradle/simple/BUILD
@@ -16,3 +16,8 @@
 #   A skeletal application that demonstrates wiring for an injected Application and Activity.
 
 package(default_visibility = ["//:src"])
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["**/*"]),
+)

--- a/java/dagger/hilt/android/example/gradle/simpleKotlin/BUILD
+++ b/java/dagger/hilt/android/example/gradle/simpleKotlin/BUILD
@@ -16,3 +16,8 @@
 #   A skeletal Kotlin application that demonstrates wiring for an injected Application and Activity.
 
 package(default_visibility = ["//:src"])
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["**/*"]),
+)

--- a/java/dagger/hilt/android/internal/builders/BUILD
+++ b/java/dagger/hilt/android/internal/builders/BUILD
@@ -28,3 +28,8 @@ android_library(
         "@maven//:androidx_fragment_fragment",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/android/internal/lifecycle/BUILD
+++ b/java/dagger/hilt/android/internal/lifecycle/BUILD
@@ -31,3 +31,8 @@ android_library(
         "@maven//:androidx_lifecycle_lifecycle_viewmodel",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/android/internal/managers/BUILD
+++ b/java/dagger/hilt/android/internal/managers/BUILD
@@ -47,3 +47,8 @@ android_library(
         "@maven//:androidx_lifecycle_lifecycle_viewmodel",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/android/internal/migration/BUILD
+++ b/java/dagger/hilt/android/internal/migration/BUILD
@@ -21,3 +21,8 @@ android_library(
     name = "injected_by_hilt",
     srcs = ["InjectedByHilt.java"],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/android/internal/modules/BUILD
+++ b/java/dagger/hilt/android/internal/modules/BUILD
@@ -28,3 +28,8 @@ android_library(
         "@maven//:androidx_fragment_fragment",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/android/internal/testing/BUILD
+++ b/java/dagger/hilt/android/internal/testing/BUILD
@@ -77,3 +77,8 @@ android_library(
         "@maven//:androidx_test_core",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["**/*"]),
+)

--- a/java/dagger/hilt/android/migration/BUILD
+++ b/java/dagger/hilt/android/migration/BUILD
@@ -24,3 +24,8 @@ android_library(
         "//java/dagger/hilt/android/internal/migration:injected_by_hilt",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["**/*"]),
+)

--- a/java/dagger/hilt/android/plugin/BUILD
+++ b/java/dagger/hilt/android/plugin/BUILD
@@ -16,3 +16,8 @@
 #   A Gradle plugin that performs a transform.
 
 package(default_visibility = ["//:src"])
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["**/*"]),
+)

--- a/java/dagger/hilt/android/processor/BUILD
+++ b/java/dagger/hilt/android/processor/BUILD
@@ -44,14 +44,9 @@ gen_maven_artifact(
     artifact_id = "hilt-android-compiler",
     artifact_name = "Hilt Android Processor",
     artifact_target = ":artifact-lib",
-    javadoc_root_packages = [
-        "dagger.hilt.processor",
-    ],
-    javadoc_srcs = [
-        "//java/dagger/hilt/processor/internal/root:RootProcessor.java",
-    ],
     shaded_deps = ["@com_google_auto_auto_common//jar"],
     shaded_rules = ["rule com.google.auto.common.** dagger.shaded.auto.common.@1"],
+    # Do not publish javadocs for processor classes as they are internal.
     deps = [
         "//java/dagger/hilt/android/processor/internal:android_classnames",
         "//java/dagger/hilt/android/processor/internal:utils",
@@ -85,4 +80,9 @@ gen_maven_artifact(
         "//java/dagger/hilt/processor/internal/root:root_metadata",
         "//java/dagger/hilt/processor/internal/root:root_type",
     ],
+)
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
 )

--- a/java/dagger/hilt/android/processor/internal/BUILD
+++ b/java/dagger/hilt/android/processor/internal/BUILD
@@ -38,3 +38,8 @@ java_library(
         "//java/dagger/internal/guava:collect",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["**/*"]),
+)

--- a/java/dagger/hilt/android/processor/internal/androidentrypoint/BUILD
+++ b/java/dagger/hilt/android/processor/internal/androidentrypoint/BUILD
@@ -99,3 +99,8 @@ java_library(
     name = "compiler_options",
     srcs = ["HiltCompilerOptions.java"],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/android/processor/internal/bindvalue/BUILD
+++ b/java/dagger/hilt/android/processor/internal/bindvalue/BUILD
@@ -50,3 +50,8 @@ java_library(
         "@google_bazel_common//third_party/java/jsr330_inject",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/android/processor/internal/testapplicationvalidation/BUILD
+++ b/java/dagger/hilt/android/processor/internal/testapplicationvalidation/BUILD
@@ -42,3 +42,8 @@ java_library(
         "@google_bazel_common//third_party/java/javapoet",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/android/processor/internal/testroot/BUILD
+++ b/java/dagger/hilt/android/processor/internal/testroot/BUILD
@@ -45,3 +45,8 @@ java_library(
         "@google_bazel_common//third_party/java/jsr250_annotations",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/android/processor/internal/uninstallmodules/BUILD
+++ b/java/dagger/hilt/android/processor/internal/uninstallmodules/BUILD
@@ -41,3 +41,8 @@ java_library(
         "@google_bazel_common//third_party/java/incap",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/android/qualifiers/BUILD
+++ b/java/dagger/hilt/android/qualifiers/BUILD
@@ -24,3 +24,8 @@ android_library(
         "@google_bazel_common//third_party/java/jsr330_inject",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/android/scopes/BUILD
+++ b/java/dagger/hilt/android/scopes/BUILD
@@ -33,3 +33,8 @@ android_library(
     srcs = ["ActivityRetainedScoped.java"],
     deps = ["@google_bazel_common//third_party/java/jsr330_inject"],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/android/testing/BUILD
+++ b/java/dagger/hilt/android/testing/BUILD
@@ -123,7 +123,6 @@ android_library(
     name = "artifact-lib",
     testonly = 1,
     tags = ["maven_coordinates=com.google.dagger:hilt-android-testing:" + POM_VERSION],
-    visibility = ["//visibility:private"],
     exports = [
         ":bind_value",
         ":hilt_android_test",
@@ -140,10 +139,16 @@ gen_maven_artifact(
     artifact_name = "Hilt Android Testing",
     artifact_target = ":artifact-lib",
     javadoc_android_api_level = 29,
+    javadoc_exclude_packages = [
+        "dagger.hilt.internal",
+        "dagger.hilt.android.internal",
+    ],
     javadoc_root_packages = [
         "dagger.hilt.android.testing",
     ],
-    javadoc_srcs = glob(["*.java"]),
+    javadoc_srcs = [
+        "//java/dagger/hilt:hilt_testing_filegroup",
+    ],
     manifest = "AndroidManifest.xml",
     packaging = "aar",
     shaded_deps = ["@com_google_auto_auto_common//jar"],
@@ -161,4 +166,9 @@ gen_maven_artifact(
         "//java/dagger/hilt/android/testing:on_component_ready_runner",
         "//java/dagger/hilt/android/testing:uninstall_modules",
     ],
+)
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
 )

--- a/java/dagger/hilt/codegen/BUILD
+++ b/java/dagger/hilt/codegen/BUILD
@@ -24,3 +24,8 @@ java_library(
         "//java/dagger/hilt/processor/internal/originatingelement:processor",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/internal/BUILD
+++ b/java/dagger/hilt/internal/BUILD
@@ -60,3 +60,8 @@ java_library(
     srcs = ["GeneratedEntryPoint.java"],
     deps = ["//java/dagger/hilt:generates_root_input"],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/internal/aliasof/BUILD
+++ b/java/dagger/hilt/internal/aliasof/BUILD
@@ -21,3 +21,8 @@ android_library(
     name = "aliasof",
     srcs = ["AliasOfPropagatedData.java"],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/internal/definecomponent/BUILD
+++ b/java/dagger/hilt/internal/definecomponent/BUILD
@@ -25,3 +25,8 @@ java_library(
         "//java/dagger/hilt/android:__pkg__",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/internal/generatesrootinput/BUILD
+++ b/java/dagger/hilt/internal/generatesrootinput/BUILD
@@ -21,3 +21,8 @@ java_library(
     name = "generatesrootinput",
     srcs = ["GeneratesRootInputPropagatedData.java"],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/migration/BUILD
+++ b/java/dagger/hilt/migration/BUILD
@@ -43,3 +43,8 @@ java_library(
         "@google_bazel_common//third_party/java/jsr250_annotations",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/processor/internal/BUILD
+++ b/java/dagger/hilt/processor/internal/BUILD
@@ -128,3 +128,8 @@ java_library(
         "@google_bazel_common//third_party/java/javapoet",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/processor/internal/aggregateddeps/BUILD
+++ b/java/dagger/hilt/processor/internal/aggregateddeps/BUILD
@@ -83,3 +83,8 @@ java_library(
         "@google_bazel_common//third_party/java/javapoet",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/processor/internal/aliasof/BUILD
+++ b/java/dagger/hilt/processor/internal/aliasof/BUILD
@@ -57,3 +57,8 @@ java_library(
         "@google_bazel_common//third_party/java/javapoet",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/processor/internal/definecomponent/BUILD
+++ b/java/dagger/hilt/processor/internal/definecomponent/BUILD
@@ -60,3 +60,8 @@ java_library(
         "@google_bazel_common//third_party/java/javapoet",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/processor/internal/disableinstallincheck/BUILD
+++ b/java/dagger/hilt/processor/internal/disableinstallincheck/BUILD
@@ -42,3 +42,8 @@ java_library(
         "@google_bazel_common//third_party/java/incap",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/processor/internal/generatesrootinput/BUILD
+++ b/java/dagger/hilt/processor/internal/generatesrootinput/BUILD
@@ -58,3 +58,8 @@ java_library(
         "@google_bazel_common//third_party/java/javapoet",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/processor/internal/originatingelement/BUILD
+++ b/java/dagger/hilt/processor/internal/originatingelement/BUILD
@@ -40,3 +40,8 @@ java_library(
         "@google_bazel_common//third_party/java/incap",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/java/dagger/hilt/processor/internal/root/BUILD
+++ b/java/dagger/hilt/processor/internal/root/BUILD
@@ -94,3 +94,8 @@ java_library(
         "@google_bazel_common//third_party/java/javapoet",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/javatests/dagger/hilt/android/processor/BUILD
+++ b/javatests/dagger/hilt/android/processor/BUILD
@@ -35,3 +35,8 @@ java_library(
         "@google_bazel_common//third_party/java/compile_testing",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/javatests/dagger/hilt/android/processor/internal/androidentrypoint/AndroidEntryPointProcessorTest.java
+++ b/javatests/dagger/hilt/android/processor/internal/androidentrypoint/AndroidEntryPointProcessorTest.java
@@ -96,37 +96,15 @@ public class AndroidEntryPointProcessorTest {
             "package test;",
             "",
             "import android.app.Application;",
-            "import dagger.hilt.GenerateComponents;",
-            "import dagger.hilt.android.AndroidEntryPoint;",
+            "import dagger.hilt.android.HiltAndroidApp;",
             "",
-            "@GenerateComponents",
-            "@AndroidEntryPoint",
+            "@HiltAndroidApp",
             "public class MyApp extends Application { }");
     Compilation compilation =
         compiler()
             .withOptions("-Adagger.hilt.android.internal.disableAndroidSuperclassValidation=true")
             .compile(testApplication);
     assertThat(compilation).succeeded();
-  }
-
-  @Test
-  public void appMissingGenerateComponenets() {
-    JavaFileObject testApplication =
-        JavaFileObjects.forSourceLines(
-            "test.MyApp",
-            "package test;",
-            "",
-            "import android.app.Application;",
-            "import dagger.hilt.GenerateComponents;",
-            "import dagger.hilt.android.AndroidEntryPoint;",
-            "",
-            "@AndroidEntryPoint(Application.class)",
-            "public class MyApp extends Hilt_MyApp { }");
-    Compilation compilation = compiler().compile(testApplication);
-    assertThat(compilation).failed();
-    assertThat(compilation)
-        .hadErrorContaining("Applications annotated with @AndroidEntryPoint must also be "
-            + "annotated with @GenerateComponents");
   }
 
   @Test

--- a/javatests/dagger/hilt/android/processor/internal/androidentrypoint/BUILD
+++ b/javatests/dagger/hilt/android/processor/internal/androidentrypoint/BUILD
@@ -22,7 +22,6 @@ compiler_test(
     name = "ActivityGeneratorTest",
     srcs = ["ActivityGeneratorTest.java"],
     compiler_deps = [
-        "//java/dagger/hilt:generate_components",
         "//java/dagger/hilt/android:android_entry_point",
         "@androidsdk//:platforms/android-29/android.jar",
     ],
@@ -38,7 +37,7 @@ compiler_test(
     name = "AndroidEntryPointProcessorTest",
     srcs = ["AndroidEntryPointProcessorTest.java"],
     compiler_deps = [
-        "//java/dagger/hilt:generate_components",
+        "//java/dagger/hilt/android:hilt_android_app",
         "//java/dagger/hilt/android:android_entry_point",
         "@androidsdk//:platforms/android-29/android.jar",
     ],

--- a/javatests/dagger/hilt/android/processor/internal/androidentrypoint/BUILD
+++ b/javatests/dagger/hilt/android/processor/internal/androidentrypoint/BUILD
@@ -48,3 +48,8 @@ compiler_test(
         "@google_bazel_common//third_party/java/truth",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/javatests/dagger/hilt/processor/internal/BUILD
+++ b/javatests/dagger/hilt/processor/internal/BUILD
@@ -33,3 +33,8 @@ java_library(
     name = "generated_import",
     srcs = ["GeneratedImport.java"],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["**/*"]),
+)

--- a/javatests/dagger/hilt/processor/internal/aggregateddeps/BUILD
+++ b/javatests/dagger/hilt/processor/internal/aggregateddeps/BUILD
@@ -43,3 +43,8 @@ compiler_test(
         "@google_bazel_common//third_party/java/truth",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/javatests/dagger/hilt/processor/internal/definecomponent/BUILD
+++ b/javatests/dagger/hilt/processor/internal/definecomponent/BUILD
@@ -39,3 +39,8 @@ GenJavaTests(
         "@google_bazel_common//third_party/java/truth",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/javatests/dagger/hilt/processor/internal/disableinstallincheck/BUILD
+++ b/javatests/dagger/hilt/processor/internal/disableinstallincheck/BUILD
@@ -36,3 +36,8 @@ compiler_test(
         "@google_bazel_common//third_party/java/truth",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["*"]),
+)

--- a/javatests/dagger/hilt/processor/internal/generatesrootinput/BUILD
+++ b/javatests/dagger/hilt/processor/internal/generatesrootinput/BUILD
@@ -38,3 +38,8 @@ GenJavaTests(
         "@google_bazel_common//third_party/java/truth",
     ],
 )
+
+filegroup(
+    name = "srcs_filegroup",
+    srcs = glob(["**/*"]),
+)

--- a/util/deploy-hilt.sh
+++ b/util/deploy-hilt.sh
@@ -44,8 +44,8 @@ _deploy \
 _deploy \
   java/dagger/hilt/android/processor/artifact.jar \
   java/dagger/hilt/android/processor/pom.xml \
-  java/dagger/hilt/android/processor/artifact-src.jar \
-  java/dagger/hilt/android/processor/artifact-javadoc.jar
+  "" \
+  ""
 
 # Gradle Plugin is built with Gradle, but still deployed via Maven (mvn)
 readonly _HILT_GRADLE_PLUGIN_DIR=java/dagger/hilt/android/plugin

--- a/util/deploy-to-maven-central.sh
+++ b/util/deploy-to-maven-central.sh
@@ -29,6 +29,13 @@ bash $(dirname $0)/deploy-dagger.sh \
   "-Durl=https://oss.sonatype.org/service/local/staging/deploy/maven2/" \
   "-Dgpg.keyname=${KEY}"
 
+bash $(dirname $0)/deploy-hilt.sh \
+  "gpg:sign-and-deploy-file" \
+  "${VERSION_NAME}-alpha" \
+  "-DrepositoryId=sonatype-nexus-staging" \
+  "-Durl=https://oss.sonatype.org/service/local/staging/deploy/maven2/" \
+  "-Dgpg.keyname=${KEY}"
+
 # Publish javadocs to gh-pages
 bazel build //:user-docs.jar
 git clone --quiet --branch gh-pages \


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Constructors and methods with the same name should appear sequentially with no other code in between. Please re-order or re-name methods.

fd4558d0637674c4f3d43c66d657b66c2e5ba0a2

-------

<p> Change usages of @GenerateComponents to @HiltAndroidApp.

7c75fe5bee2b759b0e688f85b5a5829a2e1bbd42

-------

<p> Add Hilt to the Maven central deploy script.

Hilt artifact versions will contain an appended '-alpha' after the
version number. E.g. if Dagger is 2.28, Hilt will be 2.28-alpha.
Neither snapshot releases (all version HEAD-SNAPSHOT) nor local
snapshots (all version LOCAL-SNAPSHOT) are affected.

14632bef3d968a84de7742617431f0b40a1b0167

-------

<p> Fix javadoc srcs for Hilt.

51d11283943d4f64e44ce50886985a2ef37e40a5