### PR TITLE
Avoid using UAST implementation classes in Lint checkers

### DIFF
--- a/java/dagger/lint/DaggerKotlinIssueDetector.kt
+++ b/java/dagger/lint/DaggerKotlinIssueDetector.kt
@@ -42,7 +42,6 @@ import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UField
 import org.jetbrains.uast.UMethod
 import org.jetbrains.uast.getUastParentOfType
-import org.jetbrains.uast.kotlin.KotlinUClass
 import org.jetbrains.uast.toUElement
 
 /**
@@ -257,6 +256,6 @@ class DaggerKotlinIssueDetector : Detector(), SourceCodeScanner {
 
   /** @return whether or not the [this] is a Kotlin `object` type. */
   private fun UClass.isObject(): Boolean {
-    return this is KotlinUClass && ktClass is KtObjectDeclaration
+    return sourcePsi is KtObjectDeclaration
   }
 }


### PR DESCRIPTION
`KotlinUClass.ktClass` is not supposed to be exposed and used this way.
Instead, `sourcePsi` is a good alternative in this use case.

Bug: http://issuetracker.google.com/200061619 (internal)