### PR TITLE
#3636 Makes Aggregator#process use walkInPlatformIndependentOrder

### DIFF
--- a/java/dagger/hilt/android/plugin/main/src/main/kotlin/dagger/hilt/android/plugin/root/Aggregator.kt
+++ b/java/dagger/hilt/android/plugin/main/src/main/kotlin/dagger/hilt/android/plugin/root/Aggregator.kt
@@ -385,7 +385,7 @@ private constructor(
     files.forEach { file ->
       when {
         file.isFile -> visitFile(file)
-        file.isDirectory -> file.walkTopDown().filter { it.isFile }.forEach { visitFile(it) }
+        file.isDirectory -> file.walkInPlatformIndependentOrder().filter { it.isFile }.forEach { visitFile(it) }
         else -> logger.warn("Can't process file/directory that doesn't exist: $file")
       }
     }

--- a/java/dagger/hilt/android/plugin/main/src/test/kotlin/FilesTest.kt
+++ b/java/dagger/hilt/android/plugin/main/src/test/kotlin/FilesTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023 The Dagger Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class FilesTest {
+
+    @get:Rule
+    val testProjectDir = TemporaryFolder()
+
+    @Test
+    fun testWalkInPlatformIndependentOrder() {
+        val testDir = testProjectDir.root
+
+        /**
+         * testDir
+         * ├── dir1
+         * │   ├── file1
+         * └── dir2
+         * │   ├── dir3
+         * │   │   └── file2
+         * │   └── file3
+         * └── file4
+         */
+        File(testDir, "dir2").mkdir()
+        File(testDir, "dir2/dir3").mkdir()
+        File(testDir, "dir2/dir3/file2").mkdir()
+        File(testDir, "dir2/file3").createNewFile()
+        File(testDir, "dir1").mkdir()
+        File(testDir, "dir1/file1").createNewFile()
+        File(testDir, "file4").createNewFile()
+        val filesInOrder = testDir.walkInPlatformIndependentOrder().toList()
+
+        val expected: List<File> = listOf(
+            File(testDir, ""),
+            File(testDir, "dir1"),
+            File(testDir, "dir1/file1"),
+            File(testDir, "dir2"),
+            File(testDir, "dir2/dir3"),
+            File(testDir, "dir2/dir3/file2"),
+            File(testDir, "dir2/file3"),
+            File(testDir, "file4"),
+        )
+        assertEquals(expected, filesInOrder)
+
+        val filesNotInOrder = testDir.walkTopDown().toList()
+        assertTrue(filesInOrder != filesNotInOrder)
+
+        testDir.deleteRecursively()
+    }
+}


### PR DESCRIPTION
related issue #3636

### Motivation:
- At #3636, we fix AggregateDepsTask cache miss due to inconsistent order by `walkInPlatformIndependentOrder`
- ✅ But on `Aggregator#process`, it still uses `walkTopDown`. so I think it's good to replace `Aggregator#walkTopDown` to `walkInPlatformIndependentOrder` too for consistency on all platforms

### Modification:
- Replace `Aggregator#walkTopDown` to `walkInPlatformIndependentOrder` too for consistency
- Add `walkInPlatformIndependentOrder` unit test

### Result:
- Now `Aggregator#process` works in consistent order on all platforms!