### PR TITLE
Print Gradle plugin ID if user forgot to apply

### DIFF
--- a/java/dagger/hilt/android/processor/internal/androidentrypoint/AndroidEntryPointMetadata.java
+++ b/java/dagger/hilt/android/processor/internal/androidentrypoint/AndroidEntryPointMetadata.java
@@ -271,7 +271,7 @@ public abstract class AndroidEntryPointMetadata {
           !MoreTypes.isTypeOf(Void.class, baseElement.asType()),
           androidEntryPointElement,
           "Expected @%s to have a value."
-          + " Did you forget to apply the Gradle Plugin?",
+          + " Did you forget to apply the Gradle Plugin? (dagger.hilt.android.plugin)",
           annotationClassName.simpleName());
 
       // Check that the root $CLASS extends Hilt_$CLASS


### PR DESCRIPTION
Prints out the Gradle plugin ID if it apparently wasn't applied, a minor nuisance but not printing it means the user must go to the docs every time they see this error.