### PR TITLE
MOE Sync 2020-09-01

### DIFF
--- a/java/dagger/internal/codegen/compileroption/CompilerOptions.java
+++ b/java/dagger/internal/codegen/compileroption/CompilerOptions.java
@@ -81,4 +81,11 @@ public abstract class CompilerOptions {
   public int keysPerComponentShard(TypeElement component) {
     return 3500;
   }
+
+  /**
+   * This option enables a fix to an issue where Dagger previously would erroneously allow
+   * multibinding contributions in a component to have dependencies on child components. This will
+   * eventually become the default and enforced.
+   */
+  public abstract boolean strictMultibindingValidation();
 }

--- a/java/dagger/internal/codegen/compileroption/CompilerOptions.java
+++ b/java/dagger/internal/codegen/compileroption/CompilerOptions.java
@@ -58,6 +58,20 @@ public abstract class CompilerOptions {
 
   public abstract ValidationType scopeCycleValidationType();
 
+  /**
+   * If {@code true}, Dagger will validate all transitive component dependencies of a component.
+   * Otherwise, Dagger will only validate the direct component dependencies.
+   *
+   * <p>Note: this is different from scopeCycleValidationType, which lets you silence errors of
+   * transitive component dependencies, but still requires the full transitive dependencies in the
+   * classpath.
+   *
+   * <p>The main motivation for this flag is to prevent requiring the transitive component
+   * dependencies in the classpath to speed up builds. See
+   * https://github.com/google/dagger/issues/970.
+   */
+  public abstract boolean validateTransitiveComponentDependencies();
+
   public abstract boolean warnIfInjectionFactoryNotGeneratedUpstream();
 
   public abstract boolean headerCompilation();

--- a/java/dagger/internal/codegen/compileroption/JavacPluginCompilerOptions.java
+++ b/java/dagger/internal/codegen/compileroption/JavacPluginCompilerOptions.java
@@ -75,6 +75,11 @@ public final class JavacPluginCompilerOptions extends CompilerOptions {
   }
 
   @Override
+  public boolean validateTransitiveComponentDependencies() {
+    return true;
+  }
+
+  @Override
   public boolean warnIfInjectionFactoryNotGeneratedUpstream() {
     return false;
   }

--- a/java/dagger/internal/codegen/compileroption/JavacPluginCompilerOptions.java
+++ b/java/dagger/internal/codegen/compileroption/JavacPluginCompilerOptions.java
@@ -109,4 +109,8 @@ public final class JavacPluginCompilerOptions extends CompilerOptions {
     return false;
   }
 
+  @Override
+  public boolean strictMultibindingValidation() {
+    return false;
+  }
 }

--- a/java/dagger/internal/codegen/compileroption/ProcessingEnvironmentCompilerOptions.java
+++ b/java/dagger/internal/codegen/compileroption/ProcessingEnvironmentCompilerOptions.java
@@ -30,6 +30,7 @@ import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompil
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.FORMAT_GENERATED_SOURCE;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.IGNORE_PRIVATE_AND_STATIC_INJECTION_FOR_COMPONENT;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.PLUGINS_VISIT_FULL_BINDING_GRAPHS;
+import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.STRICT_MULTIBINDING_VALIDATION;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.WARN_IF_INJECTION_FACTORY_NOT_GENERATED_UPSTREAM;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.WRITE_PRODUCER_NAME_IN_TOKEN;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.KeyOnlyOption.HEADER_COMPILATION;
@@ -169,6 +170,11 @@ public final class ProcessingEnvironmentCompilerOptions extends CompilerOptions 
   }
 
   @Override
+  public boolean strictMultibindingValidation() {
+    return isEnabled(STRICT_MULTIBINDING_VALIDATION);
+  }
+
+  @Override
   public int keysPerComponentShard(TypeElement component) {
     if (processingEnvironment.getOptions().containsKey(KEYS_PER_COMPONENT_SHARD)) {
       Preconditions.checkArgument(
@@ -293,6 +299,7 @@ public final class ProcessingEnvironmentCompilerOptions extends CompilerOptions 
 
     EXPERIMENTAL_DAGGER_ERROR_MESSAGES,
 
+    STRICT_MULTIBINDING_VALIDATION,
     ;
 
     final FeatureStatus defaultValue;

--- a/java/dagger/internal/codegen/compileroption/ProcessingEnvironmentCompilerOptions.java
+++ b/java/dagger/internal/codegen/compileroption/ProcessingEnvironmentCompilerOptions.java
@@ -31,6 +31,7 @@ import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompil
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.IGNORE_PRIVATE_AND_STATIC_INJECTION_FOR_COMPONENT;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.PLUGINS_VISIT_FULL_BINDING_GRAPHS;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.STRICT_MULTIBINDING_VALIDATION;
+import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.VALIDATE_TRANSITIVE_COMPONENT_DEPENDENCIES;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.WARN_IF_INJECTION_FACTORY_NOT_GENERATED_UPSTREAM;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.WRITE_PRODUCER_NAME_IN_TOKEN;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.KeyOnlyOption.HEADER_COMPILATION;
@@ -137,6 +138,11 @@ public final class ProcessingEnvironmentCompilerOptions extends CompilerOptions 
   @Override
   public ValidationType scopeCycleValidationType() {
     return parseOption(DISABLE_INTER_COMPONENT_SCOPE_VALIDATION);
+  }
+
+  @Override
+  public boolean validateTransitiveComponentDependencies() {
+    return isEnabled(VALIDATE_TRANSITIVE_COMPONENT_DEPENDENCIES);
   }
 
   @Override
@@ -300,6 +306,8 @@ public final class ProcessingEnvironmentCompilerOptions extends CompilerOptions 
     EXPERIMENTAL_DAGGER_ERROR_MESSAGES,
 
     STRICT_MULTIBINDING_VALIDATION,
+
+    VALIDATE_TRANSITIVE_COMPONENT_DEPENDENCIES(ENABLED)
     ;
 
     final FeatureStatus defaultValue;

--- a/java/dagger/internal/codegen/validation/ComponentDescriptorValidator.java
+++ b/java/dagger/internal/codegen/validation/ComponentDescriptorValidator.java
@@ -179,7 +179,10 @@ public final class ComponentDescriptorValidator {
             compilerOptions.scopeCycleValidationType().diagnosticKind().get(),
             component,
             message.toString());
-      } else {
+      } else if (compilerOptions.validateTransitiveComponentDependencies()
+          // Always validate direct component dependencies referenced by this component regardless
+          // of the flag value
+          || dependencyStack.isEmpty()) {
         rootComponentAnnotation(dependency)
             .ifPresent(
                 componentAnnotation -> {
@@ -428,7 +431,10 @@ public final class ComponentDescriptorValidator {
               message.toString());
         }
         scopedDependencyStack.pop();
-      } else {
+      } else if (compilerOptions.validateTransitiveComponentDependencies()
+          // Always validate direct component dependencies referenced by this component regardless
+          // of the flag value
+          || scopedDependencyStack.isEmpty()) {
         // TODO(beder): transitively check scopes of production components too.
         rootComponentAnnotation(dependency)
             .filter(componentAnnotation -> !componentAnnotation.isProduction())

--- a/javatests/dagger/internal/codegen/BindsDependsOnSubcomponentValidationTest.java
+++ b/javatests/dagger/internal/codegen/BindsDependsOnSubcomponentValidationTest.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright (C) 2020 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.internal.codegen;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static dagger.internal.codegen.Compilers.daggerCompiler;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests to make sure that delegate bindings where the impl depends on a binding in a subcomponent
+ * properly fail. These are regression tests for b/147020838.
+ */
+@RunWith(JUnit4.class)
+public class BindsDependsOnSubcomponentValidationTest {
+  @Test
+  public void testBinds() {
+    JavaFileObject parentComponent =
+        JavaFileObjects.forSourceLines(
+            "test.ParentComponent",
+            "package test;",
+            "",
+            "import dagger.Component;",
+            "",
+            "@Component(modules = ParentModule.class)",
+            "interface ParentComponent {",
+            "  ChildComponent getChild();",
+            "}");
+    JavaFileObject parentModule =
+        JavaFileObjects.forSourceLines(
+            "test.ParentModule",
+            "package test;",
+            "",
+            "import dagger.Binds;",
+            "import dagger.Module;",
+            "",
+            "@Module",
+            "interface ParentModule {",
+            "  @Binds Foo bindFoo(FooImpl impl);",
+            "}");
+    JavaFileObject childComponent =
+        JavaFileObjects.forSourceLines(
+            "test.ChildComponent",
+            "package test;",
+            "",
+            "import dagger.Subcomponent;",
+            "",
+            "@Subcomponent(modules = ChildModule.class)",
+            "interface ChildComponent {",
+            "  Foo getFoo();",
+            "}");
+    JavaFileObject childModule =
+        JavaFileObjects.forSourceLines(
+            "test.ChildModule",
+            "package test;",
+            "",
+            "import dagger.Module;",
+            "import dagger.Provides;",
+            "",
+            "@Module",
+            "interface ChildModule {",
+            "  @Provides static Long providLong() {",
+            "    return 0L;",
+            "  }",
+            "}");
+    JavaFileObject iface =
+        JavaFileObjects.forSourceLines("test.Foo", "package test;", "", "interface Foo {", "}");
+    JavaFileObject impl =
+        JavaFileObjects.forSourceLines(
+            "test.FooImpl",
+            "package test;",
+            "",
+            "import javax.inject.Inject;",
+            "",
+            "class FooImpl implements Foo {",
+            "  @Inject FooImpl(Long l) {}",
+            "}");
+    Compilation compilation =
+        daggerCompiler()
+            .compile(parentComponent, parentModule, childComponent, childModule, iface, impl);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
+    assertThat(compilation)
+        .hadErrorContaining("java.lang.Long cannot be provided without an @Inject constructor")
+        .inFile(parentComponent)
+        .onLineContaining("interface ParentComponent");
+  }
+
+  @Test
+  public void testSetBindings() {
+    JavaFileObject parentComponent =
+        JavaFileObjects.forSourceLines(
+            "test.ParentComponent",
+            "package test;",
+            "",
+            "import dagger.Component;",
+            "",
+            "@Component(modules = ParentModule.class)",
+            "interface ParentComponent {",
+            "  ChildComponent getChild();",
+            "}");
+    JavaFileObject parentModule =
+        JavaFileObjects.forSourceLines(
+            "test.ParentModule",
+            "package test;",
+            "",
+            "import dagger.Binds;",
+            "import dagger.Module;",
+            "import dagger.multibindings.IntoSet;",
+            "",
+            "@Module",
+            "interface ParentModule {",
+            "  @Binds @IntoSet Foo bindFoo(FooImpl impl);",
+            "}");
+    JavaFileObject childComponent =
+        JavaFileObjects.forSourceLines(
+            "test.ChildComponent",
+            "package test;",
+            "",
+            "import dagger.Subcomponent;",
+            "import java.util.Set;",
+            "",
+            "@Subcomponent(modules = ChildModule.class)",
+            "interface ChildComponent {",
+            "  Set<Foo> getFooSet();",
+            "}");
+    JavaFileObject childModule =
+        JavaFileObjects.forSourceLines(
+            "test.ChildModule",
+            "package test;",
+            "",
+            "import dagger.Module;",
+            "import dagger.Provides;",
+            "",
+            "@Module",
+            "interface ChildModule {",
+            "  @Provides static Long providLong() {",
+            "    return 0L;",
+            "  }",
+            "}");
+    JavaFileObject iface =
+        JavaFileObjects.forSourceLines("test.Foo", "package test;", "", "interface Foo {", "}");
+    JavaFileObject impl =
+        JavaFileObjects.forSourceLines(
+            "test.FooImpl",
+            "package test;",
+            "",
+            "import javax.inject.Inject;",
+            "",
+            "class FooImpl implements Foo {",
+            "  @Inject FooImpl(Long l) {}",
+            "}");
+    Compilation compilation =
+        daggerCompiler()
+            // TODO(user): make this flag the default and remove this
+            .withOptions("-Adagger.strictMultibindingValidation=enabled")
+            .compile(parentComponent, parentModule, childComponent, childModule, iface, impl);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
+    assertThat(compilation)
+        .hadErrorContaining("java.lang.Long cannot be provided without an @Inject constructor")
+        .inFile(parentComponent)
+        .onLineContaining("interface ParentComponent");
+  }
+
+  @Test
+  public void testSetValueBindings() {
+    JavaFileObject parentComponent =
+        JavaFileObjects.forSourceLines(
+            "test.ParentComponent",
+            "package test;",
+            "",
+            "import dagger.Component;",
+            "",
+            "@Component(modules = ParentModule.class)",
+            "interface ParentComponent {",
+            "  ChildComponent getChild();",
+            "}");
+    JavaFileObject parentModule =
+        JavaFileObjects.forSourceLines(
+            "test.ParentModule",
+            "package test;",
+            "",
+            "import dagger.Module;",
+            "import dagger.Provides;",
+            "import dagger.multibindings.ElementsIntoSet;",
+            "import java.util.Collections;",
+            "import java.util.Set;",
+            "",
+            "@Module",
+            "interface ParentModule {",
+            "  @Provides @ElementsIntoSet",
+            "  static Set<Foo> provideFoo(FooImpl impl) {",
+            "    return Collections.singleton(impl);",
+            "  }",
+            "}");
+    JavaFileObject childComponent =
+        JavaFileObjects.forSourceLines(
+            "test.ChildComponent",
+            "package test;",
+            "",
+            "import dagger.Subcomponent;",
+            "import java.util.Set;",
+            "",
+            "@Subcomponent(modules = ChildModule.class)",
+            "interface ChildComponent {",
+            "  Set<Foo> getFooSet();",
+            "}");
+    JavaFileObject childModule =
+        JavaFileObjects.forSourceLines(
+            "test.ChildModule",
+            "package test;",
+            "",
+            "import dagger.Module;",
+            "import dagger.Provides;",
+            "",
+            "@Module",
+            "interface ChildModule {",
+            "  @Provides static Long providLong() {",
+            "    return 0L;",
+            "  }",
+            "}");
+    JavaFileObject iface =
+        JavaFileObjects.forSourceLines("test.Foo", "package test;", "", "interface Foo {", "}");
+    JavaFileObject impl =
+        JavaFileObjects.forSourceLines(
+            "test.FooImpl",
+            "package test;",
+            "",
+            "import javax.inject.Inject;",
+            "",
+            "class FooImpl implements Foo {",
+            "  @Inject FooImpl(Long l) {}",
+            "}");
+    Compilation compilation =
+        daggerCompiler()
+            .compile(parentComponent, parentModule, childComponent, childModule, iface, impl);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
+    assertThat(compilation)
+        .hadErrorContaining("java.lang.Long cannot be provided without an @Inject constructor")
+        .inFile(parentComponent)
+        .onLineContaining("interface ParentComponent");
+  }
+
+  @Test
+  public void testMapBindings() {
+    JavaFileObject parentComponent =
+        JavaFileObjects.forSourceLines(
+            "test.ParentComponent",
+            "package test;",
+            "",
+            "import dagger.Component;",
+            "",
+            "@Component(modules = ParentModule.class)",
+            "interface ParentComponent {",
+            "  ChildComponent getChild();",
+            "}");
+    JavaFileObject parentModule =
+        JavaFileObjects.forSourceLines(
+            "test.ParentModule",
+            "package test;",
+            "",
+            "import dagger.Binds;",
+            "import dagger.Module;",
+            "import dagger.multibindings.IntoMap;",
+            "import dagger.multibindings.StringKey;",
+            "",
+            "@Module",
+            "interface ParentModule {",
+            "  @Binds @IntoMap @StringKey(\"foo\") Foo bindFoo(FooImpl impl);",
+            "}");
+    JavaFileObject childComponent =
+        JavaFileObjects.forSourceLines(
+            "test.ChildComponent",
+            "package test;",
+            "",
+            "import dagger.Subcomponent;",
+            "import java.util.Map;",
+            "",
+            "@Subcomponent(modules = ChildModule.class)",
+            "interface ChildComponent {",
+            "  Map<String, Foo> getFooSet();",
+            "}");
+    JavaFileObject childModule =
+        JavaFileObjects.forSourceLines(
+            "test.ChildModule",
+            "package test;",
+            "",
+            "import dagger.Module;",
+            "import dagger.Provides;",
+            "",
+            "@Module",
+            "interface ChildModule {",
+            "  @Provides static Long providLong() {",
+            "    return 0L;",
+            "  }",
+            "}");
+    JavaFileObject iface =
+        JavaFileObjects.forSourceLines("test.Foo", "package test;", "", "interface Foo {", "}");
+    JavaFileObject impl =
+        JavaFileObjects.forSourceLines(
+            "test.FooImpl",
+            "package test;",
+            "",
+            "import javax.inject.Inject;",
+            "",
+            "class FooImpl implements Foo {",
+            "  @Inject FooImpl(Long l) {}",
+            "}");
+    Compilation compilation =
+        daggerCompiler()
+            // TODO(user): make this flag the default and remove this
+            .withOptions("-Adagger.strictMultibindingValidation=enabled")
+            .compile(parentComponent, parentModule, childComponent, childModule, iface, impl);
+    assertThat(compilation).failed();
+    assertThat(compilation).hadErrorCount(1);
+    assertThat(compilation)
+        .hadErrorContaining("java.lang.Long cannot be provided without an @Inject constructor")
+        .inFile(parentComponent)
+        .onLineContaining("interface ParentComponent");
+  }
+}

--- a/javatests/dagger/internal/codegen/ComponentValidationTest.java
+++ b/javatests/dagger/internal/codegen/ComponentValidationTest.java
@@ -219,6 +219,18 @@ public final class ComponentValidationTest {
             message(
                 "test.ComponentShort contains a cycle in its component dependencies:",
                 "    test.ComponentShort"));
+
+    // Test that this also fails when transitive validation is disabled.
+    compilation =
+        daggerCompiler()
+            .withOptions("-Adagger.validateTransitiveComponentDependencies=DISABLED")
+            .compile(shortLifetime);
+    assertThat(compilation).failed();
+    assertThat(compilation)
+        .hadErrorContaining(
+            message(
+                "test.ComponentShort contains a cycle in its component dependencies:",
+                "    test.ComponentShort"));
   }
 
   @Test
@@ -281,6 +293,14 @@ public final class ComponentValidationTest {
                 "    test.ComponentMedium",
                 "    test.ComponentShort"))
         .inFile(shortLifetime);
+
+    // Test that compilation succeeds when transitive validation is disabled because the cycle
+    // cannot be detected.
+    compilation =
+        daggerCompiler()
+            .withOptions("-Adagger.validateTransitiveComponentDependencies=DISABLED")
+            .compile(longLifetime, mediumLifetime, shortLifetime);
+    assertThat(compilation).succeeded();
   }
 
   @Test

--- a/javatests/dagger/internal/codegen/ScopingValidationTest.java
+++ b/javatests/dagger/internal/codegen/ScopingValidationTest.java
@@ -845,6 +845,14 @@ public class ScopingValidationTest {
                 "    @test.ScopeA test.ComponentLong",
                 "    @test.ScopeB test.ComponentMedium",
                 "    @test.ScopeA test.ComponentShort"));
+
+    // Test that compilation succeeds when transitive validation is disabled because the scope cycle
+    // cannot be detected.
+    compilation =
+        daggerCompiler()
+            .withOptions("-Adagger.validateTransitiveComponentDependencies=DISABLED")
+            .compile(type, scopeA, scopeB, longLifetime, mediumLifetime, shortLifetime);
+    assertThat(compilation).succeeded();
   }
 
   @Test


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a flag -Adagger.strictMultibindingValidation that will enforce that multibindings contributions bound in a parent component cannot access bindings from child components. This fixes other bugs that may result from this unintentionally previously supported behavior. This flag is default off but will become the default in the future.

RELNOTES=Add -Adagger.strictMultibindingValidation to fix multibinding contributions that depend on subcomponent bindings.

b0c1f1fc614594e16a82cf4e8cab789ad93372dd

-------

<p> [Dagger]: Add a compiler option to prevent validating transitive component dependencies

See https://github.com/google/dagger/issues/970

Fixes #970

RELNOTES=Fix #970: Add a compiler option to prevent validating transitive component dependencies.

9959c7233ea0d7d984701d3db0dd7229de9b00ac