### PR TITLE
MOE Sync 2020-08-03

### DIFF
--- a/java/dagger/hilt/android/processor/internal/androidentrypoint/AndroidEntryPointMetadata.java
+++ b/java/dagger/hilt/android/processor/internal/androidentrypoint/AndroidEntryPointMetadata.java
@@ -53,6 +53,7 @@ import javax.lang.model.type.TypeMirror;
 /** Metadata class for @AndroidEntryPoint annotated classes. */
 @AutoValue
 public abstract class AndroidEntryPointMetadata {
+
   /** The class {@link Element} annotated with @AndroidEntryPoint. */
   public abstract TypeElement element();
 

--- a/java/dagger/hilt/android/processor/internal/androidentrypoint/AndroidEntryPointMetadata.java
+++ b/java/dagger/hilt/android/processor/internal/androidentrypoint/AndroidEntryPointMetadata.java
@@ -459,7 +459,8 @@ public abstract class AndroidEntryPointMetadata {
             element,
             "Activities annotated with @AndroidEntryPoint must be a subclass of "
                 + "androidx.activity.ComponentActivity. (e.g. FragmentActivity, "
-                + "AppCompatActivity, etc.)");
+                + "AppCompatActivity, etc.)"
+            );
         return Type.ACTIVITY;
       } else if (Processors.isAssignableFrom(baseElement, AndroidClassNames.SERVICE)) {
         return Type.SERVICE;

--- a/java/dagger/internal/codegen/componentgenerator/ComponentImplementationBuilder.java
+++ b/java/dagger/internal/codegen/componentgenerator/ComponentImplementationBuilder.java
@@ -277,7 +277,7 @@ public abstract class ComponentImplementationBuilder {
 
   /** Creates an inner subcomponent implementation. */
   private ComponentImplementation subcomponent(BindingGraph childGraph) {
-    return componentImplementation.childComponentImplementation(childGraph, PRIVATE, FINAL);
+    return componentImplementation.childComponentImplementation(childGraph);
   }
 
   /** Creates and adds the constructor and methods needed for initializing the component. */


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Internal refactor.

5f2bf25ed326c2cd46cbf7bad5513d08411aacb6

-------

<p> Internal refactor

1215e2af424f7b7b12cb558b3c9289853b551bf4

-------

<p> Clean up ComponentImplementation

The constructor for ComponentImplementation required a lot of inputs that were redundant and could instead be calculated from other inputs.

RELNOTES=N/A

cf4e26d9d263dd25e07544ebea97a94af71d9e3c

-------

<p> Cleanup SubcomponentNames logic

The CL cleans up some of the logic for disambiguating subcomponent names. Mostly it removes some unnecessary complexity and improves code readability.

RELNOTES=N/A

e45260ede642aedaa8d68a0c32cd12f107df4293