### PR TITLE
Configure a custom Hilt Gradle Plugin buildDir

### DIFF
--- a/java/dagger/hilt/android/plugin/build.gradle
+++ b/java/dagger/hilt/android/plugin/build.gradle
@@ -23,7 +23,12 @@ allprojects {
     mavenCentral()
   }
 }
+
+project.buildDir = 'gradleBuild'
+
 subprojects {
+    it.project.buildDir = 'gradleBuild'
+
     afterEvaluate {
         dependencies {
             // This is needed to align older versions of kotlin-stdlib.


### PR DESCRIPTION
The Dagger / Hilt project is using two build tools - Bazel and Gradle. The Bazel is using BUILD files to define the build targets. The Gradle is using the ‘build’ folder for the build output. During the Hilt build, the Gradle removes the BUILD file and creates a ‘build’ folder. That breaks the build.

This change configures Gradle projects to use the ‘gradleBuild’ folder. That enables building Dagger / Hilt on Mac.

Verified by running the `./util/install-local-snapshot.sh` script on Mac.
