### PR TITLE
MOE Sync 2020-08-05

### DIFF
--- a/java/dagger/hilt/android/processor/internal/bindvalue/BindValueGenerator.java
+++ b/java/dagger/hilt/android/processor/internal/bindvalue/BindValueGenerator.java
@@ -129,9 +129,16 @@ final class BindValueGenerator {
         MethodSpec.methodBuilder(methodName)
             .addAnnotation(Provides.class)
             .addModifiers(Modifier.STATIC)
-            .addParameter(testClassName, "test")
-            .returns(ClassName.get(bindValue.variableElement().asType()))
-            .addStatement("return test.$L", bindValue.variableElement().getSimpleName());
+            .returns(ClassName.get(bindValue.variableElement().asType()));
+
+    if (bindValue.variableElement().getModifiers().contains(Modifier.STATIC)) {
+      builder.addStatement(
+          "return $T.$L", testClassName, bindValue.variableElement().getSimpleName());
+    } else {
+      builder
+          .addParameter(testClassName, "test")
+          .addStatement("return test.$L", bindValue.variableElement().getSimpleName());
+    }
 
     ClassName annotationClassName = bindValue.annotationName();
     if (BindValueMetadata.BIND_VALUE_INTO_MAP_ANNOTATIONS.contains(annotationClassName)) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Stop BindValueGenerator referencing static members via instances.

This already happens, which is kinda gross: you don't need an instance to access static methods.

RELNOTES=Stop BindValueGenerator referencing static members via instances.

ab36b5a43c5ade7301baaa1a21104a74114bcc67