### PR TITLE
Fix remote build cache support in Hilt Gradle Plugin

### DIFF
--- a/java/dagger/hilt/android/plugin/src/main/kotlin/dagger/hilt/android/plugin/AndroidEntryPointClassVisitor.kt
+++ b/java/dagger/hilt/android/plugin/src/main/kotlin/dagger/hilt/android/plugin/AndroidEntryPointClassVisitor.kt
@@ -7,6 +7,9 @@ import com.android.build.api.instrumentation.InstrumentationParameters
 import java.io.File
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.FieldVisitor
@@ -25,7 +28,8 @@ class AndroidEntryPointClassVisitor(
 
   @Suppress("UnstableApiUsage") // ASM Pipeline APIs
   interface AndroidEntryPointParams : InstrumentationParameters {
-    @get:Input
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     val additionalClassesDir: Property<File>
   }
 

--- a/java/dagger/hilt/android/plugin/src/main/kotlin/dagger/hilt/android/plugin/HiltGradlePlugin.kt
+++ b/java/dagger/hilt/android/plugin/src/main/kotlin/dagger/hilt/android/plugin/HiltGradlePlugin.kt
@@ -246,8 +246,8 @@ class HiltGradlePlugin @Inject constructor(
         scope = InstrumentationScope.PROJECT
       ) { params ->
         val classesDir =
-          project.layout.buildDirectory.dir("intermediates/javac/${androidComponent.name}/classes")
-        params.additionalClassesDir.from(classesDir)
+          File(project.buildDir, "intermediates/javac/${androidComponent.name}/classes")
+        params.additionalClassesDir.set(classesDir)
       }
       androidComponent.setAsmFramesComputationMode(
         FramesComputationMode.COMPUTE_FRAMES_FOR_INSTRUMENTED_METHODS

--- a/java/dagger/hilt/android/plugin/src/main/kotlin/dagger/hilt/android/plugin/HiltGradlePlugin.kt
+++ b/java/dagger/hilt/android/plugin/src/main/kotlin/dagger/hilt/android/plugin/HiltGradlePlugin.kt
@@ -246,8 +246,8 @@ class HiltGradlePlugin @Inject constructor(
         scope = InstrumentationScope.PROJECT
       ) { params ->
         val classesDir =
-          File(project.buildDir, "intermediates/javac/${androidComponent.name}/classes")
-        params.additionalClassesDir.set(classesDir)
+          project.layout.buildDirectory.dir("intermediates/javac/${androidComponent.name}/classes")
+        params.additionalClassesDir.from(classesDir)
       }
       androidComponent.setAsmFramesComputationMode(
         FramesComputationMode.COMPUTE_FRAMES_FOR_INSTRUMENTED_METHODS

--- a/java/dagger/hilt/android/plugin/src/test/kotlin/BuildCacheTest.kt
+++ b/java/dagger/hilt/android/plugin/src/test/kotlin/BuildCacheTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2020 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.gradle.testkit.runner.TaskOutcome.FROM_CACHE
+import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.util.*
+import kotlin.random.Random
+
+// Test that verifies the hilt class transform does not break the Gradle's remote build cache.
+class BuildCacheTest {
+  @get:Rule
+  val gradleHomeFolder = TemporaryFolder()
+
+  @get:Rule
+  val firstProjectDir = TemporaryFolder()
+
+  lateinit var firstGradleRunner: GradleTestRunner
+
+  @get:Rule
+  val secondProjectDir = TemporaryFolder()
+
+  lateinit var secondGradleRunner: GradleTestRunner
+
+  private val testId = UUID.randomUUID().toString()
+
+  @Before
+  fun setup() {
+    firstGradleRunner = createGradleRunner(firstProjectDir)
+    secondGradleRunner = createGradleRunner(secondProjectDir)
+  }
+
+  private fun createGradleRunner(folder: TemporaryFolder): GradleTestRunner {
+    val gradleRunner = GradleTestRunner(folder)
+    gradleRunner.addDependencies(
+      "implementation 'androidx.appcompat:appcompat:1.1.0'",
+      "implementation 'com.google.dagger:hilt-android:LOCAL-SNAPSHOT'",
+      "annotationProcessor 'com.google.dagger:hilt-compiler:LOCAL-SNAPSHOT'",
+    )
+    gradleRunner.runAdditionalTasks("--build-cache")
+    gradleRunner.addSrc(
+      srcPath = "minimal/MyApp.java",
+      srcContent =
+      """
+        package minimal;
+        
+        import android.app.Application;
+
+        @dagger.hilt.android.HiltAndroidApp
+        public class MyApp extends Application {
+          // random id inserted into the code to ensure that the first is never a cache hit and the second 
+          // run always is
+          public static String RANDOM_ID = "$testId";
+        }
+        """.trimIndent()
+    )
+    gradleRunner.setAppClassName(".MyApp")
+    return gradleRunner
+  }
+
+  // Verifies that library B and library C injected classes are available in the root classpath.
+  @Test
+  fun test_buildCacheHitOnRelocatedProject() {
+    val firstResult = firstGradleRunner.build()
+    assertEquals(firstResult.getTask(":transformDebugClassesWithAsm").outcome, SUCCESS)
+
+    val secondResult = secondGradleRunner.build()
+    val cacheableTasks = listOf(
+      ":checkDebugAarMetadata",
+      ":checkDebugDuplicateClasses",
+      ":compileDebugJavaWithJavac",
+      ":compressDebugAssets",
+      ":extractDeepLinksDebug",
+      ":generateDebugBuildConfig",
+      ":generateDebugResValues",
+      ":javaPreCompileDebug",
+      ":mergeDebugAssets",
+      ":mergeDebugJavaResource",
+      ":mergeDebugJniLibFolders",
+      ":mergeDebugNativeLibs",
+      ":mergeDebugShaders",
+      ":mergeExtDexDebug",
+      ":mergeLibDexDebug",
+      ":mergeProjectDexDebug",
+      ":processDebugManifestForPackage",
+      ":transformDebugClassesWithAsm",
+      ":validateSigningDebug",
+      ":writeDebugAppMetadata",
+      ":writeDebugSigningConfigVersions",
+    )
+
+    val tasksFromCache = secondResult.tasks.filter { it.outcome == FROM_CACHE }.map { it.path }.sorted()
+    assertEquals(cacheableTasks, tasksFromCache)
+  }
+}

--- a/java/dagger/hilt/android/plugin/src/test/kotlin/GradleTestRunner.kt
+++ b/java/dagger/hilt/android/plugin/src/test/kotlin/GradleTestRunner.kt
@@ -16,6 +16,7 @@
 
 import java.io.File
 import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.BuildTask
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.rules.TemporaryFolder
 
@@ -206,6 +207,9 @@ class GradleTestRunner(val tempFolder: TemporaryFolder) {
     private val projectRoot: File,
     private val buildResult: BuildResult
   ) {
+
+    val tasks: List<BuildTask> get() = buildResult.tasks
+
     // Finds a task by name.
     fun getTask(name: String) = buildResult.task(name) ?: error("Task '$name' not found.")
 

--- a/java/dagger/hilt/android/plugin/src/test/kotlin/NoTransformTest.kt
+++ b/java/dagger/hilt/android/plugin/src/test/kotlin/NoTransformTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class NoTransformTest {
+
+  @get:Rule
+  val testProjectDir = TemporaryFolder()
+
+  lateinit var gradleRunner: GradleTestRunner
+
+  @Before
+  fun setup() {
+    gradleRunner = GradleTestRunner(testProjectDir)
+  }
+
+  // Simple functional test to verify transformation.
+  @Test
+  fun testAssemble() {
+    gradleRunner.addDependencies(
+      "implementation 'androidx.appcompat:appcompat:1.1.0'",
+      "implementation 'com.google.dagger:hilt-android:LOCAL-SNAPSHOT'",
+      "annotationProcessor 'com.google.dagger:hilt-compiler:LOCAL-SNAPSHOT'"
+    )
+    gradleRunner.addAndroidOption(
+      "buildFeatures.buildConfig = false"
+    )
+
+    val result = gradleRunner.build()
+    val assembleTask = result.getTask(":assembleDebug")
+    Assert.assertEquals(TaskOutcome.SUCCESS, assembleTask.outcome)
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/google/dagger/issues/2763

~As proposed in the reported issue, this PR changes the annotations on the `additionalClassesDir` to match what Gradle would expect when referencing a directory that's within the root directory of the project.~ This was changed to mark it as `@Internal` to make sure the field is ignored in the cache-key calculation. 

I added a unit test which, when run on the current master fails because the `:transformDebugClassesWithAsm` results in a cache miss. On this branch it does succeed.