### PR TITLE
Catch UnknownElementExceptions InjectionSiteFactory

### DIFF
--- a/java/dagger/internal/codegen/binding/InjectionSiteFactory.java
+++ b/java/dagger/internal/codegen/binding/InjectionSiteFactory.java
@@ -39,6 +39,7 @@ import javax.inject.Inject;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.UnknownElementException;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ExecutableType;
@@ -73,7 +74,12 @@ final class InjectionSiteFactory {
       DeclaredType type = currentType.get();
       ancestors.add(MoreElements.asType(type.asElement()));
       for (Element enclosedElement : type.asElement().getEnclosedElements()) {
-        injectionSiteVisitor.visit(enclosedElement, type).ifPresent(injectionSites::add);
+        try {
+          injectionSiteVisitor.visit(enclosedElement, type).ifPresent(injectionSites::add);
+        } catch (UnknownElementException e) {
+          // Ignore if element visitor encounters unkown elements, for example 
+          // language features from newer Java versions
+        }
       }
     }
     return ImmutableSortedSet.copyOf(


### PR DESCRIPTION
After running into UnknownElementExceptions in Java 14+ codebases with Dagger (see #2106), I decided to try to fix this issue.

With this change Dagger is working again for me in a Java 15 codebase. I don't think there is a downside to this change, and even when Dagger eventually updates to `ElementKindVisitor14`, it would still be helpful for future language changes beyond Java 14.

Unfortunately, I don't think creating a test case for this is feasible, since it would have to be run with a different JDK version, etc. Sure, we could make the InjectionSiteVisitor "injectable" and create a test Visitor that throws UnknownElementException, but not sure if this is worth the effort.

This is my first PR ever, let me know if there's anything I can do to improve this.

Thanks
Chris