### PR TITLE
Proposal: Add `TYPE` target to `ClassKey`

### DIFF
--- a/java/dagger/multibindings/ClassKey.java
+++ b/java/dagger/multibindings/ClassKey.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * member whose type is {@code Class<? extends Something>}.
  */
 @Documented
-@Target({ElementType.METHOD, ElementType.FIELD})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.TYPE})
 @Retention(RUNTIME)
 @MapKey
 public @interface ClassKey {


### PR DESCRIPTION
I wanted to propose allowing use of this annotation on classes as well for use with Anvil's [`@ContributesMultibinding`](https://github.com/square/anvil/blob/main/annotations/src/main/java/com/squareup/anvil/annotations/ContributesMultibinding.kt), which would allow this syntax.

```kotlin
@ContributesMultibinding(AppScope::class)
@ClassKey(Listener::class)
class MainListener @Inject constructor() : Listener
```