### PR TITLE
Add rules_android android_library

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_android//rules:rules.bzl", "android_library")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "define_kt_toolchain")
 load("//tools/javadoc:javadoc.bzl", "javadoc_library")
 


### PR DESCRIPTION
On bazel 9, failure to include said library results in the following error 
ERROR: .../dagger+/BUILD:32:1: name 'android_library' is not defined