### PR TITLE
MOE Sync 2020-06-17

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -90,6 +90,7 @@ maven_install(
         "com.android.tools.lint:lint-checks:%s" % ANDROID_LINT_VERSION,
         "com.android.tools.lint:lint-tests:%s" % ANDROID_LINT_VERSION,
         "com.android.tools:testutils:%s" % ANDROID_LINT_VERSION,
+        "com.github.tschuchortdev:kotlin-compile-testing:1.2.8",
         "com.google.guava:guava:27.1-android",
         "org.jetbrains.kotlin:kotlin-stdlib:1.3.50",
         "org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0",

--- a/javatests/dagger/hilt/android/processor/AndroidCompilers.java
+++ b/javatests/dagger/hilt/android/processor/AndroidCompilers.java
@@ -33,6 +33,7 @@ import dagger.testing.compile.CompilerTests;
 import java.util.Arrays;
 import java.util.Map;
 import javax.annotation.processing.Processor;
+import com.tschuchort.compiletesting.KotlinCompilation;
 
 /** {@link Compiler} instances for testing Android Hilt. */
 public final class AndroidCompilers {
@@ -47,6 +48,18 @@ public final class AndroidCompilers {
         .forEach(processor -> processors.put(processor.getClass(), processor));
 
     return CompilerTests.compiler().withProcessors(processors.values());
+  }
+
+  public static KotlinCompilation kotlinCompiler() {
+    KotlinCompilation compilation = new KotlinCompilation();
+    compilation.setAnnotationProcessors(defaultProcessors());
+    compilation.setClasspaths(
+        ImmutableList.<java.io.File>builder()
+            .addAll(compilation.getClasspaths())
+            .add(CompilerTests.compilerDepsJar())
+            .build()
+    );
+    return compilation;
   }
 
   private static ImmutableList<Processor> defaultProcessors() {

--- a/javatests/dagger/hilt/android/processor/BUILD
+++ b/javatests/dagger/hilt/android/processor/BUILD
@@ -33,6 +33,7 @@ java_library(
         "//java/dagger/internal/guava:collect",
         "//java/dagger/testing/compile",
         "@google_bazel_common//third_party/java/compile_testing",
+        "@maven//:com_github_tschuchortdev_kotlin_compile_testing",
     ],
 )
 

--- a/javatests/dagger/hilt/android/processor/internal/androidentrypoint/BUILD
+++ b/javatests/dagger/hilt/android/processor/internal/androidentrypoint/BUILD
@@ -49,6 +49,23 @@ compiler_test(
     ],
 )
 
+compiler_test(
+    name = "KotlinAndroidEntryPointProcessorTest",
+    srcs = ["KotlinAndroidEntryPointProcessorTest.java"],
+    compiler_deps = [
+        "//java/dagger/hilt/android:hilt_android_app",
+        "//java/dagger/hilt/android:android_entry_point",
+        "@androidsdk//:platforms/android-29/android.jar",
+    ],
+    deps = [
+        "//java/dagger/internal/guava:collect",
+        "//javatests/dagger/hilt/android/processor:android_compilers",
+        "@google_bazel_common//third_party/java/junit",
+        "@google_bazel_common//third_party/java/truth",
+        "@maven//:com_github_tschuchortdev_kotlin_compile_testing",
+    ],
+)
+
 filegroup(
     name = "srcs_filegroup",
     srcs = glob(["*"]),

--- a/javatests/dagger/hilt/android/processor/internal/androidentrypoint/KotlinAndroidEntryPointProcessorTest.java
+++ b/javatests/dagger/hilt/android/processor/internal/androidentrypoint/KotlinAndroidEntryPointProcessorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.hilt.android.processor.internal.androidentrypoint;
+
+import static dagger.hilt.android.processor.AndroidCompilers.kotlinCompiler;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.truth.Truth;
+import com.tschuchort.compiletesting.KotlinCompilation;
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode;
+import com.tschuchort.compiletesting.SourceFile;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class KotlinAndroidEntryPointProcessorTest {
+  @Test
+  public void checkBaseClassConstructorHasNotDefaultParameters() {
+    SourceFile fragmentSrc = SourceFile.Companion.kotlin("MyFragment.kt",
+        String.join("\n",
+            "package test",
+            "",
+            "import dagger.hilt.android.AndroidEntryPoint",
+            "",
+            "@AndroidEntryPoint",
+            "class MyFragment : BaseFragment()"
+        ),
+        false);
+    SourceFile baseFragmentSrc = SourceFile.Companion.kotlin("BaseFragment.kt",
+        String.join("\n",
+            "package test",
+            "",
+            "import androidx.fragment.app.Fragment",
+            "",
+            "abstract class BaseFragment(layoutId: Int = 0) : Fragment()"
+        ),
+        false);
+    KotlinCompilation compilation = kotlinCompiler();
+    compilation.setSources(ImmutableList.of(fragmentSrc, baseFragmentSrc));
+    compilation.setKaptArgs(ImmutableMap.of(
+        "dagger.hilt.android.internal.disableAndroidSuperclassValidation", "true"));
+    KotlinCompilation.Result result = compilation.compile();
+    Truth.assertThat(result.getExitCode()).isEqualTo(ExitCode.COMPILATION_ERROR);
+    Truth.assertThat(result.getMessages()).contains("The base class, 'test.BaseFragment', of the "
+        + "@AndroidEntryPoint, 'test.MyFragment', contains a constructor with default parameters. "
+        + "This is currently not supported by the Gradle plugin. Either specify the base class as "
+        + "described at https://dagger.dev/hilt/gradle-setup#why-use-the-plugin or remove the "
+        + "default value declaration.");
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Error out when default param is in constructor of base class.

This change detects when the immediate base class of an AndroidEntryPoint in
Kotlin has a constructor with default values. Hilt currently cannot bytecode
transform the op `invokespecial` when the ClassAndType ref points to the Kotlin
synthetic method with a `kotlin/jvm/internal/DefaultConstructorMarker` because
such method won't be present in the Java source generated Hilt_ class.

The correct transformation requires interpreting the bitmask to call the right
overloaded constructor. This means users have to use `@JvmOverloads` and
requires Hilt to know about the Kotlin compilers implementation and code
produced for methods with default values.

This helps detect https://github.com/google/dagger/issues/1904.

RELNOTES=Restrict usage of default params in constructor of immediate base class of an AndroidEntryPoint.

aeeef36d92092a4b849056821bc5cca5327e754b