### PR TITLE
perf: Add caching for getDeclaredFields/Methods in InjectValidator to…

### DIFF
--- a/javatests/artifacts/dagger-ksp/bench.scenarios
+++ b/javatests/artifacts/dagger-ksp/bench.scenarios
@@ -1,0 +1,43 @@
+// Benchmark scenarios for comparing KAPT vs KSP performance in Dagger
+// Run with: gradle-profiler --benchmark --scenario-file bench.scenarios kaptBuild kspBuild
+
+kaptBuild {
+    title = "Dagger KAPT Build"
+    tasks = ["clean", ":kotlin-app:compileKotlin"]
+    gradle-args = ["-Dscan.tag.DaggerKapt", "--rerun-tasks"]
+    run-using = tooling-api
+    daemon = warm
+    warm-ups = 2
+    iterations = 3
+}
+
+kspBuild {
+    title = "Dagger KSP Build"
+    tasks = ["clean", ":kotlin-app:compileKotlin"]
+    gradle-args = ["-Dscan.tag.DaggerKsp", "--rerun-tasks"]
+    run-using = tooling-api
+    daemon = warm
+    warm-ups = 2
+    iterations = 3
+}
+
+// With profiling enabled
+kaptProfile {
+    title = "Dagger KAPT Build (Profiled)"
+    tasks = [":kotlin-app:compileKotlin"]
+    gradle-args = ["-Dscan.tag.DaggerKapt", "--rerun-tasks"]
+    run-using = tooling-api
+    daemon = warm
+    warm-ups = 1
+    iterations = 2
+}
+
+kspProfile {
+    title = "Dagger KSP Build (Profiled)"
+    tasks = [":kotlin-app:compileKotlin"]
+    gradle-args = ["-Dscan.tag.DaggerKsp", "--rerun-tasks"]
+    run-using = tooling-api
+    daemon = warm
+    warm-ups = 1
+    iterations = 2
+}


### PR DESCRIPTION
… fix KSP performance regression

- Added declaredFieldsCache and declaredMethodsCache to avoid repeated expensive KSP API calls
- Implemented getCachedDeclaredFields() and getCachedDeclaredMethods() helper methods
- Updated validateForMembersInjectionInternalUncached() to use cached results
- Updated clearCache() to invalidate new caches

This optimization addresses the 3x performance regression when using KSP compared to KAPT. Flame chart analysis showed getDeclaredFields() and getDeclaredMethods() were dominating execution time due to repeated calls for the same types. Caching these results should reduce KSP API calls by 50-70% and significantly improve build times.