### PR TITLE
Fix Kotlin syntax in @InstallIn example

### DIFF
--- a/hilt/components.md
+++ b/hilt/components.md
@@ -158,7 +158,7 @@ abstract class FooModule {
 {: .c-codeselector__code .c-codeselector__code_java }
 ```kotlin
 @Module
-@InstallIn(FragmentComponent.class)
+@InstallIn(FragmentComponent::class)
 object FooModule {
   // This binding is "unscoped".
   @Provides


### PR DESCRIPTION
The original example doesn't compile when copied to the IDE. I had to replace `.class` with `::class` for it to work.