### PR TITLE
4298 cycle breaks

### DIFF
--- a/java/dagger/internal/codegen/bindinggraphvalidation/DependencyCycleValidator.java
+++ b/java/dagger/internal/codegen/bindinggraphvalidation/DependencyCycleValidator.java
@@ -43,6 +43,7 @@ import dagger.internal.codegen.base.Formatter;
 import dagger.internal.codegen.base.MapType;
 import dagger.internal.codegen.base.OptionalType;
 import dagger.internal.codegen.binding.DependencyRequestFormatter;
+import dagger.internal.codegen.compileroption.CompilerOptions;
 import dagger.internal.codegen.javapoet.TypeNames;
 import dagger.internal.codegen.model.Binding;
 import dagger.internal.codegen.model.BindingGraph;
@@ -64,10 +65,15 @@ import javax.inject.Inject;
 final class DependencyCycleValidator extends ValidationBindingGraphPlugin {
 
   private final DependencyRequestFormatter dependencyRequestFormatter;
+  private final boolean disallowCycleBreaks;
 
   @Inject
-  DependencyCycleValidator(DependencyRequestFormatter dependencyRequestFormatter) {
+  DependencyCycleValidator(
+          DependencyRequestFormatter dependencyRequestFormatter,
+          CompilerOptions compilerOptions
+  ) {
     this.dependencyRequestFormatter = dependencyRequestFormatter;
+    this.disallowCycleBreaks = compilerOptions.disallowCycleBreaks();
   }
 
   @Override
@@ -233,7 +239,7 @@ final class DependencyCycleValidator extends ValidationBindingGraphPlugin {
       case PROVIDER:
       case LAZY:
       case PROVIDER_OF_LAZY:
-        return true;
+          return !disallowCycleBreaks;
 
       case INSTANCE:
         if (MapType.isMap(requestedType)) {

--- a/java/dagger/internal/codegen/bindinggraphvalidation/DependencyCycleValidator.java
+++ b/java/dagger/internal/codegen/bindinggraphvalidation/DependencyCycleValidator.java
@@ -239,7 +239,8 @@ final class DependencyCycleValidator extends ValidationBindingGraphPlugin {
       case PROVIDER:
       case LAZY:
       case PROVIDER_OF_LAZY:
-          return !disallowCycleBreaks;
+        // If cycle breaks are allowed, break
+        return !disallowCycleBreaks;
 
       case INSTANCE:
         if (MapType.isMap(requestedType)) {

--- a/java/dagger/internal/codegen/compileroption/CompilerOptions.java
+++ b/java/dagger/internal/codegen/compileroption/CompilerOptions.java
@@ -149,4 +149,6 @@ public abstract class CompilerOptions {
    * for {@code Foo<? extends Bar>} and {@code Foo<Bar>} would result in a duplicate binding error.
    */
   public abstract boolean ignoreProvisionKeyWildcards();
+
+  public abstract boolean disallowCycleBreaks();
 }

--- a/java/dagger/internal/codegen/compileroption/ProcessingEnvironmentCompilerOptions.java
+++ b/java/dagger/internal/codegen/compileroption/ProcessingEnvironmentCompilerOptions.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Sets.immutableEnumSet;
 import static dagger.internal.codegen.compileroption.FeatureStatus.DISABLED;
 import static dagger.internal.codegen.compileroption.FeatureStatus.ENABLED;
+import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.DISALLOW_CYCLE_BREAKS;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.EXPERIMENTAL_AHEAD_OF_TIME_SUBCOMPONENTS;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.EXPERIMENTAL_ANDROID_MODE;
 import static dagger.internal.codegen.compileroption.ProcessingEnvironmentCompilerOptions.Feature.EXPERIMENTAL_DAGGER_ERROR_MESSAGES;
@@ -195,6 +196,11 @@ public final class ProcessingEnvironmentCompilerOptions extends CompilerOptions 
   }
 
   @Override
+  public boolean disallowCycleBreaks() {
+     return isEnabled(DISALLOW_CYCLE_BREAKS);
+  }
+
+  @Override
   public boolean strictMultibindingValidation() {
     return isEnabled(STRICT_MULTIBINDING_VALIDATION);
   }
@@ -347,7 +353,9 @@ public final class ProcessingEnvironmentCompilerOptions extends CompilerOptions 
 
     IGNORE_PROVISION_KEY_WILDCARDS(ENABLED),
 
-    VALIDATE_TRANSITIVE_COMPONENT_DEPENDENCIES(ENABLED)
+    VALIDATE_TRANSITIVE_COMPONENT_DEPENDENCIES(ENABLED),
+
+    DISALLOW_CYCLE_BREAKS
     ;
 
     final FeatureStatus defaultValue;

--- a/java/dagger/internal/codegen/javac/JavacPluginCompilerOptions.java
+++ b/java/dagger/internal/codegen/javac/JavacPluginCompilerOptions.java
@@ -140,4 +140,9 @@ final class JavacPluginCompilerOptions extends CompilerOptions {
   public boolean ignoreProvisionKeyWildcards() {
     return false;
   }
+
+  @Override
+  public boolean disallowCycleBreaks() {
+    return false;
+  }
 }


### PR DESCRIPTION
Fix for https://github.com/google/dagger/issues/4298

The goal of this PR is to expose a compiler option disallowCycleBreaks which would cause Lazy and Provider cycles to be reported during compilation.