### PR TITLE
Add R8 keep rule for Hilt_* base classes to fix ClassCastException in release builds

### DIFF
--- a/hilt-android/main/resources/META-INF/com.android.tools/proguard/hilt-android.pro
+++ b/hilt-android/main/resources/META-INF/com.android.tools/proguard/hilt-android.pro
@@ -3,3 +3,8 @@
 -keep,allowobfuscation,allowshrinking @dagger.hilt.internal.ComponentEntryPoint class *
 -keep,allowobfuscation,allowshrinking @dagger.hilt.internal.GeneratedEntryPoint class *
 -keep,allowobfuscation,allowshrinking @dagger.hilt.android.EarlyEntryPoint class *
+
+# Prevent R8 full mode from vertically merging Hilt_* base classes with
+# @AndroidEntryPoint user classes. The bytecode transform rewrites user classes
+# to extend Hilt_*; vertical class merging breaks this hierarchy.
+-keep,allowobfuscation,allowshrinking class **.Hilt_*

--- a/hilt-android/main/resources/META-INF/com.android.tools/r8/hilt-android.pro
+++ b/hilt-android/main/resources/META-INF/com.android.tools/r8/hilt-android.pro
@@ -3,3 +3,8 @@
 -keep,allowobfuscation,allowshrinking @dagger.hilt.internal.ComponentEntryPoint class *
 -keep,allowobfuscation,allowshrinking @dagger.hilt.internal.GeneratedEntryPoint class *
 -keep,allowobfuscation,allowshrinking @dagger.hilt.android.EarlyEntryPoint class *
+
+# Prevent R8 full mode from vertically merging Hilt_* base classes with
+# @AndroidEntryPoint user classes. The bytecode transform rewrites user classes
+# to extend Hilt_*; vertical class merging breaks this hierarchy.
+-keep,allowobfuscation,allowshrinking class **.Hilt_*


### PR DESCRIPTION
When using `@AndroidEntryPoint` on a class (e.g., a Service, Activity, or BroadcastReceiver) with R8 full mode enabled (`android.enableR8.fullMode=true`), the app crashes at runtime with:
java.lang.RuntimeException: Unable to create service *.presentation.service.PushMessagingService: java.lang.ClassCastException
This works correctly in debug builds and when R8 full mode is disabled.
**Root Cause:**
In R8 full mode, the aggressive vertical class merging optimization merges `@AndroidEntryPoint` user classes with their generated `Hilt_*` base classes when the user class has no additional methods. For example, `PushMessagingService` (`class PushMessagingService : FirebaseMessagingService()`) would be merged with `Hilt_PushMessagingService` into a single class.
This merging breaks the bytecode-transformed class hierarchy set up by `AndroidEntryPointClassVisitor`, which rewrites `@AndroidEntryPoint` classes to extend `Hilt_*` instead of their original superclass. After merging, the `instanceof GeneratedComponentManager` check in `EntryPoints.get()` fails because the flattened class hierarchy no longer implements the Hilt interface, causing the `ClassCastException`.
**Fix:**
Added `-keep,allowobfuscation,allowshrinking class **.Hilt_*` to the Hilt Android proguard rules. This prevents R8 from merging the generated `Hilt_*` base classes with user classes via vertical class merging, while still allowing R8 to rename unused classes (`allowobfuscation`) and remove them when proven unused (`allowshrinking`).
This follows the same pattern used by Dagger's `@LazyClassKey` (`LazyClassKeyProcessingStep.java:46`).
**Changes**
- `hilt-android/main/resources/META-INF/com.android.tools/r8/hilt-android.pro`: Added keep rule
- `hilt-android/main/resources/META-INF/com.android.tools/proguard/hilt-android.pro`: Added keep rule
Fixes #4668