### PR TITLE
Fix Lint crash with AGP 8.1.0

### DIFF
--- a/java/dagger/lint/DaggerKotlinIssueDetector.kt
+++ b/java/dagger/lint/DaggerKotlinIssueDetector.kt
@@ -200,7 +200,7 @@ class DaggerKotlinIssueDetector : Detector(), SourceCodeScanner {
       override fun visitMethod(node: UMethod) {
         if (!node.isConstructor &&
           node.hasAnnotation(PROVIDES_ANNOTATION) &&
-          node.hasAnnotation(JVM_STATIC_ANNOTATION)
+          node.findAnnotation(JVM_STATIC_ANNOTATION) != null
         ) {
           val containingClass = node.containingClass?.toUElement(UClass::class.java) ?: return
           if (containingClass.isObject()) {


### PR DESCRIPTION
A crash occurred in the project I'm working on when upgrading to AGP 8.1.0. See https://github.com/google/dagger/issues/3980.

I was able to reproduce the issue with a simple project. See https://github.com/mr-thierry/dagger_lint_crash

The cause of the crash is that in `DaggerKotlinIssueDetector`, `node.hasAnnotation(JVM_STATIC_ANNOTATION)` can return `true`, but `node.findAnnotation(JVM_STATIC_ANNOTATION)` can still return `null`. On AGP 8.0.0, `findAnnotation` wouldn't return null. I'm not sure what has changed in AGP that caused this.