### PR TITLE
Add publishing Plugin Marker Artifact for Hilt Android Gradle plugin

### DIFF
--- a/java/dagger/hilt/android/plugin/build.gradle
+++ b/java/dagger/hilt/android/plugin/build.gradle
@@ -184,11 +184,19 @@ tasks.withType(GenerateModuleMetadata) {
   enabled = false
 }
 
+group = "com.google.dagger"
+ext.artifact = "hilt-android-gradle-plugin"
+
+def getPublishVersion() {
+  def publishVersion = findProperty("PublishVersion")
+  return (publishVersion != null) ? publishVersion : "LOCAL-SNAPSHOT"
+}
+
 // TODO(danysantiago): Use POM template in tools/ to avoid duplicating lines.
 publishing {
   publications {
     plugin(MavenPublication) {
-      artifactId = 'hilt-android-gradle-plugin'
+      artifactId = artifact
       version = getPublishVersion()
       from components.kotlin
       artifact(shadowJar)
@@ -238,6 +246,17 @@ publishing {
         }
       }
     }
+    pluginMarker(MavenPublication) {
+      groupId = "dagger.hilt.android.plugin"
+      artifactId = "dagger.hilt.android.plugin.gradle.plugin"
+      version = getPublishVersion()
+      pom.withXml {
+        def dependencyNode = asNode().appendNode("dependencies").appendNode("dependency")
+        dependencyNode.appendNode("groupId", group)
+        dependencyNode.appendNode("artifactId", artifact)
+        dependencyNode.appendNode("version", getPublishVersion())
+      }
+    }
   }
   // Publish to build output repository.
   repositories {
@@ -245,11 +264,4 @@ publishing {
       url = uri("$buildDir/repo")
     }
   }
-}
-
-group='com.google.dagger'
-
-def getPublishVersion() {
-  def publishVersion = findProperty("PublishVersion")
-  return (publishVersion != null) ? publishVersion : "LOCAL-SNAPSHOT"
 }

--- a/util/deploy-hilt-gradle-plugin.sh
+++ b/util/deploy-hilt-gradle-plugin.sh
@@ -13,6 +13,7 @@ _deploy_plugin() {
   ./$plugindir/gradlew -p $plugindir --no-daemon clean \
     publishAllPublicationsToMavenRepository -PPublishVersion="$VERSION_NAME"
   local outdir=$plugindir/build/repo/com/google/dagger/hilt-android-gradle-plugin/$VERSION_NAME
+  local markerOutDir=$plugindir/build/repo/dagger/hilt/android/plugin/dagger.hilt.android.plugin.gradle.plugin/$VERSION_NAME
   # When building '-SNAPSHOT' versions in gradle, the filenames replaces
   # '-SNAPSHOT' with timestamps, so we need to disambiguate by finding each file
   # to deploy. See: https://stackoverflow.com/questions/54182823/
@@ -29,6 +30,10 @@ _deploy_plugin() {
     -DpomFile="$(find $outdir -name "*-$suffix.pom")" \
     -Dsources="$(find $outdir -name "*-$suffix-sources.jar")" \
     -Djavadoc="$(find $outdir -name "*-$suffix-javadoc.jar")" \
+    "${EXTRA_MAVEN_ARGS[@]:+${EXTRA_MAVEN_ARGS[@]}}"
+  mvn "$MVN_GOAL" \
+    -Dfile="$(find $markerOutDir -name "*-$suffix.pom")" \
+    -DpomFile="$(find $markerOutDir -name "*-$suffix.pom")" \
     "${EXTRA_MAVEN_ARGS[@]:+${EXTRA_MAVEN_ARGS[@]}}"
 }
 


### PR DESCRIPTION
In Gradle projects, plugins can be referenced only by their ids (without adding classpath dependency to the `buildscript` block) if Plugin Marker Artifact is published to the Maven repository (https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_markers). Configure creating marker POM in Hilt Android Gradle plugin's project and extend deploy-hilt-gradle-plugin script to publish marker automatically whenever plugin is published.

Fixes: #2774

RELNOTES=Plugin Marker Artifact is now published for Hilt Android Gradle plugin, which allows to declare dependency on the plugin using only its id.