### PR TITLE
Add note on using a case-sensitive filesystem

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,8 @@ information on using pull requests.
 
 Dagger is built with [`bazel`](https://bazel.build).
 
+Ensure that dagger is checked out on a case-sensitive filesystem. On a case-insensitive file system some tasks that attempt to delete the `build/` folder will also delete the bazel `BUILD` files.
+
 ### Building Dagger from the command line
 
 *   [Install Bazel](https://docs.bazel.build/versions/master/install.html)


### PR DESCRIPTION
I ran into this when trying to run the command to install local snapshots. It kept deleting `BUILD` files during the build as part of gradle `clean` tasks which were intended to delete `build/` directories. That would then cause the build itself to fail as well.

Linux uses case-sensitive filesystems by default, but MacOS has case-insensitive as the default.