### PR TITLE
Update DAGGER_TAG + DAGGER_SHA to 2.28.3 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ release.
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-DAGGER_TAG = "2.28.1"
-DAGGER_SHA = "9e69ab2f9a47e0f74e71fe49098bea908c528aa02fa0c5995334447b310d0cdd"
+DAGGER_TAG = "2.28.3"
+DAGGER_SHA = "e79101e1259151a074c259b563214ef8f17c1e70637349b1af08e8e59f02fa9b"
 http_archive(
     name = "dagger",
     strip_prefix = "dagger-dagger-%s" % DAGGER_TAG,


### PR DESCRIPTION
I downloaded the zip file from the [2.28.3 release page](https://github.com/google/dagger/releases/tag/dagger-2.28.3) and ran `shasum -a 256 dagger-dagger-2.28.3.zip` to compute the hash.