### PR TITLE
Permit Multibinds with MembersInjector values

### DIFF
--- a/java/dagger/internal/codegen/base/FrameworkTypes.java
+++ b/java/dagger/internal/codegen/base/FrameworkTypes.java
@@ -33,6 +33,9 @@ public final class FrameworkTypes {
   private static final ImmutableSet<ClassName> PROVISION_TYPES =
       ImmutableSet.of(TypeNames.PROVIDER, TypeNames.LAZY, TypeNames.MEMBERS_INJECTOR);
 
+  private static final ImmutableSet<ClassName> ACCESSOR_TYPES =
+      ImmutableSet.of(TypeNames.PROVIDER, TypeNames.LAZY, TypeNames.PRODUCED, TypeNames.PRODUCER);
+
   // NOTE(beder): ListenableFuture is not considered a producer framework type because it is not
   // defined by the framework, so we can't treat it specially in ordinary Dagger.
   private static final ImmutableSet<ClassName> PRODUCTION_TYPES =
@@ -49,6 +52,11 @@ public final class FrameworkTypes {
   /** Returns true if the type represents a framework type. */
   public static boolean isFrameworkType(XType type) {
     return typeIsOneOf(ALL_FRAMEWORK_TYPES, type);
+  }
+
+  /** Returns true if the type represents an accessor type. */
+  public static boolean isAccessorType(XType type) {
+    return typeIsOneOf(ACCESSOR_TYPES, type);
   }
 
   private static boolean typeIsOneOf(Set<ClassName> classNames, XType type) {

--- a/java/dagger/internal/codegen/validation/MultibindsMethodValidator.java
+++ b/java/dagger/internal/codegen/validation/MultibindsMethodValidator.java
@@ -16,6 +16,7 @@
 
 package dagger.internal.codegen.validation;
 
+import static dagger.internal.codegen.base.FrameworkTypes.isAccessorType;
 import static dagger.internal.codegen.base.FrameworkTypes.isFrameworkType;
 import static dagger.internal.codegen.validation.BindingElementValidator.AllowsMultibindings.NO_MULTIBINDINGS;
 import static dagger.internal.codegen.validation.BindingElementValidator.AllowsScoping.NO_SCOPING;
@@ -95,7 +96,7 @@ class MultibindsMethodValidator extends BindingMethodValidator {
       } else if (isWildcard(mapType.valueType())) {
         report.addError(
             bindingMethods("return type cannot use a wildcard as the Map value type."));
-      } else if (isFrameworkType(mapType.valueType())) {
+      } else if (isAccessorType(mapType.valueType())) {
         String frameworkTypeName = getSimpleName(mapType.valueType().getTypeElement());
         report.addError(
             bindingMethods(
@@ -108,7 +109,7 @@ class MultibindsMethodValidator extends BindingMethodValidator {
         report.addError(bindingMethods("return type cannot be a raw Set type"));
       } else if (isWildcard(setType.elementType())) {
         report.addError(bindingMethods("return type cannot use a wildcard as the Set value type."));
-      } else if (isFrameworkType(setType.elementType())) {
+      } else if (isAccessorType(setType.elementType())) {
         String frameworkTypeName = getSimpleName(setType.elementType().getTypeElement());
         report.addError(
             bindingMethods(

--- a/javatests/dagger/functional/multibindings/BUILD
+++ b/javatests/dagger/functional/multibindings/BUILD
@@ -37,6 +37,7 @@ GenJavaTests(
         "MultibindsModule.java",
         "NestedAnnotationContainer.java",
         "NumberClassKey.java",
+        "RequiresFieldInjection.java",
         "ShortKey.java",
         "UnwrappedAnnotationKey.java",
         "WrappedAnnotationKey.java",

--- a/javatests/dagger/functional/multibindings/MultibindingComponent.java
+++ b/javatests/dagger/functional/multibindings/MultibindingComponent.java
@@ -17,6 +17,7 @@
 package dagger.functional.multibindings;
 
 import dagger.Component;
+import dagger.MembersInjector;
 import dagger.functional.multibindings.subpackage.ContributionsModule;
 import dagger.multibindings.StringKey;
 import java.util.Collection;
@@ -67,4 +68,10 @@ interface MultibindingComponent {
 
   @Named("complexQualifier")
   Map<String, CharSequence> maybeEmptyQualifiedMap();
+
+  MembersInjector<RequiresFieldInjection> membersInjector();
+
+  Map<Class<?>, MembersInjector<?>> membersInjectorMap();
+
+  Set<MembersInjector<?>> membersInjectorSet();
 }

--- a/javatests/dagger/functional/multibindings/MultibindingModule.java
+++ b/javatests/dagger/functional/multibindings/MultibindingModule.java
@@ -16,6 +16,8 @@
 
 package dagger.functional.multibindings;
 
+import dagger.MapKey;
+import dagger.MembersInjector;
 import dagger.Module;
 import dagger.Provides;
 import dagger.multibindings.ClassKey;
@@ -93,6 +95,19 @@ class MultibindingModule {
   @Provides
   static Collection<String> provideMapValues(Map<String, String> map) {
     return map.values();
+  }
+
+  @Provides
+  @IntoMap
+  @ClassKey(RequiresFieldInjection.class)
+  static MembersInjector<?> provideMembersInjectorIntoMap(MembersInjector<RequiresFieldInjection> injector) {
+    return injector;
+  }
+
+  @Provides
+  @IntoSet
+  static MembersInjector<?> provideMembersInjectorIntoSet(MembersInjector<RequiresFieldInjection> injector) {
+    return injector;
   }
 
   @Provides

--- a/javatests/dagger/functional/multibindings/MultibindingTest.java
+++ b/javatests/dagger/functional/multibindings/MultibindingTest.java
@@ -183,6 +183,18 @@ public class MultibindingTest {
         .containsEntry("key", "qualified foo value");
   }
 
+  @Test
+  public void membersInjectorSet() {
+    assertThat(multibindingComponent.membersInjectorSet())
+        .containsExactly(multibindingComponent.membersInjector());
+  }
+
+  @Test
+  public void membersInjectorMap() {
+    assertThat(multibindingComponent.membersInjectorMap())
+        .containsExactly(RequiresFieldInjection.class, multibindingComponent.membersInjector());
+  }
+
   @AutoAnnotation
   static StringKey testStringKey(String value) {
     return new AutoAnnotation_MultibindingTest_testStringKey(value);

--- a/javatests/dagger/functional/multibindings/MultibindsModule.java
+++ b/javatests/dagger/functional/multibindings/MultibindsModule.java
@@ -16,6 +16,7 @@
 
 package dagger.functional.multibindings;
 
+import dagger.MembersInjector;
 import dagger.Module;
 import dagger.multibindings.Multibinds;
 import java.util.Map;
@@ -39,7 +40,13 @@ abstract class MultibindsModule {
   abstract Set<CharSequence> set();
 
   @Multibinds
+  abstract Set<MembersInjector<?>> membersInjectorSet();
+
+  @Multibinds
   abstract Map<String, CharSequence> map();
+
+  @Multibinds
+  abstract Map<Class<?>, MembersInjector<?>> membersInjectorMap();
 
   @Multibinds
   @Named("complexQualifier")

--- a/javatests/dagger/functional/multibindings/RequiresFieldInjection.java
+++ b/javatests/dagger/functional/multibindings/RequiresFieldInjection.java
@@ -1,0 +1,10 @@
+package dagger.functional.multibindings;
+
+import javax.inject.Inject;
+import java.util.Set;
+
+public class RequiresFieldInjection {
+
+    @Inject
+    Set<Integer> set;
+}


### PR DESCRIPTION
The `MultibindsMethodValidator` prevents `Multibinds` methods from using `Producer`, `Produced`, `Lazy`, `Provider`, and `MembersInjector` as a `Map` value type or a `Set` element type. However, out of all of these, `MembersInjector` does not actually produce or access any instances; instead, it operates on an instance provided as an argument. Therefore, using it as a `Map` or `Set` value type is actually quite different than any of the rest.

It's actually already possible multi-bind a `Set` or `Map` with `MembersInjector` values, but not to declare such a binding with `Multibinds`. This PR changes the validator to allow such binding declarations, and adds additional tests to verify (and demonstrate) that this works as intended.