### PR TITLE
MOE Sync 2020-07-17

### DIFF
--- a/java/dagger/hilt/processor/internal/ClassNames.java
+++ b/java/dagger/hilt/processor/internal/ClassNames.java
@@ -101,6 +101,8 @@ public final class ClassNames {
 
   public static final ClassName APPLICATION_COMPONENT =
       get("dagger.hilt.components", "SingletonComponent");
+  public static final ClassName LEGACY_APPLICATION_COMPONENT =
+      get("dagger.hilt.android.components", "ApplicationComponent");
   // TODO(user): Move these class names out when we factor out the android portion
   public static final ClassName APPLICATION = get("android.app", "Application");
   public static final ClassName MULTI_DEX_APPLICATION =

--- a/java/dagger/hilt/processor/internal/definecomponent/DefineComponentMetadatas.java
+++ b/java/dagger/hilt/processor/internal/definecomponent/DefineComponentMetadatas.java
@@ -63,8 +63,8 @@ final class DefineComponentMetadatas {
   private DefineComponentMetadata get(Element element, LinkedHashSet<Element> childPath) {
     // This is a temporary hack to map the old ApplicationComponent to the new SingletonComponent
     if (element.getKind().equals(ElementKind.INTERFACE)
-        && asType(element).getQualifiedName().contentEquals(
-            "dagger.hilt.android.components.ApplicationComponent")) {
+        && asType(element).getQualifiedName()
+            .contentEquals(ClassNames.LEGACY_APPLICATION_COMPONENT.toString())) {
       element = asTypeElement(asType(element).getInterfaces().get(0));
     }
 

--- a/javatests/artifacts/hilt-android/simple/app/build.gradle
+++ b/javatests/artifacts/hilt-android/simple/app/build.gradle
@@ -51,11 +51,21 @@ hilt {
     enableTransformForLocalTests = true
 }
 
+configurations.all {
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        if ("$dagger_version" == 'LOCAL-SNAPSHOT'
+                && details.requested.group == 'com.google.dagger') {
+            details.useVersion 'LOCAL-SNAPSHOT'
+            details.because 'LOCAL-SNAPSHOT should act as latest version.'
+        }
+    }
+}
+
 dependencies {
   implementation project(':feature')
   implementation 'androidx.appcompat:appcompat:1.1.0'
-  implementation 'com.google.dagger:hilt-android:LOCAL-SNAPSHOT'
-  annotationProcessor 'com.google.dagger:hilt-android-compiler:LOCAL-SNAPSHOT'
+  implementation "com.google.dagger:hilt-android:$dagger_version"
+  annotationProcessor "com.google.dagger:hilt-android-compiler:$dagger_version"
 
   testImplementation 'com.google.truth:truth:1.0.1'
   testImplementation 'junit:junit:4.13'
@@ -64,19 +74,27 @@ dependencies {
   testImplementation 'androidx.test.ext:junit:1.1.1'
   testImplementation 'androidx.test:runner:1.2.0'
   testImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-  testImplementation 'com.google.dagger:hilt-android-testing:LOCAL-SNAPSHOT'
-  testAnnotationProcessor 'com.google.dagger:hilt-android-compiler:LOCAL-SNAPSHOT'
+  testImplementation "com.google.dagger:hilt-android-testing:$dagger_version"
+  testAnnotationProcessor "com.google.dagger:hilt-android-compiler:$dagger_version"
 
   androidTestImplementation 'com.google.truth:truth:1.0.1'
   androidTestImplementation 'junit:junit:4.13'
   androidTestImplementation 'androidx.test.ext:junit:1.1.1'
   androidTestImplementation 'androidx.test:runner:1.2.0'
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-  androidTestImplementation 'com.google.dagger:hilt-android-testing:LOCAL-SNAPSHOT'
-  androidTestAnnotationProcessor 'com.google.dagger:hilt-android-compiler:LOCAL-SNAPSHOT'
+  androidTestImplementation "com.google.dagger:hilt-android-testing:$dagger_version"
+  androidTestAnnotationProcessor "com.google.dagger:hilt-android-compiler:$dagger_version"
 
   // To help us catch usages of Guava APIs for Java 8 in the '-jre' variant.
   annotationProcessor'com.google.guava:guava:28.1-android'
   testAnnotationProcessor'com.google.guava:guava:28.1-android'
   androidTestAnnotationProcessor'com.google.guava:guava:28.1-android'
+
+  // To help us catch version skew related issues in hilt extensions.
+  // TODO(bcorso): Add examples testing the actual API.
+  implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha01'
+  implementation 'androidx.hilt:hilt-work:1.0.0-alpha01'
+  annotationProcessor 'androidx.hilt:hilt-compiler:1.0.0-alpha01'
+  testAnnotationProcessor 'androidx.hilt:hilt-compiler:1.0.0-alpha01'
+  androidTestAnnotationProcessor 'androidx.hilt:hilt-compiler:1.0.0-alpha01'
 }

--- a/javatests/artifacts/hilt-android/simple/build.gradle
+++ b/javatests/artifacts/hilt-android/simple/build.gradle
@@ -16,6 +16,7 @@
 
 buildscript {
     ext {
+        dagger_version = 'LOCAL-SNAPSHOT'
         kotlin_version = '1.3.61'
         agp_version = System.getenv('AGP_VERSION') ?: "3.6.3"
     }
@@ -27,7 +28,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:$agp_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:LOCAL-SNAPSHOT'
+        classpath "com.google.dagger:hilt-android-gradle-plugin:$dagger_version"
     }
 }
 

--- a/javatests/artifacts/hilt-android/simple/feature/build.gradle
+++ b/javatests/artifacts/hilt-android/simple/feature/build.gradle
@@ -49,6 +49,6 @@ dependencies {
     api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.google.dagger:hilt-android:LOCAL-SNAPSHOT'
-    kapt 'com.google.dagger:hilt-android-compiler:LOCAL-SNAPSHOT'
+    implementation "com.google.dagger:hilt-android:$dagger_version"
+    kapt "com.google.dagger:hilt-android-compiler:$dagger_version"
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add backwards compatibility with ApplicationComponent for libraries using pre 2.28.2 version of Hilt.

Fixes #1987

The issue is that libraries using pre 2.28.2 versions of Hilt will generate metadata with the old ApplicationComponent class, but the 2.28.2 compiler assumes that the metadata has already been converted to SingletonComponent. This fix allows backwards compatibility between pre 2.28.2 and post 2.28.2 versions by allowing ApplicationComponent class in the generated metadata.

RELNOTES=Fix #1987: Add backwards compatibility for ApplicationComponent with libraries using pre 2.28.2 versions of Hilt.

d381876a087f2b795a3e7d1817375e2226992868