### PR TITLE
Add ActivityRetainedLifecycle to default bindings docs

### DIFF
--- a/hilt/components.md
+++ b/hilt/components.md
@@ -194,7 +194,7 @@ as dependencies into your own custom bindings.
 Component                       | Default Bindings
 ------------------------------- | ---------------------------------------------
 **`SingletonComponent`**        | `Application`[^2]
-**`ActivityRetainedComponent`** | `Application`
+**`ActivityRetainedComponent`** | `Application`, `ActivityRetainedLifecycle`
 **`ViewModelComponent`**        | `SavedStateHandle`, `ViewModelLifecycle`
 **`ActivityComponent`**         | `Application`, `Activity`
 **`FragmentComponent`**         | `Application`, `Activity`, `Fragment`


### PR DESCRIPTION
Since this can be injected, seems like it's missing from docs.