### PR TITLE
Fix typo in Hilt ViewModel assisted injection factory Kotlin snippet

### DIFF
--- a/hilt/view-model.md
+++ b/hilt/view-model.md
@@ -228,7 +228,7 @@ interface MovieViewModelFactory {
 ```kotlin
 @AssistedFactory
 interface MovieViewModelFactory {
-  fun create(val movieId: Int): MovieViewModel
+  fun create(movieId: Int): MovieViewModel
 }
 ```
 {: .c-codeselector__code .c-codeselector__code_kotlin }


### PR DESCRIPTION
Hey, found a typo in a Kotlin code snippet while reading the docs on Hilt ViewModel assisted injection.