### PR TITLE
DisableCachingByDefault for CopyTransform

### DIFF
--- a/java/dagger/hilt/android/plugin/main/src/main/kotlin/dagger/hilt/android/plugin/util/CopyTransform.kt
+++ b/java/dagger/hilt/android/plugin/main/src/main/kotlin/dagger/hilt/android/plugin/util/CopyTransform.kt
@@ -16,7 +16,6 @@
 
 package dagger.hilt.android.plugin.util
 
-import org.gradle.api.artifacts.transform.CacheableTransform
 import org.gradle.api.artifacts.transform.InputArtifact
 import org.gradle.api.artifacts.transform.TransformAction
 import org.gradle.api.artifacts.transform.TransformOutputs
@@ -24,12 +23,13 @@ import org.gradle.api.artifacts.transform.TransformParameters
 import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Classpath
+import org.gradle.work.DisableCachingByDefault
 
 /**
  * A transform that registers the input file (usually a jar or a class) as an output and thus
  * changing from one artifact type to another.
  */
-@CacheableTransform
+@DisableCachingByDefault("Copying files does not benefit from caching")
 abstract class CopyTransform : TransformAction<TransformParameters.None> {
   @get:Classpath
   @get:InputArtifact


### PR DESCRIPTION
The CopyTransform is simply copying files and does not benefit from caching. It is faster to re-execute the transform.

Here is an example of a build where pulling the CopyTransform from the cache led to negative savings: https://ge.solutions-team.gradle.com/s/ks7slrcl5kihg/performance/transform-execution?type=dagger.hilt.android.plugin.util.CopyTransform