### PR TITLE
MOE Sync 2020-08-31

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -55,7 +55,7 @@ jarjar_library(
     name = "shaded_android_processor",
     jars = [
         "//java/dagger/android/processor",
-        "@com_google_auto_auto_common//jar",
+        "@maven//:com_google_auto_auto_common",
     ],
     rules = [
         "rule com.google.auto.common.** dagger.android.shaded.auto.common.@1",
@@ -66,7 +66,7 @@ jarjar_library(
     name = "shaded_grpc_server_processor",
     jars = [
         "//java/dagger/grpc/server/processor",
-        "@com_google_auto_auto_common//jar",
+        "@maven//:com_google_auto_auto_common",
     ],
     rules = [
         "rule com.google.auto.common.** dagger.grpc.shaded.auto.common.@1",

--- a/java/dagger/hilt/android/processor/BUILD
+++ b/java/dagger/hilt/android/processor/BUILD
@@ -99,7 +99,7 @@ gen_maven_artifact(
     javadoc_srcs = [
         "//java/dagger/hilt:hilt_processing_filegroup",
     ],
-    shaded_deps = ["@com_google_auto_auto_common//jar"],
+    shaded_deps = ["@maven//:com_google_auto_auto_common"],
     shaded_rules = ["rule com.google.auto.common.** dagger.hilt.android.shaded.auto.common.@1"],
 )
 

--- a/java/dagger/internal/codegen/BUILD
+++ b/java/dagger/internal/codegen/BUILD
@@ -112,7 +112,7 @@ gen_maven_artifact(
     # The javadocs should only include ComponentProcessor.java, since that is the only class used
     # externally. Specifically, ComponentProcessor.forTesting() is required for testing SPI plugins.
     javadoc_srcs = ["ComponentProcessor.java"],
-    shaded_deps = ["@com_google_auto_auto_common//jar"],
+    shaded_deps = ["@maven//:com_google_auto_auto_common"],
     shaded_rules = ["rule com.google.auto.common.** dagger.shaded.auto.common.@1"],
 )
 

--- a/java/dagger/spi/BUILD
+++ b/java/dagger/spi/BUILD
@@ -77,6 +77,6 @@ gen_maven_artifact(
         ":spi-srcs",
         "//java/dagger/model:model-srcs",
     ],
-    shaded_deps = ["@com_google_auto_auto_common//jar"],
+    shaded_deps = ["@maven//:com_google_auto_auto_common"],
     shaded_rules = ["rule com.google.auto.common.** dagger.spi.shaded.auto.common.@1"],
 )


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> [Dagger]: Remove all references to bazel-common's auto-common dep.

We're using our own version of auto-common defined in our maven_install.

RELNOTES=N/A

68c96b08290f62f1fef7b13af4fe6d207f3f74b0