### PR TITLE
MOE Sync 2020-06-17

### DIFF
--- a/java/dagger/hilt/android/processor/internal/androidentrypoint/ApplicationGenerator.java
+++ b/java/dagger/hilt/android/processor/internal/androidentrypoint/ApplicationGenerator.java
@@ -28,7 +28,6 @@ import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
 import dagger.hilt.android.processor.internal.AndroidClassNames;
-import dagger.hilt.processor.internal.ClassNames;
 import dagger.hilt.processor.internal.ComponentNames;
 import dagger.hilt.processor.internal.Processors;
 import java.io.IOException;
@@ -154,11 +153,10 @@ public final class ApplicationGenerator {
         .add("// This is a known unsafe cast, but is safe in the only correct use case:\n")
         .add("// $T extends $T\n", metadata.elementClassName(), metadata.generatedClassName())
         .addStatement(
-            "(($T) generatedComponent()).$L($T.<$T>unsafeCast(this))",
+            "(($T) generatedComponent()).$L($L)",
             metadata.injectorClassName(),
             metadata.injectMethodName(),
-            ClassNames.UNSAFE_CASTS,
-            metadata.elementClassName())
+            Generators.unsafeCastThisTo(metadata.elementClassName()))
         .build();
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Allow @AndroidEntryPoint base class to be @AndroidEntryPoint class when using plugin.

This fixes a bug when using the plugin where the child generated class uses `@Overrides void inject()` which fails because that method doesn't exist in an ancestor until after bytecode injection.

Fixes #1910

RELNOTES=Fix #1910: Allow usage of an @AndroidEntryPoint base class when using short-form notation with the hilt gradle plugin.

9bea9be64116107158057bfbd785677edeee3ce0