### PR TITLE
Introduce Bazel Steward - a tool for keeping dependencies up to date in Bazel

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -1,0 +1,15 @@
+name: Dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * *'
+
+jobs:
+  bazel-steward:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: VirtusLab/bazel-steward@latest


### PR DESCRIPTION
Hello everyone,

As one of developers I am submitting this pull request to introduce our new tool for Bazel repositories. [Bazel Steward](https://github.com/VirtusLab/bazel-steward) simplifies the process of checking and updating dependencies in your Bazel projects, making it more efficient to keep them up-to-date.
We hope that this tool will be useful to the Bazel community, and we look forward to your feedback.

This pull request integrates Bazel Steward through Github Actions which is currently the easiest way to do this. It will run every day at 12 and create new PRs or resolve conflicts on existing if necessary. You can preview how it looks in [a fork](https://github.com/mikkoziel/dagger/pulls) that we used to test it. For more details, you can check [the project readme](https://github.com/VirtusLab/bazel-steward#readme).

Bazel Steward is able to correctly update all your maven dependencies and version of Bazel itself. Support for updating rules works in many cases, but we are still working on it to make it more robust.

We hope that Bazel Steward will make it easier for you to manage dependencies. If you encounter any issues or have any feedback, please don't hesitate to reach out to us. Thank you!
