### PR TITLE
Fix jar file handle in AGP 4.1.0 

### DIFF
--- a/java/dagger/hilt/android/plugin/src/main/kotlin/dagger/hilt/android/plugin/AndroidEntryPointClassTransformer.kt
+++ b/java/dagger/hilt/android/plugin/src/main/kotlin/dagger/hilt/android/plugin/AndroidEntryPointClassTransformer.kt
@@ -27,6 +27,8 @@ import javassist.bytecode.Bytecode
 import javassist.bytecode.CodeIterator
 import javassist.bytecode.Opcode
 import org.slf4j.LoggerFactory
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
 
 typealias CodeArray = javassist.bytecode.ByteArray // Avoids conflict with Kotlin's stdlib ByteArray
 
@@ -99,6 +101,19 @@ internal class AndroidEntryPointClassTransformer(
       "Invalid file, '$inputFile' is not a class."
     }
     val clazz = inputFile.inputStream().use { classPool.makeClass(it, false) }
+    return transformClassToOutput(clazz)
+  }
+
+  /**
+   * The same as
+   * @link { dagger.hilt.android.plugin.AndroidEntryPointClassTransformer.transformFile(java.io.File) }
+   * but handle jar entries.
+   */
+  fun transformFile(jarFile: JarFile, jarEntry: JarEntry): Boolean {
+    check(jarEntry.isClassFile()) {
+      "Invalid file, '${jarEntry.name}' is not a class."
+    }
+    val clazz = jarFile.getInputStream(jarEntry).use { classPool.makeClass(it, false) }
     return transformClassToOutput(clazz)
   }
 

--- a/java/dagger/hilt/android/plugin/src/main/kotlin/dagger/hilt/android/plugin/util/Files.kt
+++ b/java/dagger/hilt/android/plugin/src/main/kotlin/dagger/hilt/android/plugin/util/Files.kt
@@ -2,6 +2,8 @@ package dagger.hilt.android.plugin.util
 
 import com.android.SdkConstants
 import java.io.File
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
 import java.util.zip.ZipEntry
 
 /* Checks if a file is a .class file. */
@@ -10,5 +12,30 @@ fun File.isClassFile() = this.isFile && this.extension == SdkConstants.EXT_CLASS
 /* Checks if a Zip entry is a .class file. */
 fun ZipEntry.isClassFile() = !this.isDirectory && this.name.endsWith(SdkConstants.DOT_CLASS)
 
-/* CHecks if a file is a .jar file. */
+/* Checks if a file is a .jar file. */
 fun File.isJarFile() = this.isFile && this.extension == SdkConstants.EXT_JAR
+
+/* Copy a JarEntry to output directory. */
+fun JarEntry.copyTo(jarFile: JarFile, target: File, overwrite: Boolean = false, bufferSize: Int = DEFAULT_BUFFER_SIZE): File {
+    if (target.exists()) {
+        if (!overwrite)
+            throw FileAlreadyExistsException(file = File(jarFile.name), other = target, reason = "The destination file already exists.")
+        else if (!target.delete())
+            throw FileAlreadyExistsException(file = File(jarFile.name), other = target, reason = "Tried to overwrite the destination, but failed to delete it.")
+    }
+
+    if (this.isDirectory) {
+        if (!target.mkdirs())
+            throw FileSystemException(file = File(jarFile.name), other = target, reason = "Failed to create target directory.")
+    } else {
+        target.parentFile?.mkdirs()
+
+        jarFile.getInputStream(this).use { input ->
+            target.outputStream().use { output ->
+                input.copyTo(output, bufferSize)
+            }
+        }
+    }
+
+    return target
+}


### PR DESCRIPTION
In AGP 4.0+, Desugar devide output into 3 part project， subProject， externalLib and marked all output as jar file. As we test, when run release build (with desugarTask), AndroidEntryPointTransform can never handle the application class successfully.

```groovy
        projectClasses.forEachIndexed { index, file ->
            inputToOutputs[file.toPath()] = projectOutput.resolve("$index.jar").toPath()
        }
        subProjectClasses.forEachIndexed { index, file ->
            inputToOutputs[file.toPath()] = subProjectOutput.resolve("$index.jar").toPath()
        }
        externaLibsClasses.forEachIndexed { index, file ->
            inputToOutputs[file.toPath()] = externalLibsOutput.resolve("$index.jar").toPath()
        }
```

So we do this modify to compact with new AGP but not break previous verison. 