### PR TITLE
MOE Sync 2020-07-08

### DIFF
--- a/java/dagger/hilt/android/plugin/src/main/kotlin/dagger/hilt/android/plugin/AndroidEntryPointClassTransformer.kt
+++ b/java/dagger/hilt/android/plugin/src/main/kotlin/dagger/hilt/android/plugin/AndroidEntryPointClassTransformer.kt
@@ -156,7 +156,11 @@ internal class AndroidEntryPointClassTransformer(
   ) {
     val constantPool = clazz.classFile.constPool
     clazz.declaredMethods
-      .filter { it.methodInfo.isMethod && !Modifier.isStatic(it.modifiers) }
+      .filter {
+        it.methodInfo.isMethod &&
+          !Modifier.isStatic(it.modifiers) &&
+          !Modifier.isAbstract(it.modifiers)
+      }
       .forEach { method ->
         val codeAttr = method.methodInfo.codeAttribute
         val code = codeAttr.code

--- a/java/dagger/hilt/android/plugin/src/test/kotlin/HiltGradlePluginTest.kt
+++ b/java/dagger/hilt/android/plugin/src/test/kotlin/HiltGradlePluginTest.kt
@@ -135,6 +135,42 @@ class HiltGradlePluginTest {
     }
   }
 
+  // Verify transformation ignores abstract methods.
+  @Test
+  fun testAssemble_abstractMethod() {
+    gradleTransformRunner.addDependencies(
+      "implementation 'androidx.appcompat:appcompat:1.1.0'",
+      "implementation 'com.google.dagger:hilt-android:LOCAL-SNAPSHOT'",
+      "annotationProcessor 'com.google.dagger:hilt-android-compiler:LOCAL-SNAPSHOT'"
+    )
+
+    gradleTransformRunner.addSrc(
+      srcPath = "minimal/AbstractActivity.java",
+      srcContent =
+        """
+        package minimal;
+
+        import androidx.appcompat.app.AppCompatActivity;
+
+        @dagger.hilt.android.AndroidEntryPoint
+        public abstract class AbstractActivity extends AppCompatActivity {
+            public abstract void method();
+        }
+        """.trimIndent()
+    )
+
+    val result = gradleTransformRunner.build()
+    val assembleTask = result.getTask(":assembleDebug")
+    assertEquals(TaskOutcome.SUCCESS, assembleTask.outcome)
+
+    val transformedClass = result.getTransformedFile("minimal/AbstractActivity.class")
+    FileInputStream(transformedClass).use { fileInput ->
+      ClassFile(DataInputStream(fileInput)).let { classFile ->
+        assertEquals("minimal.Hilt_AbstractActivity", classFile.superclass)
+      }
+    }
+  }
+
   // Verify plugin configuration fails when runtime dependency is missing but plugin is applied.
   @Test
   fun testAssemble_missingLibraryDep() {

--- a/java/dagger/hilt/android/testing/CustomTestApplication.java
+++ b/java/dagger/hilt/android/testing/CustomTestApplication.java
@@ -26,9 +26,6 @@ import java.lang.annotation.Target;
  *
  * <p>This annotation is useful for creating an application that can be used with instrumentation
  * tests in gradle, since every instrumentation test must share the same application type.
- *
- * <p>This annotation cannot be used within the same build as {@link CustomBaseTestApplication},
- * which is used to set the base application type for a single test.
  */
 @Target({ElementType.TYPE})
 @GeneratesRootInput


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Ignore abstract methods when transforming @AndroidEntryPoint-annotated classes.

Abstract methods contain no code attribute and therefore don't have any
'super.something()' calls that need to be transformed.

Fixes https://github.com/google/dagger/issues/1955

RELNOTES=Fix a bug where Hilt would incorrectly try to transform abstract methods on abstract classes annnotated with @AndroidEntryPoint.

5e0f04ecf8e617041d3dccabf9e129b43cfb6642

-------

<p> Internal cleanup

RELNOTES=N/A

d26cd9f4f7a3012fc586cdbddc15604c875f6ba6