### PR TITLE
MOE Sync 2020-06-18

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,8 @@ mailing list.
 
 ### Bazel
 
-If you build with `bazel`, you will need to configure your top-level workspace
-to access Dagger/Hilt targets that export the proper dependencies and plugins.
-
 First, import the Dagger repository into your `WORKSPACE` file using
-[`http_archive`][bazel-external-deps], load the `DAGGER_ARTIFACTS` and
-`DAGGER_REPOSITORIES`, and add them to your list of [`maven_install`] artifacts.
+[`http_archive`][bazel-external-deps].
 
 Note: The `http_archive` must point to a tagged release of Dagger, not just any
 commit. The version of the Dagger artifacts will match the version of the tagged
@@ -45,6 +41,18 @@ http_archive(
     name = "dagger",
     urls = ["https://github.com/google/dagger/archive/dagger-<version>.zip"],
 )
+```
+
+Next you will need to setup targets that export the proper dependencies
+and plugins. Follow the sections below to setup the dependencies you need.
+
+#### Dagger Setup
+
+First, load the Dagger artifacts and repositories, and add them to your list of
+[`maven_install`] artifacts.
+
+```python
+# Top-level WORKSPACE file
 
 load("@dagger//:workspace_defs.bzl", "DAGGER_ARTIFACTS", "DAGGER_REPOSITORIES")
 
@@ -54,7 +62,8 @@ maven_install(
 )
 ```
 
-Next, load and call `dagger_rules` in your top-level `BUILD` file:
+Next, load and call [`dagger_rules`](https://github.com/google/dagger/blob/master/workspace_defs.bzl)
+in your top-level `BUILD` file:
 
 ```python
 # Top-level BUILD file
@@ -64,7 +73,7 @@ load("@dagger//:workspace_defs.bzl", "dagger_rules")
 dagger_rules()
 ```
 
-This will setup Dagger and Hilt build targets of the form `:<artifact_id>`.
+This will add the following Dagger build targets:
 (Note that these targets already export all of the dependencies and processors
 they need).
 
@@ -73,8 +82,88 @@ deps = [
     ":dagger",                  # For Dagger
     ":dagger-spi",              # For Dagger SPI
     ":dagger-producers",        # For Dagger Producers
+]
+```
+
+#### Dagger Android Setup
+
+First, load the Dagger Android artifacts and repositories, and add them to your
+list of [`maven_install`] artifacts.
+
+```python
+# Top-level WORKSPACE file
+
+load(
+    "@dagger//:workspace_defs.bzl",
+    "DAGGER_ANDROID_ARTIFACTS",
+    "DAGGER_ANDROID_REPOSITORIES"
+)
+
+maven_install(
+    artifacts = DAGGER_ANDROID_ARTIFACTS + [...],
+    repositories = DAGGER_ANDROID_REPOSITORIES + [...],
+)
+```
+
+Next, load and call [`dagger_android_rules`](https://github.com/google/dagger/blob/master/workspace_defs.bzl)
+in your top-level `BUILD` file:
+
+```python
+# Top-level BUILD file
+
+load("@dagger//:workspace_defs.bzl", "dagger_android_rules")
+
+dagger_android_rules()
+```
+
+This will add the following Dagger Android build targets:
+(Note that these targets already export all of the dependencies and processors
+they need).
+
+```python
+deps = [
     ":dagger-android",          # For Dagger Android
     ":dagger-android-support",  # For Dagger Android (Support)
+]
+```
+
+#### Hilt Android Setup
+
+First, load the Hilt Android artifacts and repositories, and add them to your
+list of [`maven_install`] artifacts.
+
+```python
+# Top-level WORKSPACE file
+
+load(
+    "@dagger//:workspace_defs.bzl",
+    "HILT_ANDROID_ARTIFACTS",
+    "HILT_ANDROID_REPOSITORIES"
+)
+
+maven_install(
+    artifacts = HILT_ANDROID_ARTIFACTS + [...],
+    repositories = HILT_ANDROID_REPOSITORIES + [...],
+)
+```
+
+Next, load and call [`hilt_android_rules`](https://github.com/google/dagger/blob/master/workspace_defs.bzl)
+in your top-level `BUILD` file:
+
+```python
+# Top-level BUILD file
+
+load("@dagger//:workspace_defs.bzl", "hilt_android_rules")
+
+hilt_android_rules()
+```
+
+This will add the following Hilt Android build targets:
+(Note that these targets already export all of the dependencies and processors
+they need).
+
+```python
+deps = [
     ":hilt-android",            # For Hilt Android
     ":hilt-android-testing",    # For Hilt Android Testing
 ]

--- a/examples/bazel/BUILD
+++ b/examples/bazel/BUILD
@@ -15,6 +15,8 @@
 # Description:
 #   Dagger Bazel examples
 
-load("@dagger//:workspace_defs.bzl", "dagger_rules")
+load("@dagger//:workspace_defs.bzl", "dagger_rules", "hilt_android_rules")
 
 dagger_rules()
+
+hilt_android_rules()

--- a/examples/bazel/WORKSPACE
+++ b/examples/bazel/WORKSPACE
@@ -25,7 +25,13 @@ local_repository(
     path = "../../",
 )
 
-load("@dagger//:workspace_defs.bzl", "DAGGER_ARTIFACTS", "DAGGER_REPOSITORIES")
+load(
+    "@dagger//:workspace_defs.bzl",
+    "DAGGER_ARTIFACTS",
+    "DAGGER_REPOSITORIES",
+    "HILT_ANDROID_ARTIFACTS",
+    "HILT_ANDROID_REPOSITORIES",
+)
 
 #########################
 # Load Android repository
@@ -71,7 +77,7 @@ http_archive(
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(
-    artifacts = DAGGER_ARTIFACTS + [
+    artifacts = DAGGER_ARTIFACTS + HILT_ANDROID_ARTIFACTS + [
         "androidx.test.ext:junit:1.1.1",
         "androidx.test:runner:1.1.1",
         "com.google.truth:truth:1.0.1",
@@ -79,5 +85,5 @@ maven_install(
         "org.robolectric:robolectric:4.1",
         "org.robolectric:annotations:4.1",
     ],
-    repositories = DAGGER_REPOSITORIES,
+    repositories = DAGGER_REPOSITORIES + HILT_ANDROID_REPOSITORIES,
 )

--- a/java/dagger/hilt/android/processor/internal/androidentrypoint/ApplicationGenerator.java
+++ b/java/dagger/hilt/android/processor/internal/androidentrypoint/ApplicationGenerator.java
@@ -28,7 +28,6 @@ import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
 import dagger.hilt.android.processor.internal.AndroidClassNames;
-import dagger.hilt.processor.internal.ClassNames;
 import dagger.hilt.processor.internal.ComponentNames;
 import dagger.hilt.processor.internal.Processors;
 import java.io.IOException;
@@ -154,11 +153,10 @@ public final class ApplicationGenerator {
         .add("// This is a known unsafe cast, but is safe in the only correct use case:\n")
         .add("// $T extends $T\n", metadata.elementClassName(), metadata.generatedClassName())
         .addStatement(
-            "(($T) generatedComponent()).$L($T.<$T>unsafeCast(this))",
+            "(($T) generatedComponent()).$L($L)",
             metadata.injectorClassName(),
             metadata.injectMethodName(),
-            ClassNames.UNSAFE_CASTS,
-            metadata.elementClassName())
+            Generators.unsafeCastThisTo(metadata.elementClassName()))
         .build();
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Allow @AndroidEntryPoint base class to be @AndroidEntryPoint class when using plugin.

This fixes a bug when using the plugin where the child generated class uses `@Overrides void inject()` which fails because that method doesn't exist in an ancestor until after bytecode injection.

Fixes #1910

RELNOTES=Fix #1910: Allow usage of an @AndroidEntryPoint base class when using short-form notation with the hilt gradle plugin.

a19c8b70b1203e8d2243b36dd9c863b47fbfd100

-------

<p> Split Dagger, Dagger Android, and Hilt Android setup for Bazel users

This allows Dagger users to configure targets without requiring android_sdk repository.

RELNOTES=N/A

292100dc4894c3f04d8d60189a6bb14634c7badf