### PR TITLE
Fix the isolated project violation

### DIFF
--- a/java/dagger/hilt/android/plugin/main/src/main/kotlin/dagger/hilt/android/plugin/HiltGradlePlugin.kt
+++ b/java/dagger/hilt/android/plugin/main/src/main/kotlin/dagger/hilt/android/plugin/HiltGradlePlugin.kt
@@ -52,6 +52,7 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.api.artifacts.ExternalDependency
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.compile.JavaCompile
@@ -421,7 +422,9 @@ class HiltGradlePlugin @Inject constructor(private val providers: ProviderFactor
           it.name.startsWith("hiltAnnotationProcessor") || it.name.startsWith("hiltCompileOnly")
         }
         .flatMap { configuration ->
-          configuration.dependencies.map { dependency -> dependency.group to dependency.name }
+          configuration.dependencies
+            .filterIsInstance<ExternalDependency>()
+            .map { dependency -> dependency.group to dependency.name }
         }
         .toSet()
     fun getMissingDepMsg(depCoordinate: String): String =


### PR DESCRIPTION
Dependency.group would be accessed which, for project dependencies, would cause an isolated project violation. Now project dependencies are filtered out.

This partially fixes #4423