### PR TITLE
Hilt: skip view injection in edit mode

### DIFF
--- a/java/dagger/hilt/android/processor/internal/androidentrypoint/ViewGenerator.java
+++ b/java/dagger/hilt/android/processor/internal/androidentrypoint/ViewGenerator.java
@@ -117,6 +117,9 @@ public final class ViewGenerator {
           AnnotationSpec.builder(AndroidClassNames.TARGET_API).addMember("value", "21").build());
     }
 
+    builder.beginControlFlow("if(isInEditMode())")
+      .addStatement("return")
+      .endControlFlow();
     builder.addStatement("inject()");
 
     return builder.build();


### PR DESCRIPTION
This code change includes a check to skip injecting views in case `View#isInEditMode` returns `true`, i.e. view is displayed in IDE's XML layout editor preview. 

Main driver for this change is that I'm running a BUCK project and can only reliably get the version of view classes that extend from the generated `Hilt_` classes. These cannot be instantiated in the preview since the view injector requires an application context, which is unavailable. 

More importantly this is no-op in Gradle projects, since modified classes are never loaded by it, so there are no other side effects.